### PR TITLE
Allow multiple SDO client objects

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -137,7 +137,7 @@
     static CO_HBconsumer_t      COO_HBcons;
     static CO_HBconsNode_t      COO_HBcons_monitoredNodes[CO_NO_HB_CONS];
 #if CO_NO_SDO_CLIENT != 0
-    static CO_SDOclient_t       COO_SDOclient[CO_NO_SDO_CLIENT];
+    static CO_SDOclient_t       COO_SDOclient;
 #endif
 #if CO_NO_TRACE > 0
     static CO_trace_t           COO_trace[CO_NO_TRACE];
@@ -240,8 +240,7 @@ CO_ReturnError_t CO_init(
     CO->HBcons                          = &COO_HBcons;
     CO_HBcons_monitoredNodes            = &COO_HBcons_monitoredNodes[0];
   #if CO_NO_SDO_CLIENT != 0
-    for(i=0; i<CO_NO_SDO_CLIENT; i++)
-        CO->SDOclient[i]                = &COO_SDOclient[i];
+    CO->SDOclient                       = &COO_SDOclient;
   #endif
   #if CO_NO_TRACE > 0
     for(i=0; i<CO_NO_TRACE; i++) {
@@ -274,9 +273,7 @@ CO_ReturnError_t CO_init(
         CO->HBcons                          = (CO_HBconsumer_t *)   calloc(1, sizeof(CO_HBconsumer_t));
         CO_HBcons_monitoredNodes            = (CO_HBconsNode_t *)   calloc(CO_NO_HB_CONS, sizeof(CO_HBconsNode_t));
       #if CO_NO_SDO_CLIENT != 0
-        for(i=0; i<CO_NO_SDO_CLIENT; i++){
-            CO->SDOclient[i]                = (CO_SDOclient_t *)    calloc(1, sizeof(CO_SDOclient_t));
-        }
+        CO->SDOclient                       = (CO_SDOclient_t *)    calloc(1, sizeof(CO_SDOclient_t));
       #endif
       #if CO_NO_TRACE > 0
         for(i=0; i<CO_NO_TRACE; i++) {
@@ -306,7 +303,7 @@ CO_ReturnError_t CO_init(
                   + sizeof(CO_HBconsumer_t)
                   + sizeof(CO_HBconsNode_t) * CO_NO_HB_CONS
   #if CO_NO_SDO_CLIENT != 0
-                  + sizeof(CO_SDOclient_t) * CO_NO_SDO_CLIENT
+                  + sizeof(CO_SDOclient_t)
   #endif
                   + 0;
   #if CO_NO_TRACE > 0
@@ -337,9 +334,7 @@ CO_ReturnError_t CO_init(
     if(CO->HBcons                       == NULL) errCnt++;
     if(CO_HBcons_monitoredNodes         == NULL) errCnt++;
   #if CO_NO_SDO_CLIENT != 0
-    for(i=0; i<CO_NO_SDO_CLIENT; i++){
-        if(CO->SDOclient[i]             == NULL) errCnt++;
-    }
+    if(CO->SDOclient                    == NULL) errCnt++;
   #endif
   #if CO_NO_TRACE > 0
     for(i=0; i<CO_NO_TRACE; i++) {
@@ -517,17 +512,14 @@ CO_ReturnError_t CO_init(
 
 
 #if CO_NO_SDO_CLIENT != 0
-    for (i=0; i<CO_NO_SDO_CLIENT; i++)
-    {
-        err = CO_SDOclient_init(
-                CO->SDOclient[i],
-                CO->SDO[i],
-                (CO_SDOclientPar_t*) &OD_SDOClientParameter[i],
-                CO->CANmodule[0],
-                CO_RXCAN_SDO_CLI,
-                CO->CANmodule[0],
-                CO_TXCAN_SDO_CLI);
-    }
+    err = CO_SDOclient_init(
+            CO->SDOclient,
+            CO->SDO[0],
+            (CO_SDOclientPar_t*) &OD_SDOClientParameter[0],
+            CO->CANmodule[0],
+            CO_RXCAN_SDO_CLI,
+            CO->CANmodule[0],
+            CO_TXCAN_SDO_CLI);
 
     if(err){CO_delete(CANbaseAddress); return err;}
 #endif
@@ -578,9 +570,7 @@ void CO_delete(int32_t CANbaseAddress){
       }
   #endif
   #if CO_NO_SDO_CLIENT != 0
-    for(i=0; i<CO_NO_SDO_CLIENT; i++){
-        free(CO->SDOclient);
-    }
+    free(CO->SDOclient);
   #endif
     free(CO_HBcons_monitoredNodes);
     free(CO->HBcons);

--- a/CANopen.h
+++ b/CANopen.h
@@ -80,7 +80,7 @@
     #include "CO_SYNC.h"
     #include "CO_PDO.h"
     #include "CO_HBconsumer.h"
-#if CO_NO_SDO_CLIENT == 1
+#if CO_NO_SDO_CLIENT != 0
     #include "CO_SDOmaster.h"
 #endif
 #if CO_NO_TRACE > 0
@@ -128,8 +128,8 @@ typedef struct{
     CO_RPDO_t          *RPDO[CO_NO_RPDO];/**< RPDO objects */
     CO_TPDO_t          *TPDO[CO_NO_TPDO];/**< TPDO objects */
     CO_HBconsumer_t    *HBcons;         /**<  Heartbeat consumer object*/
-#if CO_NO_SDO_CLIENT == 1
-    CO_SDOclient_t     *SDOclient;      /**< SDO client object */
+#if CO_NO_SDO_CLIENT != 0
+    CO_SDOclient_t     *SDOclient[CO_NO_SDO_CLIENT];      /**< SDO client object */
 #endif
 #if CO_NO_TRACE > 0
     CO_trace_t         *trace[CO_NO_TRACE]; /**< Trace object for monitoring variables */

--- a/CANopen.h
+++ b/CANopen.h
@@ -129,7 +129,7 @@ typedef struct{
     CO_TPDO_t          *TPDO[CO_NO_TPDO];/**< TPDO objects */
     CO_HBconsumer_t    *HBcons;         /**<  Heartbeat consumer object*/
 #if CO_NO_SDO_CLIENT != 0
-    CO_SDOclient_t     *SDOclient[CO_NO_SDO_CLIENT];      /**< SDO client object */
+    CO_SDOclient_t     *SDOclient;      /**< SDO client object */
 #endif
 #if CO_NO_TRACE > 0
     CO_trace_t         *trace[CO_NO_TRACE]; /**< Trace object for monitoring variables */


### PR DESCRIPTION
These changes allow multiple SDO client objects to be declared in CO_OD.h

This is hugely based on #4.

I'd like your feedback, I'm quite new to the CANopen world and maybe I missed a way to implement this with one SDO client and multiple SDO objects.

Best regards
Ben