### PR TITLE
Driver for STM32F3xx-microcontrollers

### DIFF
--- a/stack/STM32F3/CO_Flash.c
+++ b/stack/STM32F3/CO_Flash.c
@@ -1,0 +1,276 @@
+/*
+ * STM32F3 flash support for CANopen stack
+ *
+ * @file        CO_Flash.c
+ * @author      Janez Paternoster
+ * @author      Olof Larsson
+ * @author      Petteri Mustonen
+ * @copyright   2014 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+//============================================================================
+//                                INCLUDES
+//============================================================================
+#include "CANopen.h"
+#include "stm32f30x.h"
+
+//============================================================================
+//                                DEFINES
+//============================================================================
+#define PARAM_STORE_PASSWORD   0x65766173
+#define PARAM_RESTORE_PASSWORD 0x64616F6C
+
+#define DEBUG 0
+
+#define LAST_PAGE_ADDRESS           0x0800F800
+#define PAGES_PER_FLASH_AREA        1
+#define FLASH_PAGE_SIZE             0x800
+#define CO_OD_FLASH_PARAM_DEFAULT   LAST_PAGE_ADDRESS - (1*PAGES_PER_FLASH_AREA*FLASH_PAGE_SIZE)
+#define CO_OD_FLASH_PARAM_RUNTIME   LAST_PAGE_ADDRESS - (2*PAGES_PER_FLASH_AREA*FLASH_PAGE_SIZE)
+
+#define CO_UNUSED(v)  (void)(v)
+
+//============================================================================
+//                                LOCAL DATA
+//============================================================================
+extern struct sCO_OD_ROM CO_OD_ROM;
+
+enum CO_OD_H1010_StoreParam_Sub
+{
+    OD_H1010_STORE_PARAM_COUNT,
+    OD_H1010_STORE_PARAM_ALL,
+    OD_H1010_STORE_PARAM_COMM,
+    OD_H1010_STORE_PARAM_APP,
+    OD_H1010_STORE_PARAM_MANUFACTURER,
+    OD_H1010_STORE_PARAM_RESERVED       = 0x80
+};
+
+enum CO_OD_H1011_RestoreDefaultParam_Sub
+{
+    OD_H1011_RESTORE_PARAM_COUNT,
+    OD_H1011_RESTORE_PARAM_ALL,
+    OD_H1011_RESTORE_PARAM_COMM,
+    OD_H1011_RESTORE_PARAM_APP,
+    OD_H1011_RESTORE_PARAM_MANUFACTURER,
+    OD_H1011_RESTORE_PARAM_RESERVED     = 0x80
+};
+
+enum CO_StorageFunctionality_Flags
+{
+    SAVES_PARAM_ON_COMMAND   = 0x01,
+    SAVES_PARAM_AUTONOMOUSLY = 0x02
+};
+
+enum CO_RestoreFunctionality_Flags
+{
+    RESTORES_PARAMETERS   = 0x01
+};
+
+//============================================================================
+/**
+* Store parameters of object dictionary into flash memory.
+* \param[in] FlashAddress Use CO_OD_Flash_Adress for the normal parameter
+*                         block and CO_OD_Flash_Default_Param for the
+*                         default parameters
+*/
+static CO_SDO_abortCode_t storeParameters(uint32_t FlashAddress, uint8_t ParametersSub)
+{
+    uint32_t addressPtr = 0x00;
+    uint32_t addressFinal = 0x00;
+    uint32_t* chunk;
+
+    CO_UNUSED(ParametersSub);
+
+    /* Unlock flash*/
+    FLASH_Unlock();
+
+    /* Check flash allocation */
+    int32_t bytes_to_write = sizeof(CO_OD_ROM);
+    if ((uint32_t)bytes_to_write > (FLASH_PAGE_SIZE*PAGES_PER_FLASH_AREA)) {
+        return CO_SDO_AB_HW;
+    }
+
+    addressFinal = FlashAddress + bytes_to_write;
+    /* Clear pending flakgs (if any) */  
+    FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR); 
+
+    /* Erase page */
+    FLASH_ErasePage(FlashAddress);
+
+    /* Program data into flash word by word */
+    chunk = (uint32_t*) &CO_OD_ROM;
+    for (addressPtr = FlashAddress; addressPtr < addressFinal; addressPtr += 4) {
+        if (FLASH_ProgramWord(addressPtr, *chunk) != FLASH_COMPLETE) {
+            return CO_SDO_AB_HW;
+        }
+        chunk++;
+    }
+    FLASH_Lock();
+
+    return CO_SDO_AB_NONE;
+}
+
+//============================================================================
+/**
+* Restore parameters of object dictionary from flash memory.
+* \param[in] FlashAddress Use CO_OD_Flash_Adress for the normal parameter
+*                         block and CO_OD_Flash_Default_Param for the
+*                         default parameters
+*/
+void flash_read(uint32_t FlashAddress, void* RamAddress, size_t len)
+{
+    uint8_t* p_flash = (uint8_t *) FlashAddress;
+    uint8_t* p_ram = (uint8_t *) RamAddress;
+    uint32_t idx;
+
+    for (idx = 0; idx < len; idx++) {
+        *p_ram = *(__IO uint8_t *)p_flash;
+        p_ram++;
+        p_flash++;
+    }
+}
+
+static CO_SDO_abortCode_t restoreParameters(uint32_t FlashAddress, uint8_t ParametersSub)
+{
+    CO_UNUSED(ParametersSub);
+
+    flash_read(FlashAddress, &CO_OD_ROM, sizeof(CO_OD_ROM));
+
+    return CO_SDO_AB_NONE;
+}
+
+//============================================================================
+/**
+* Access to object dictionary OD_H1010_STORE_PARAM_FUNC
+*/
+static CO_SDO_abortCode_t CO_ODF_1010_StoreParam(CO_ODF_arg_t *ODF_arg)
+{
+
+    uint32_t* value = (uint32_t*)ODF_arg->data;
+
+    if (ODF_arg->reading) {
+        if(OD_H1010_STORE_PARAM_ALL == ODF_arg->subIndex) {
+            *value = SAVES_PARAM_ON_COMMAND;
+        }
+        return CO_SDO_AB_NONE;
+    }
+
+    if(OD_H1010_STORE_PARAM_ALL != ODF_arg->subIndex) {
+        return CO_SDO_AB_NONE;
+    }
+
+    if (*value != PARAM_STORE_PASSWORD) {
+        return CO_SDO_AB_DATA_TRANSF;
+    }
+
+    return storeParameters(CO_OD_FLASH_PARAM_RUNTIME, ODF_arg->subIndex);
+}
+
+//============================================================================
+/**
+* Access to object dictionary OD_H1010_STORE_PARAM_FUNC
+*/
+static CO_SDO_abortCode_t CO_ODF_1011_RestoreParam(CO_ODF_arg_t *ODF_arg)
+{
+    uint32_t* value = (uint32_t*)ODF_arg->data;
+
+    if (ODF_arg->reading) {
+        if (OD_H1011_RESTORE_PARAM_ALL == ODF_arg->subIndex) {
+            *value = RESTORES_PARAMETERS;
+        }
+        return CO_SDO_AB_NONE;
+    }
+
+    if (OD_H1011_RESTORE_PARAM_ALL != ODF_arg->subIndex) {
+        return CO_SDO_AB_NONE;
+    }
+
+    if (*value != PARAM_RESTORE_PASSWORD) {
+        return CO_SDO_AB_DATA_TRANSF;
+    }
+
+    CO_SDO_abortCode_t Result = restoreParameters(CO_OD_FLASH_PARAM_DEFAULT, ODF_arg->subIndex);
+    
+    if (Result != CO_SDO_AB_NONE) {
+        return Result;
+    }
+
+    return storeParameters(CO_OD_FLASH_PARAM_RUNTIME, OD_H1011_RESTORE_PARAM_ALL);
+}
+
+//===========================================================================
+/**
+* Initialize flash library and data storage in flash
+* We use two blocks in flash for data storage. One block is used for the
+* default data that will be restored. The default parameters are stored
+* at address CO_OD_Flash_Default_Param. The data that will be loaded at
+* startup or saved if user modifies data is store at CO_OD_Flash_Adress.
+*/
+void CO_FlashInit(void)
+{
+    /* Before we can access the data, we need to make sure, that the flash
+    block are properly initialized. We do this by reading the block into
+    a local sCO_OD_ROM variable and verifying the FirstWord and LastWord
+    members. */
+
+    struct sCO_OD_ROM DefaultObjDicParam;
+    flash_read(CO_OD_FLASH_PARAM_DEFAULT, &DefaultObjDicParam, sizeof(DefaultObjDicParam));
+
+    /* If the default parameters are not present in flash, then we know that
+    we need to create them for later restore. */
+
+    if ((DefaultObjDicParam.FirstWord != CO_OD_FIRST_LAST_WORD) ||
+    (DefaultObjDicParam.LastWord  != CO_OD_FIRST_LAST_WORD)) {
+        storeParameters(CO_OD_FLASH_PARAM_RUNTIME, OD_H1010_STORE_PARAM_ALL);
+        storeParameters(CO_OD_FLASH_PARAM_DEFAULT, OD_H1010_STORE_PARAM_ALL);
+    }
+    else {
+        restoreParameters(CO_OD_FLASH_PARAM_RUNTIME, OD_H1010_STORE_PARAM_ALL);
+    }
+}
+
+//===========================================================================
+void CO_FlashRegisterODFunctions(CO_t* CO)
+{
+    CO_OD_configure(*(CO->SDO), OD_H1010_STORE_PARAM_FUNC,
+    CO_ODF_1010_StoreParam, (void*)0, 0, 0);
+
+    CO_OD_configure(*(CO->SDO), OD_H1011_REST_PARAM_FUNC,
+    CO_ODF_1011_RestoreParam, (void*)0, 0, 0);
+}

--- a/stack/STM32F3/CO_Flash.h
+++ b/stack/STM32F3/CO_Flash.h
@@ -1,0 +1,71 @@
+/*
+ * STM32F3 flash support for CANopen stack
+ *
+ * @file        CO_Flash.h
+ * @author      Janez Paternoster
+ * @author      Olof Larsson
+ * @author      Petteri Mustonen
+ * @copyright   2014 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+#ifndef CO_FLASH_H
+#define CO_FLASH_H
+
+//============================================================================
+//                                INCLUDES
+//============================================================================
+#include "CANopen.h"
+
+/**
+ * Initialize flash library and data storage in flash
+ * We use two blocks in flash for data storage. One block is used for the
+ * default data that will be restored. The default parameters are stored
+ * at address CO_OD_Flash_Default_Param. The data that will be loaded at
+ * startup or saved if user modifies data.
+ */
+void CO_FlashInit(void);
+
+/**
+ * Register object dictionary functions for parameter storage and restoring
+ * parameters (Object dictionary index 0x1010 Store Param and 0x1011 Restore
+ * default param.
+ */
+void CO_FlashRegisterODFunctions(CO_t* CO);
+
+#endif

--- a/stack/STM32F3/CO_driver.c
+++ b/stack/STM32F3/CO_driver.c
@@ -1,0 +1,510 @@
+/*
+ * CAN module object for ST STM32F334 microcontroller.
+ *
+ * @file        CO_driver.c
+ * @author      Janez Paternoster
+ * @author      Ondrej Netik
+ * @author      Vijayendra
+ * @author      Jan van Lienden
+ * @author      Petteri Mustonen
+ * @copyright   2013 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f30x.h"
+#include "CO_driver.h"
+#include "CO_Emergency.h"
+#include <string.h>
+
+/* Private macro -------------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private variable ----------------------------------------------------------*/
+/* Private function ----------------------------------------------------------*/
+static void CO_CANClkSetting (void);
+static void CO_CANconfigGPIO (void);
+static uint8_t CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
+
+/*******************************************************************************
+   Macro and Constants - CAN module registers
+ *******************************************************************************/
+
+
+/******************************************************************************/
+void CO_CANsetConfigurationMode(CAN_TypeDef* CANbaseAddress){
+}
+
+
+/******************************************************************************/
+void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
+    CANmodule->CANnormal = true;
+}
+
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANmodule_init(
+        CO_CANmodule_t         *CANmodule,
+        CAN_TypeDef            *CANbaseAddress,
+        CO_CANrx_t              rxArray[],
+        uint16_t                rxSize,
+        CO_CANtx_t              txArray[],
+        uint16_t                txSize,
+        uint16_t                CANbitRate)
+{
+    CAN_InitTypeDef CAN_InitStruct;
+    CAN_FilterInitTypeDef CAN_FilterInitStruct;
+    NVIC_InitTypeDef NVIC_InitStructure;
+    int i;
+    uint8_t result;
+
+    /* verify arguments */
+    if(CANmodule==NULL || rxArray==NULL || txArray==NULL) {
+        return CO_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->rxArray = rxArray;
+    CANmodule->rxSize = rxSize;
+    CANmodule->txArray = txArray;
+    CANmodule->txSize = txSize;
+    CANmodule->CANnormal = false;
+    CANmodule->useCANrxFilters = false;
+    CANmodule->bufferInhibitFlag = 0;
+    CANmodule->firstCANtxMessage = 1;
+    CANmodule->CANtxCount = 0;
+    CANmodule->errOld = 0;
+    CANmodule->em = 0;
+	
+    CAN_ITConfig(CANmodule->CANbaseAddress, (CAN_IT_TME | CAN_IT_FMP0), DISABLE);
+
+    for (i = 0; i < rxSize; i++) {
+        CANmodule->rxArray[i].ident = 0;
+        CANmodule->rxArray[i].pFunct = 0;
+    }
+    
+    for (i = 0; i < txSize; i++) {
+        CANmodule->txArray[i].bufferFull = 0;
+    }
+
+    /* Setting Clock of CAN HW */
+    CO_CANClkSetting();
+
+    /* GPIO Config for CAN */
+    CO_CANconfigGPIO();
+
+    /* Init CAN controler */
+    CAN_DeInit(CANmodule->CANbaseAddress);
+    CAN_StructInit(&CAN_InitStruct);
+ 
+    switch (CANbitRate) {
+        case 1000: CAN_InitStruct.CAN_Prescaler = 2;
+            break;
+        case 500: CAN_InitStruct.CAN_Prescaler = 4;
+            break;
+        default:
+        case 250: CAN_InitStruct.CAN_Prescaler = 8;
+            break;
+        case 125: CAN_InitStruct.CAN_Prescaler = 16;
+            break;
+        case 100: CAN_InitStruct.CAN_Prescaler = 20;
+            break;
+        case 50: CAN_InitStruct.CAN_Prescaler = 40;
+            break;
+        case 20: CAN_InitStruct.CAN_Prescaler = 100;
+            break;
+        case 10: CAN_InitStruct.CAN_Prescaler = 200;
+            break;
+    }
+    
+    CAN_InitStruct.CAN_SJW = CAN_SJW_1tq;     // changed by VJ, old value = CAN_SJW_1tq;
+    CAN_InitStruct.CAN_BS1 = CAN_BS1_13tq;    // changed by VJ, old value = CAN_BS1_3tq;
+    CAN_InitStruct.CAN_BS2 = CAN_BS2_2tq;     // changed by VJ, old value = CAN_BS2_2tq;
+    CAN_InitStruct.CAN_NART = ENABLE;         // No Automatic retransmision
+
+    result = CAN_Init(CANmodule->CANbaseAddress, &CAN_InitStruct);
+    if (result == 0) {
+       return CO_ERROR_TIMEOUT;  /* CO- Return Init failed */
+    }
+
+    memset(&CAN_FilterInitStruct, 0, sizeof (CAN_FilterInitStruct));
+    CAN_FilterInitStruct.CAN_FilterNumber = 0;
+    CAN_FilterInitStruct.CAN_FilterIdHigh = 0;
+    CAN_FilterInitStruct.CAN_FilterIdLow = 0;
+    CAN_FilterInitStruct.CAN_FilterMaskIdHigh = 0;
+    CAN_FilterInitStruct.CAN_FilterMaskIdLow = 0;
+    CAN_FilterInitStruct.CAN_FilterFIFOAssignment = 0; // pouzivame jen FIFO0
+    CAN_FilterInitStruct.CAN_FilterMode = CAN_FilterMode_IdMask;
+    CAN_FilterInitStruct.CAN_FilterScale = CAN_FilterScale_32bit;
+    CAN_FilterInitStruct.CAN_FilterActivation = ENABLE;
+    CAN_FilterInit(&CAN_FilterInitStruct);
+
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+    /* interrupts from receiver */
+    NVIC_InitStructure.NVIC_IRQChannel = CAN1_RX0_INTERRUPTS;
+    NVIC_Init(&NVIC_InitStructure);
+    /* interrupts from transmitter */
+    NVIC_InitStructure.NVIC_IRQChannel = CAN1_TX_INTERRUPTS;
+    NVIC_Init(&NVIC_InitStructure);
+
+    /* Can_init function of ST Driver puts the controller into the normal mode */
+
+    CAN_ITConfig(CANmodule->CANbaseAddress, (CAN_IT_TME | CAN_IT_FMP0), ENABLE);
+
+    return CO_ERROR_NO;
+}
+
+/******************************************************************************/
+void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
+{
+    CAN_DeInit(CANmodule->CANbaseAddress);
+}
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANrxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        uint16_t                mask,
+        int8_t                  rtr,
+        void                   *object,
+        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message))
+{
+    CO_CANrx_t *rxBuffer;
+    uint16_t RXF, RXM;
+
+    //safety
+    if (!CANmodule || !object || !pFunct || index >= CANmodule->rxSize) {
+        return CO_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    /* buffer, which will be configured */
+    rxBuffer = CANmodule->rxArray + index;
+
+    /* Configure object variables */
+    rxBuffer->object = object;
+    rxBuffer->pFunct = pFunct;
+
+    /* CAN identifier and CAN mask, bit aligned with CAN module registers */
+    RXF = (ident & 0x07FF) << 2;
+    if (rtr) RXF |= 0x02;
+    RXM = (mask & 0x07FF) << 2;
+    RXM |= 0x02;
+
+    /* configure filter and mask */
+    if (RXF != rxBuffer->ident || RXM != rxBuffer->mask) {
+        rxBuffer->ident = RXF;
+        rxBuffer->mask = RXM;
+    }
+
+    return CO_ERROR_NO;
+}
+
+/******************************************************************************/
+CO_CANtx_t *CO_CANtxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        int8_t                  rtr,
+        uint8_t                 noOfBytes,
+        int8_t                  syncFlag)
+{
+    uint32_t TXF;
+    CO_CANtx_t *buffer;
+
+    /* safety */
+    if (!CANmodule || CANmodule->txSize <= index) return 0;
+
+    /* get specific buffer */
+    buffer = &CANmodule->txArray[index];
+
+    /* CAN identifier, bit aligned with CAN module registers */
+    TXF = ident << 21;
+    TXF &= 0xFFE00000;
+    if (rtr) TXF |= 0x02;
+
+    /* write to buffer */
+    buffer->ident = TXF;
+    buffer->DLC = noOfBytes;
+    buffer->bufferFull = 0;
+    buffer->syncFlag = syncFlag ? 1 : 0;
+
+    return buffer;
+}
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
+{
+    CO_ReturnError_t err = CO_ERROR_NO;
+    uint8_t txBuff;
+
+    /* Verify overflow */
+    if (buffer->bufferFull) {
+        if(!CANmodule->firstCANtxMessage) /* don't set error, if bootup message is still on buffers */
+            CO_errorReport((CO_EM_t*)CANmodule->em, CO_EM_CAN_TX_OVERFLOW, CO_EMC_CAN_OVERRUN, 0);
+        err = CO_ERROR_TX_OVERFLOW;
+    }
+
+    CO_LOCK_CAN_SEND();
+    
+    /* First try to transmit the message immediately if mailbox is free.
+     * Only one TX mailbox is used of the three available in the hardware */
+    CANmodule->bufferInhibitFlag = buffer->syncFlag;
+    txBuff = CO_CANsendToModule(CANmodule, buffer);
+
+    /* No free mailbox -> use interrupt for transmission */
+    if (txBuff == CAN_TxStatus_NoMailBox) {
+        buffer->bufferFull = 1;
+        CANmodule->CANtxCount++;
+    }
+    CO_UNLOCK_CAN_SEND();
+
+    return err;
+}
+
+/******************************************************************************/
+void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule)
+{
+    uint32_t tpdoDeleted = 0U;
+    uint8_t state = 0;
+
+    CO_LOCK_CAN_SEND();
+    /* Abort message from CAN module, if there is synchronous TPDO. */
+    state = CAN_TransmitStatus(CANmodule->CANbaseAddress, CO_CAN_TXMAILBOX);
+    if((state == CAN_TxStatus_Pending) && (CANmodule->bufferInhibitFlag)) {
+        CAN_CancelTransmit(CANmodule->CANbaseAddress, CO_CAN_TXMAILBOX);
+        CANmodule->bufferInhibitFlag = false;
+        tpdoDeleted = 1U;
+    }
+    
+    /* delete also pending synchronous TPDOs in TX buffers */
+    if(CANmodule->CANtxCount != 0U){
+        uint16_t i;
+        CO_CANtx_t *buffer = &CANmodule->txArray[0];
+        for(i = CANmodule->txSize; i > 0U; i--){
+            if(buffer->bufferFull){
+                if(buffer->syncFlag){
+                    buffer->bufferFull = false;
+                    CANmodule->CANtxCount--;
+                    tpdoDeleted = 2U;
+                }
+            }
+            buffer++;
+        }
+    }
+    CO_UNLOCK_CAN_SEND();
+
+
+    if(tpdoDeleted != 0U){
+        CO_errorReport((CO_EM_t*)CANmodule->em, CO_EM_TPDO_OUTSIDE_WINDOW, CO_EMC_COMMUNICATION, tpdoDeleted);
+    }
+}
+
+/******************************************************************************/
+void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
+{
+    uint32_t err;
+    CO_EM_t* em = (CO_EM_t*)CANmodule->em;
+
+    err = CANmodule->CANbaseAddress->ESR;
+
+    if(CANmodule->errOld != err) {
+        CANmodule->errOld = err;
+
+        /* CAN RX bus overflow */
+        if(CANmodule->CANbaseAddress->RF0R & 0x10) {
+            CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
+            CANmodule->CANbaseAddress->RF0R &=~0x10;//clear bits
+        }
+
+        /* CAN TX bus off */
+        if(err & 0x04) {
+            CO_errorReport(em, CO_EM_CAN_TX_BUS_OFF, CO_EMC_BUS_OFF_RECOVERED, err);
+        }
+        else {
+            CO_errorReset(em, CO_EM_CAN_TX_BUS_OFF, err);
+        }
+        
+        /* CAN TX or RX bus passive */
+        if(err & 0x02) {
+            if(!CANmodule->firstCANtxMessage) CO_errorReport(em, CO_EM_CAN_TX_BUS_PASSIVE, CO_EMC_CAN_PASSIVE, err);
+        }
+        else {
+        // int16_t wasCleared;
+        /* wasCleared = */CO_errorReset(em, CO_EM_CAN_TX_BUS_PASSIVE, err);
+        /* if(wasCleared == 1) */CO_errorReset(em, CO_EM_CAN_TX_OVERFLOW, err);
+        }
+
+
+        /* CAN TX or RX bus warning */
+        if(err & 0x01) {
+            CO_errorReport(em, CO_EM_CAN_BUS_WARNING, CO_EMC_NO_ERROR, err);
+        }
+        else {
+            CO_errorReset(em, CO_EM_CAN_BUS_WARNING, err);
+        }
+    }
+}
+
+/******************************************************************************/
+/* Interrupt from receiver */
+void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule)
+{
+    CanRxMsg CAN1_RxMsg;
+    uint16_t index;
+    uint8_t msgMatched = 0;
+    CO_CANrx_t *msgBuff = CANmodule->rxArray;
+
+	CAN_Receive(CANmodule->CANbaseAddress, CAN_FilterFIFO0, &CAN1_RxMsg);
+    
+    for (index = 0; index < CANmodule->rxSize; index++) {
+        uint16_t msg = (CAN1_RxMsg.StdId << 2) | (CAN1_RxMsg.RTR ? 2 : 0);
+
+        if (((msg ^ msgBuff->ident) & msgBuff->mask) == 0) {
+            msgMatched = 1;
+            break;
+        }
+        msgBuff++;
+    }
+    
+    /* Call specific function, which will process the message */
+    if (msgMatched && msgBuff->pFunct) {
+        msgBuff->pFunct(msgBuff->object, (CO_CANrxMsg_t*) &CAN1_RxMsg);
+    }
+}
+
+/******************************************************************************/
+/* Interrupt from trasmitter */
+void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule)
+{
+    /* First CAN message (bootup) was sent successfully */
+    CANmodule->firstCANtxMessage = 0;
+    
+    /* clear flag from previous message */
+    CANmodule->bufferInhibitFlag = 0;
+    
+    /* Are there any new messages waiting to be send */
+    if (CANmodule->CANtxCount > 0) {
+        uint16_t i;             /* index of transmitting message */
+
+        /* first buffer */
+        CO_CANtx_t *buffer = CANmodule->txArray;
+        /* search through whole array of pointers to transmit message buffers. */
+        for(i = CANmodule->txSize; i > 0; i--) {
+            /* if message buffer is full, send it. */
+            if(buffer->bufferFull) {
+                buffer->bufferFull = 0;
+                CANmodule->CANtxCount--;
+                
+                /* Copy message to CAN buffer */
+                CANmodule->bufferInhibitFlag = buffer->syncFlag;
+                CO_CANsendToModule(CANmodule, buffer);
+                break;                      /* exit for loop */
+            }
+            buffer++;
+        }/* end of for loop */
+
+        /* Clear counter if no more messages */
+        if(i == 0) CANmodule->CANtxCount = 0;
+    }
+}
+
+/******************************************************************************/
+static uint8_t CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
+{
+    CAN_TxMailBox_TypeDef* txMbox;
+
+    /* Checks if the transmit mailbox is available */
+    if ((CANmodule->CANbaseAddress->TSR & CAN_TSR_TME0) == CAN_TSR_TME0) {
+        txMbox = &CANmodule->CANbaseAddress->sTxMailBox[CO_CAN_TXMAILBOX];
+    }
+    else {
+        return CAN_TxStatus_NoMailBox;
+    }
+
+    /* ID: always assuming standard 11-bit ID */
+    txMbox->TIR &= 1;
+    txMbox->TIR |= ((buffer->ident) | CAN_RTR_DATA);
+
+    /* DLC */
+    buffer->DLC &= (uint8_t)0x0000000F;
+    txMbox->TDTR &= (uint32_t)0xFFFFFFF0;
+    txMbox->TDTR |= buffer->DLC;
+    
+    /* Data field */
+    txMbox->TDLR = (((uint32_t)buffer->data[3] << 24) |  
+                    ((uint32_t)buffer->data[2] << 16) |
+                    ((uint32_t)buffer->data[1] << 8) | 
+                    ((uint32_t)buffer->data[0]));
+                    
+    txMbox->TDHR = (((uint32_t)buffer->data[7] << 24) | 
+                    ((uint32_t)buffer->data[6] << 16) |
+                    ((uint32_t)buffer->data[5] << 8) |
+                    ((uint32_t)buffer->data[4]));
+                    
+    /* Request transmission */
+    txMbox->TIR |= 1;
+    
+    return 0;
+}
+
+/******************************************************************************/
+static void CO_CANClkSetting (void)
+{
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE);
+}
+
+/******************************************************************************/
+static void CO_CANconfigGPIO (void)
+{
+    GPIO_InitTypeDef GPIO_InitStruct;
+
+	GPIO_InitStruct.GPIO_Pin = GPIO_Pin_CAN_RX | GPIO_Pin_CAN_TX;
+	GPIO_InitStruct.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_Level_1;
+	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStruct.GPIO_PuPd = GPIO_PuPd_NOPULL;
+	
+	GPIO_Init(GPIO_CAN, &GPIO_InitStruct);
+    
+    /* Map to correct alternative function (9 == CAN) */
+	GPIO_PinAFConfig(GPIO_CAN, GPIO_PinSource_CAN_RX, GPIO_AF_9);
+	GPIO_PinAFConfig(GPIO_CAN, GPIO_PinSource_CAN_TX, GPIO_AF_9);
+}

--- a/stack/STM32F3/CO_driver.h
+++ b/stack/STM32F3/CO_driver.h
@@ -1,0 +1,250 @@
+/*
+ * CAN module object for ST STM32F334 microcontroller.
+ *
+ * @file        CO_driver.h
+ * @author      Janez Paternoster
+ * @author      Ondrej Netik
+ * @author      Vijayendra
+ * @author      Jan van Lienden
+ * @author      Petteri Mustonen
+ * @copyright   2013 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+
+#ifndef CO_DRIVER_H
+#define CO_DRIVER_H
+
+
+/* For documentation see file drvTemplate/CO_driver.h */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdbool.h>
+#include <stddef.h>         /* for 'NULL' */
+#include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
+#include "stm32f30x.h"
+
+#define bool_t bool
+#define CO_LITTLE_ENDIAN
+
+/* Exported define -----------------------------------------------------------*/
+#define PACKED_STRUCT               __attribute__((packed))
+#define ALIGN_STRUCT_DWORD          __attribute__((aligned(4)))
+
+/* Peripheral addresses */
+#define ADDR_CAN1                   CAN1
+
+/* Critical sections */
+#define CO_LOCK_CAN_SEND()          __set_PRIMASK(1);
+#define CO_UNLOCK_CAN_SEND()        __set_PRIMASK(0);
+
+#define CO_LOCK_EMCY()              __set_PRIMASK(1);
+#define CO_UNLOCK_EMCY()            __set_PRIMASK(0);
+
+#define CO_LOCK_OD()                __set_PRIMASK(1);
+#define CO_UNLOCK_OD()              __set_PRIMASK(0);
+
+#define CLOCK_CAN                   RCC_APB1Periph_CAN1
+
+#define CAN_REMAP_1                 /* Select CAN1 remap 1 */
+#ifdef CAN1_NO_REMAP                /* CAN1 not remapped */
+#define CLOCK_GPIO_CAN              RCC_APB2Periph_GPIOA
+#define GPIO_Remapping_CAN          (0)
+#define GPIO_CAN                    GPIOA
+#define GPIO_Pin_CAN_RX             GPIO_Pin_11
+#define GPIO_Pin_CAN_TX             GPIO_Pin_12
+#define GPIO_PinSource_CAN_RX       GPIO_PinSource11
+#define GPIO_PinSource_CAN_TX       GPIO_PinSource12
+#define GPIO_CAN_Remap_State        DISABLE
+#endif
+#ifdef CAN_REMAP_1                  /* CAN1 remap 1 */
+#define CLOCK_GPIO_CAN              RCC_AHBPeriph_GPIOB
+#define GPIO_Remapping_CAN          GPIO_Remap1_CAN1
+#define GPIO_CAN                    GPIOB
+#define GPIO_Pin_CAN_RX             GPIO_Pin_8
+#define GPIO_Pin_CAN_TX             GPIO_Pin_9
+#define GPIO_PinSource_CAN_RX       GPIO_PinSource8
+#define GPIO_PinSource_CAN_TX       GPIO_PinSource9
+#define GPIO_CAN_Remap_State        ENABLE
+#endif
+
+#define CAN1_TX_INTERRUPTS          CAN1_TX_IRQn
+#define CAN1_RX0_INTERRUPTS         CAN1_RX0_IRQn
+
+#define CO_CAN_TXMAILBOX   ((uint8_t)0x00)
+
+/* Timeout for initialization */
+
+#define INAK_TIMEOUT        ((uint32_t)0x0000FFFF)
+/* Data types */
+    typedef float                   float32_t;
+    typedef long double             float64_t;
+    typedef char                    char_t;
+    typedef unsigned char           oChar_t;
+    typedef unsigned char           domain_t;
+
+/* Return values */
+typedef enum{
+    CO_ERROR_NO                 = 0,
+    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
+    CO_ERROR_OUT_OF_MEMORY      = -2,
+    CO_ERROR_TIMEOUT            = -3,
+    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
+    CO_ERROR_RX_OVERFLOW        = -5,
+    CO_ERROR_RX_PDO_OVERFLOW    = -6,
+    CO_ERROR_RX_MSG_LENGTH      = -7,
+    CO_ERROR_RX_PDO_LENGTH      = -8,
+    CO_ERROR_TX_OVERFLOW        = -9,
+    CO_ERROR_TX_PDO_WINDOW      = -10,
+    CO_ERROR_TX_UNCONFIGURED    = -11,
+    CO_ERROR_PARAMETERS         = -12,
+    CO_ERROR_DATA_CORRUPT       = -13,
+    CO_ERROR_CRC                = -14
+}CO_ReturnError_t;
+
+/* CAN receive message structure as aligned in CAN module.
+ * prevzato z stm32f10_can.h - velikostne polozky a poradi odpovidaji. */
+typedef struct{
+    uint32_t    ident;          /* Standard Identifier */
+    uint32_t    ExtId;          /* Specifies the extended identifier */
+    uint8_t     IDE;            /* Specifies the type of identifier for the
+                                   message that will be received */
+    uint8_t     RTR;            /* Remote Transmission Request bit */
+    uint8_t     DLC;            /* Data length code (bits 0...3) */
+    uint8_t     data[8];        /* 8 data bytes */
+    uint8_t     FMI;            /* Specifies the index of the filter the message
+                                   stored in the mailbox passes through */
+}CO_CANrxMsg_t;
+
+
+/* Received message object */
+typedef struct{
+    uint16_t           ident;
+    uint16_t           mask;
+    void               *object;
+    void              (*pFunct)(void *object, const CO_CANrxMsg_t *message); // Changed by VJ
+}CO_CANrx_t;
+
+
+/* Transmit message object. */
+typedef struct{
+    uint32_t            ident;
+    uint8_t             DLC;
+    uint8_t             data[8];
+    volatile uint8_t    bufferFull;
+    volatile uint8_t    syncFlag;
+}CO_CANtx_t;/* ALIGN_STRUCT_DWORD; */
+
+
+/* CAN module object. */
+typedef struct{
+    CAN_TypeDef        *CANbaseAddress;         /* STM32F4xx specific */
+    CO_CANrx_t         *rxArray;
+    uint16_t            rxSize;
+    CO_CANtx_t         *txArray;
+    uint16_t            txSize;
+    volatile bool     CANnormal;
+    volatile bool     useCANrxFilters;
+    //volatile uint8_t    useCANrxFilters;
+    volatile uint8_t    bufferInhibitFlag;
+    volatile uint8_t    firstCANtxMessage;
+    volatile uint16_t   CANtxCount;
+    uint32_t            errOld;
+    void               *em;
+}CO_CANmodule_t;
+
+/* Exported variables -----------------------------------------------------------*/
+
+/* Exported functions -----------------------------------------------------------*/
+
+/* Request CAN configuration or normal mode */
+void CO_CANsetConfigurationMode(CAN_TypeDef* CANbaseAddress);
+void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
+
+/* Initialize CAN module object. */
+CO_ReturnError_t CO_CANmodule_init(
+        CO_CANmodule_t         *CANmodule,
+        CAN_TypeDef            *CANbaseAddress,
+        CO_CANrx_t              rxArray[],
+        uint16_t                rxSize,
+        CO_CANtx_t              txArray[],
+        uint16_t                txSize,
+        uint16_t                CANbitRate);
+
+
+/* Switch off CANmodule. */
+void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
+
+/* Configure CAN message receive buffer. */
+CO_ReturnError_t CO_CANrxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        uint16_t                mask,
+        int8_t                  rtr,
+        void                   *object,
+        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
+
+
+/* Configure CAN message transmit buffer. */
+CO_CANtx_t *CO_CANtxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        int8_t                  rtr,
+        uint8_t                 noOfBytes,
+        int8_t                  syncFlag);
+
+/* Send CAN message. */
+CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
+
+
+/* Clear all synchronous TPDOs from CAN module transmit buffers. */
+void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
+
+
+/* Verify all errors of CAN module. */
+void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
+
+
+/* CAN interrupts receives and transmits CAN messages. */
+void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule);
+void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule);
+
+#endif


### PR DESCRIPTION
Pull request includes initial CAN and Flash drivers for STM32F3-family of microcontrollers. CAN driver is based on the existing STM32F1 driver in the reposirory and the Flash-driver is based on the Atmel SAM3X Flash driver. 

A custom-made STM32F334-based board was used in the development and things seem to work in basic desktop testing with simple CANOpen bus of two devices. No testing in real CANOpen environment is done yet. Any feedback or improvement ideas are welcome!