### PR TITLE
Add LPC1768 driver

### DIFF
--- a/stack/LPC1768/CO_CAN.h
+++ b/stack/LPC1768/CO_CAN.h
@@ -1,0 +1,25 @@
+#ifndef CO_CAN_H
+#define CO_CAN_H
+
+#ifndef MBED_CAN
+#error "MBED_CAN must be defined to select CAN port"
+#endif
+
+#include "mbed.h"
+
+#if (MBED_CAN == 0)
+#define MBED_CAN_RX		p9
+#define MBED_CAN_TX		p10
+#define MBED_CAN_REG	LPC_CAN1
+#else
+#define MBED_CAN_RX		(p30)
+#define MBED_CAN_TX		(p29)
+#define MBED_CAN_REG	(LPC_CAN2)
+#endif
+
+#define MBED_CHECK_TX_BUFFERS (MBED_CAN_REG->SR & 0x4 || MBED_CAN_REG->SR & 0x400 || MBED_CAN_REG->SR & 0x40000)
+#define MBED_CHECK_TX_INTERRUPTS(intStatus) (intStatus & 0x2 || intStatus & 0x200 || intStatus & 0x400)
+
+extern CAN *CANport;
+
+#endif // CO_CAN_H

--- a/stack/LPC1768/CO_CAN.h
+++ b/stack/LPC1768/CO_CAN.h
@@ -1,3 +1,48 @@
+/*
+ * CAN module object for LPC1768 microcontroller using Mbed SDK.
+ *
+ * @file        CO_CAN.h
+ * @ingroup     CO_driver
+ * @author      Benoit Rapidel
+ * @copyright   2016 Benoit Rapidel
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
 #ifndef CO_CAN_H
 #define CO_CAN_H
 

--- a/stack/LPC1768/CO_driver.cpp
+++ b/stack/LPC1768/CO_driver.cpp
@@ -48,10 +48,12 @@
 #include "LPC17xx.h"
 #include "CAN.h"
 
+extern "C" {
 #include "CO_driver.h"
 #include "CO_Emergency.h"
 
 #include "CO_CAN.h"
+}
 
 CAN CANport0(MBED_CAN_RX, MBED_CAN_TX);
 CAN *CANport = NULL;

--- a/stack/LPC1768/CO_driver.cpp
+++ b/stack/LPC1768/CO_driver.cpp
@@ -1,0 +1,445 @@
+/*
+ * CAN module object for generic microcontroller.
+ *
+ * This file is a template for other microcontrollers.
+ *
+ * @file        CO_driver.c
+ * @ingroup     CO_driver
+ * @author      Janez Paternoster
+ * @copyright   2004 - 2015 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+#include "mbed.h"
+#include "LPC17xx.h"
+#include "CAN.h"
+
+#include "CO_driver.h"
+#include "CO_Emergency.h"
+
+#include "CO_CAN.h"
+
+CAN CANport0(MBED_CAN_RX, MBED_CAN_TX);
+CAN *CANport = NULL;
+
+
+/* helper functions */
+
+CANMessage toCANMessage(CO_CANtx_t *CO_msg) {
+    CANMessage msg;
+    msg.id = (uint32_t) CO_msg->ident & 0x07FFU;
+    msg.len = (uint32_t) CO_msg->DLC;
+    msg.type =
+        ((uint32_t) CO_msg->ident & 0x8000U) == 0x8000 ?
+        CANRemote : CANData;
+    memcpy(msg.data, CO_msg->data, CO_msg->DLC);
+
+    return msg;
+}
+
+void fromCANMessage(CANMessage *msg, CO_CANrxMsg_t *CO_msg) {
+    CO_msg->ident = (uint32_t) msg->id & 0x07FFU;
+    CO_msg->DLC = (uint32_t) msg->len;
+    CO_msg->ident =
+        (msg->type == CANRemote) ? CO_msg->ident | 0x8000 : CO_msg->ident;
+    memcpy(CO_msg->data, msg->data, CO_msg->DLC);
+}
+
+/******************************************************************************/
+void CO_CANsetConfigurationMode(int32_t CANbaseAddress) {
+    /* Put CAN module in configuration mode */
+}
+
+/******************************************************************************/
+void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule) {
+    /* Put CAN module in normal mode */
+    // CANport->mode(CAN::Reset);
+
+    // can_mode(LPC_CAN2->, CAN::Normal);
+    // LPC_IOCON->PIO0_4 = PIN_INPUT P
+    CANmodule->CANnormal = true;
+}
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANmodule_init(CO_CANmodule_t *CANmodule,
+        int32_t CANbaseAddress, CO_CANrx_t rxArray[], uint16_t rxSize,
+        CO_CANtx_t txArray[], uint16_t txSize, uint16_t CANbitRate) {
+    uint16_t i;
+    uint16_t freq_err = 0;
+
+    /* verify arguments */
+    if (CANmodule == NULL || rxArray == NULL || txArray == NULL) {
+        return CO_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    /* Configure object variables */
+    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->rxArray = rxArray;
+    CANmodule->rxSize = rxSize;
+    CANmodule->txArray = txArray;
+    CANmodule->txSize = txSize;
+    CANmodule->CANnormal = false;
+    CANmodule->useCANrxFilters = false; //(rxSize <= 32U) ? true : false;/* microcontroller dependent */
+    CANmodule->bufferInhibitFlag = false;
+    CANmodule->firstCANtxMessage = true;
+    CANmodule->CANtxCount = 0U;
+    CANmodule->errOld = 0U;
+    CANmodule->em = NULL;
+
+    for (i = 0U; i < rxSize; i++) {
+        rxArray[i].ident = 0U;
+        rxArray[i].pFunct = NULL;
+    }
+    for (i = 0U; i < txSize; i++) {
+        txArray[i].bufferFull = false;
+    }
+
+    /* Configure CAN module registers */
+    CANport = &CANport0;
+    // CANport->reset();
+
+    /* Configure CAN timing */
+    int CANbaudRate = CANbitRate * 1000;
+    freq_err = CANport->frequency(CANbaudRate);
+    if(freq_err != 1) {
+        return CO_ERROR_PARAMETERS;
+    }
+
+    /* Configure CAN module hardware filters */
+    if (CANmodule->useCANrxFilters) {
+        /* CAN module filters are used, they will be configured with */
+        /* CO_CANrxBufferInit() functions, called by separate CANopen */
+        /* init functions. */
+        /* Configure all masks so, that received message must match filter */
+        // TODO
+    } else {
+        /* CAN module filters are not used, all messages with standard 11-bit */
+        /* identifier will be received */
+        /* Configure mask 0 so, that all messages with standard identifier are accepted */
+        // CANport->filter(0, 0, CANAny);
+    }
+
+    /* configure CAN interrupt registers */
+
+    return CO_ERROR_NO;
+}
+
+/******************************************************************************/
+void CO_CANmodule_disable(CO_CANmodule_t *CANmodule) {
+    /* turn off the module */
+}
+
+/******************************************************************************/
+uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg) {
+    return (uint16_t) rxMsg->ident;
+}
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANrxBufferInit(CO_CANmodule_t *CANmodule, uint16_t index,
+        uint16_t ident, uint16_t mask, bool_t rtr, void *object,
+        void (*pFunct)(void *object, const CO_CANrxMsg_t *message)) {
+    CO_ReturnError_t ret = CO_ERROR_NO;
+
+    if ((CANmodule != NULL) && (object != NULL) && (pFunct != NULL)
+            && (index < CANmodule->rxSize)) {
+        /* buffer, which will be configured */
+        CO_CANrx_t *buffer = &CANmodule->rxArray[index];
+
+        /* Configure object variables */
+        buffer->object = object;
+        buffer->pFunct = pFunct;
+
+        /* CAN identifier and CAN mask, bit aligned with CAN module. Different on different microcontrollers. */
+        buffer->ident = ident & 0x07FFU;
+        if (rtr) buffer->ident |= 0x0800U;
+
+        buffer->mask = (mask & 0x07FFU) | 0x0800U;
+
+        /* Set CAN hardware module filter and mask. */
+        if (CANmodule->useCANrxFilters) {
+            // TODO
+        }
+    } else {
+        ret = CO_ERROR_ILLEGAL_ARGUMENT;
+    }
+
+    return ret;
+}
+
+/******************************************************************************/
+CO_CANtx_t *CO_CANtxBufferInit(CO_CANmodule_t *CANmodule, uint16_t index,
+        uint16_t ident, bool_t rtr, uint8_t noOfBytes, bool_t syncFlag) {
+    CO_CANtx_t *buffer = NULL;
+
+    if ((CANmodule != NULL) && (index < CANmodule->txSize)) {
+        /* get specific buffer */
+        buffer = &CANmodule->txArray[index];
+
+        /* CAN identifier, DLC and rtr, bit aligned with CAN module transmit buffer.
+         * Microcontroller specific. */
+        buffer->ident = ((uint32_t) ident & 0x07FFU);
+        buffer->DLC = ((uint32_t) noOfBytes & 0xFU);
+        /* toggle RTR bit if CAN message is remote type */
+        if (rtr) buffer->ident |= 0x8000U;
+
+        buffer->bufferFull = false;
+        buffer->syncFlag = syncFlag;
+    }
+
+    return buffer;
+}
+
+/******************************************************************************/
+CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer) {
+    CO_ReturnError_t err = CO_ERROR_NO;
+
+    CANMessage msg;
+
+    /* Verify overflow */
+    if (buffer->bufferFull) {
+        if (!CANmodule->firstCANtxMessage) {
+            /* don't set error, if bootup message is still on buffers */
+            CO_errorReport((CO_EM_t*) CANmodule->em, CO_EM_CAN_TX_OVERFLOW,
+                    CO_EMC_CAN_OVERRUN, buffer->ident);
+        }
+        err = CO_ERROR_TX_OVERFLOW;
+        // USBport.printf("BUFF_FULL OVERFLOW\r\n");
+    }
+
+    CO_LOCK_CAN_SEND();
+    /* if CAN TX buffer is free, copy message to it */
+    if ((MBED_CHECK_TX_BUFFERS) && CANmodule->CANtxCount == 0) {
+        CANmodule->bufferInhibitFlag = buffer->syncFlag;
+        /* copy message and txRequest */
+        // USBport.printf("SEND\r\n");
+        CANport->write(toCANMessage(buffer));
+    }
+    /* if no buffer is free, message will be sent by interrupt */
+    else {
+        // USBport.printf("BUFF_FULL\r\n");
+        buffer->bufferFull = true;
+        CANmodule->CANtxCount++;
+    } CO_UNLOCK_CAN_SEND();
+
+    return err;
+}
+
+/******************************************************************************/
+void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule) {
+    uint32_t tpdoDeleted = 0U;
+
+    CO_LOCK_CAN_SEND();
+    /* Abort message from CAN module, if there is synchronous TPDO.
+     * Take special care with this functionality. */
+    if (((MBED_CAN_REG->GSR & (1 << 2)) == 0) && CANmodule->bufferInhibitFlag) {
+        /* clear TXREQ */
+        MBED_CAN_REG->CMR = (1 << 5) | (1 << 1); // Select TX buffer 1 and run AT command (abort)
+        MBED_CAN_REG->CMR = (1 << 6) | (1 << 1); // Select TX buffer 2 and run AT command (abort)
+        MBED_CAN_REG->CMR = (1 << 7) | (1 << 1); // Select TX buffer 3 and run AT command (abort)
+
+        CANmodule->bufferInhibitFlag = false;
+        tpdoDeleted = 1U;
+    }
+    /* delete also pending synchronous TPDOs in TX buffers */
+    if (CANmodule->CANtxCount != 0U) {
+        uint16_t i;
+        CO_CANtx_t *buffer = &CANmodule->txArray[0];
+        for (i = CANmodule->txSize; i > 0U; i--) {
+            if (buffer->bufferFull) {
+                if (buffer->syncFlag) {
+                    buffer->bufferFull = false;
+                    CANmodule->CANtxCount--;
+                    tpdoDeleted = 2U;
+                }
+            }
+            buffer++;
+        }
+    } CO_UNLOCK_CAN_SEND();
+
+    if (tpdoDeleted != 0U) {
+        CO_errorReport((CO_EM_t*) CANmodule->em, CO_EM_TPDO_OUTSIDE_WINDOW,
+                CO_EMC_COMMUNICATION, tpdoDeleted);
+    }
+}
+
+/******************************************************************************/
+void CO_CANverifyErrors(CO_CANmodule_t *CANmodule) {
+    uint16_t rxErrors, txErrors, overflow;
+    CO_EM_t* em = (CO_EM_t*) CANmodule->em;
+    uint32_t err;
+
+    /* get error counters from module. Id possible, function may use different way to
+     * determine errors. */
+    rxErrors = CANport->rderror();
+    txErrors = CANport->tderror();
+    overflow = (MBED_CAN_REG->GSR & 0x2);
+
+    err = ((uint32_t) txErrors << 16) | ((uint32_t) rxErrors << 8) | overflow;
+
+    if (CANmodule->errOld != err) {
+        CANmodule->errOld = err;
+
+        if (txErrors >= 256U) { /* bus off */
+            CO_errorReport(em, CO_EM_CAN_TX_BUS_OFF, CO_EMC_BUS_OFF_RECOVERED,
+                    err);
+        } else { /* not bus off */
+            CO_errorReset(em, CO_EM_CAN_TX_BUS_OFF, err);
+
+            if ((rxErrors >= 96U) || (txErrors >= 96U)) { /* bus warning */
+                CO_errorReport(em, CO_EM_CAN_BUS_WARNING, CO_EMC_NO_ERROR, err);
+            }
+
+            if (rxErrors >= 128U) { /* RX bus passive */
+                CO_errorReport(em, CO_EM_CAN_RX_BUS_PASSIVE, CO_EMC_CAN_PASSIVE,
+                        err);
+            } else {
+                CO_errorReset(em, CO_EM_CAN_RX_BUS_PASSIVE, err);
+            }
+
+            if (txErrors >= 128U) { /* TX bus passive */
+                if (!CANmodule->firstCANtxMessage) {
+                    CO_errorReport(em, CO_EM_CAN_TX_BUS_PASSIVE,
+                            CO_EMC_CAN_PASSIVE, err);
+                }
+            } else {
+                bool_t isError = CO_isError(em, CO_EM_CAN_TX_BUS_PASSIVE);
+                if (isError) {
+                    CO_errorReset(em, CO_EM_CAN_TX_BUS_PASSIVE, err);
+                    CO_errorReset(em, CO_EM_CAN_TX_OVERFLOW, err);
+                }
+            }
+
+            if ((rxErrors < 96U) && (txErrors < 96U)) { /* no error */
+                CO_errorReset(em, CO_EM_CAN_BUS_WARNING, err);
+            }
+        }
+
+        if (overflow != 0U) { /* CAN RX bus overflow */
+            CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
+        }
+    }
+}
+
+/******************************************************************************/
+void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
+    uint16_t intStatus;
+
+    intStatus = MBED_CAN_REG->ICR;
+
+    /* receive interrupt */
+    if (intStatus & 0x1) {
+        CO_CANrxMsg_t rcvMsgBuf; /* buffer for the received message in CAN module */
+        CO_CANrxMsg_t *rcvMsg; /* pointer to received message in CAN module */
+        uint16_t index; /* index of received message */
+        uint32_t rcvMsgIdent; /* identifier of the received message */
+        CO_CANrx_t *buffer = NULL; /* receive message buffer from CO_CANmodule_t object. */
+        bool_t msgMatched = false;
+        CANMessage msg;
+
+        CANport->read(msg);
+        fromCANMessage(&msg, &rcvMsgBuf); /* get message from module here */
+        rcvMsg = &rcvMsgBuf;
+        rcvMsgIdent = rcvMsg->ident;
+        if (CANmodule->useCANrxFilters) {
+            /* CAN module filters are used. Message with known 11-bit identifier has */
+            /* been received */
+            index = 0; /* get index of the received message here. Or something similar */
+            if (index < CANmodule->rxSize) {
+                buffer = &CANmodule->rxArray[index];
+                /* verify also RTR */
+                if (((rcvMsgIdent ^ buffer->ident) & buffer->mask) == 0U) {
+                    msgMatched = true;
+                }
+            }
+        } else {
+            /* CAN module filters are not used, message with any standard 11-bit identifier */
+            /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
+            buffer = &CANmodule->rxArray[0];
+            for (index = CANmodule->rxSize; index > 0U; index--) {
+                if (((rcvMsgIdent ^ buffer->ident) & buffer->mask) == 0U) {
+                    msgMatched = true;
+                    break;
+                }
+                buffer++;
+            }
+        }
+
+        /* Call specific function, which will process the message */
+        if (msgMatched && (buffer != NULL) && (buffer->pFunct != NULL)) {
+            buffer->pFunct(buffer->object, rcvMsg);
+        }
+        /* Clear interrupt flag */
+        /* The interrupt flag is cleaned by CANport.read() function call */
+    }
+    else if ((intStatus & 0x2) || (intStatus & 0x200) || (intStatus & 0x400)) {
+        /* transmit interrupt */
+
+        /* Clear interrupt flag */
+
+        /* First CAN message (bootup) was sent successfully */
+        CANmodule->firstCANtxMessage = false;
+        /* clear flag from previous message */
+        CANmodule->bufferInhibitFlag = false;
+        /* Are there any new messages waiting to be send */
+        if (CANmodule->CANtxCount > 0U) {
+            uint16_t i; /* index of transmitting message */
+
+            /* first buffer */
+            CO_CANtx_t *buffer = &CANmodule->txArray[0];
+            /* search through whole array of pointers to transmit message buffers. */
+            for (i = CANmodule->txSize; i > 0U; i--) {
+                /* if message buffer is full, send it. */
+                if (buffer->bufferFull) {
+                    buffer->bufferFull = false;
+                    CANmodule->CANtxCount--;
+
+                    /* Copy message to CAN buffer */
+                    CANmodule->bufferInhibitFlag = buffer->syncFlag;
+                    /* canSend... */
+                    CANport->write(toCANMessage(buffer));
+                    break; /* exit for loop */
+                }
+                buffer++;
+            }/* end of for loop */
+
+            /* Clear counter if no more messages */
+            if (i == 0U) {
+                CANmodule->CANtxCount = 0U;
+            }
+        }
+    }
+}

--- a/stack/LPC1768/CO_driver.cpp
+++ b/stack/LPC1768/CO_driver.cpp
@@ -1,12 +1,10 @@
 /*
- * CAN module object for generic microcontroller.
+ * CAN module object for LPC1768 microcontroller using Mbed SDK.
  *
- * This file is a template for other microcontrollers.
- *
- * @file        CO_driver.c
+ * @file        CO_driver.cpp
  * @ingroup     CO_driver
- * @author      Janez Paternoster
- * @copyright   2004 - 2015 Janez Paternoster
+ * @author      Benoit Rapidel
+ * @copyright   2016 Benoit Rapidel
  *
  * This file is part of CANopenNode, an opensource CANopen Stack.
  * Project home page is <https://github.com/CANopenNode/CANopenNode>.
@@ -44,6 +42,7 @@
  * library, but you are not obliged to do so. If you do not wish
  * to do so, delete this exception statement from your version.
  */
+
 #include "mbed.h"
 #include "LPC17xx.h"
 #include "CAN.h"

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -1,0 +1,465 @@
+/**
+ * CAN module object for generic microcontroller.
+ *
+ * This file is a template for other microcontrollers.
+ *
+ * @file        CO_driver.h
+ * @ingroup     CO_driver
+ * @author      Janez Paternoster
+ * @copyright   2004 - 2015 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+#ifndef CO_DRIVER_H
+#define CO_DRIVER_H
+
+
+/* Include processor header file */
+#include <stddef.h>         /* for 'NULL' */
+#include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
+#include <stdbool.h>        /* for 'true', 'false' */
+
+#define MBED_CAN 1
+
+
+/**
+ * @defgroup CO_driver Driver
+ * @ingroup CO_CANopen
+ * @{
+ *
+ * Microcontroller specific code for CANopenNode.
+ *
+ * This file contains type definitions, functions and macros for:
+ *  - Basic data types.
+ *  - Receive and transmit buffers for CANopen messages.
+ *  - Interaction with CAN module on the microcontroller.
+ *  - CAN receive and transmit interrupts.
+ *
+ * This file is not only a CAN driver. There are no classic CAN queues for CAN
+ * messages. This file provides direct connection with other CANopen
+ * objects. It tries to provide fast responses and tries to avoid unnecessary
+ * calculations and memory consumptions.
+ *
+ * CO_CANmodule_t contains an array of _Received message objects_ (of type
+ * CO_CANrx_t) and an array of _Transmit message objects_ (of type CO_CANtx_t).
+ * Each CANopen communication object owns one member in one of the arrays.
+ * For example Heartbeat producer generates one CANopen transmitting object,
+ * so it has reserved one member in CO_CANtx_t array.
+ * SYNC module may produce sync or consume sync, so it has reserved one member
+ * in CO_CANtx_t and one member in CO_CANrx_t array.
+ *
+ * ###Reception of CAN messages.
+ * Before CAN messages can be received, each member in CO_CANrx_t must be
+ * initialized. CO_CANrxBufferInit() is called by CANopen module, which
+ * uses specific member. For example @ref CO_HBconsumer uses multiple members
+ * in CO_CANrx_t array. (It monitors multiple heartbeat messages from remote
+ * nodes.) It must call CO_CANrxBufferInit() multiple times.
+ *
+ * Main arguments to the CO_CANrxBufferInit() function are CAN identifier
+ * and a pointer to callback function. Those two arguments (and some others)
+ * are copied to the member of the CO_CANrx_t array.
+ *
+ * Callback function is a function, specified by specific CANopen module
+ * (for example by @ref CO_HBconsumer). Each CANopen module defines own
+ * callback function. Callback function will process the received CAN message.
+ * It will copy the necessary data from CAN message to proper place. It may
+ * also trigger additional task, which will further process the received message.
+ * Callback function must be fast and must only make the necessary calculations
+ * and copying.
+ *
+ * Received CAN messages are processed by CAN receive interrupt function.
+ * After CAN message is received, function first tries to find matching CAN
+ * identifier from CO_CANrx_t array. If found, then a corresponding callback
+ * function is called.
+ *
+ * Callback function accepts two parameters:
+ *  - object is pointer to object registered by CO_CANrxBufferInit().
+ *  - msg  is pointer to CAN message of type CO_CANrxMsg_t.
+ *
+ * Callback function must return #CO_ReturnError_t: CO_ERROR_NO,
+ * CO_ERROR_RX_OVERFLOW, CO_ERROR_RX_PDO_OVERFLOW, CO_ERROR_RX_MSG_LENGTH or
+ * CO_ERROR_RX_PDO_LENGTH.
+ *
+ *
+ * ###Transmission of CAN messages.
+ * Before CAN messages can be transmitted, each member in CO_CANtx_t must be
+ * initialized. CO_CANtxBufferInit() is called by CANopen module, which
+ * uses specific member. For example Heartbeat producer must initialize it's
+ * member in CO_CANtx_t array.
+ *
+ * CO_CANtxBufferInit() returns a pointer of type CO_CANtx_t, which contains buffer
+ * where CAN message data can be written. CAN message is send with calling
+ * CO_CANsend() function. If at that moment CAN transmit buffer inside
+ * microcontroller's CAN module is free, message is copied directly to CAN module.
+ * Otherwise CO_CANsend() function sets _bufferFull_ flag to true. Message will be
+ * then sent by CAN TX interrupt as soon as CAN module is freed. Until message is
+ * not copied to CAN module, its contents must not change. There may be multiple
+ * _bufferFull_ flags in CO_CANtx_t array set to true. In that case messages with
+ * lower index inside array will be sent first.
+ */
+
+
+/**
+ * @name Critical sections
+ * CANopenNode is designed to run in different threads, as described in README.
+ * Threads are implemented differently in different systems. In microcontrollers
+ * threads are interrupts with different priorities, for example.
+ * It is necessary to protect sections, where different threads access to the
+ * same resource. In simple systems interrupts or scheduler may be temporary
+ * disabled between access to the shared resource. Otherwise mutexes or
+ * semaphores can be used.
+ *
+ * ####Reentrant functions.
+ * Functions CO_CANsend() from C_driver.h, CO_errorReport() from CO_Emergency.h
+ * and CO_errorReset() from CO_Emergency.h may be called from different threads.
+ * Critical sections must be protected. Eather by disabling scheduler or
+ * interrupts or by mutexes or semaphores.
+ *
+ * ####Object Dictionary variables.
+ * In general, there are two threads, which accesses OD variables: mainline and
+ * timer. CANopenNode initialization and SDO server runs in mainline. PDOs runs
+ * in faster timer thread. Processing of PDOs must not be interrupted by
+ * mainline. Mainline thread must protect sections, which accesses the same OD
+ * variables as timer thread. This care must also take the application. Note
+ * that not all variables are allowed to be mapped to PDOs, so they may not need
+ * to be protected. SDO server protects sections with access to OD variables.
+ *
+ * ####CAN receive thread.
+ * It partially processes received CAN data and puts them into appropriate
+ * objects. Objects are later processed. It does not need protection of
+ * critical sections. There is one circumstance, where CANrx should be disabled:
+ * After presence of SYNC message on CANopen bus, CANrx should be temporary
+ * disabled until all receive PDOs are processed. See also CO_SYNC.h file and
+ * CO_SYNC_initCallback() function.
+ * @{
+ */
+    #define CO_LOCK_CAN_SEND()  /**< Lock critical section in CO_CANsend() */
+    #define CO_UNLOCK_CAN_SEND()/**< Unlock critical section in CO_CANsend() */
+
+    #define CO_LOCK_EMCY()      /**< Lock critical section in CO_errorReport() or CO_errorReset() */
+    #define CO_UNLOCK_EMCY()    /**< Unlock critical section in CO_errorReport() or CO_errorReset() */
+
+    #define CO_LOCK_OD()        /**< Lock critical section when accessing Object Dictionary */
+    #define CO_UNLOCK_OD()      /**< Unock critical section when accessing Object Dictionary */
+/** @} */
+
+/**
+ * @defgroup CO_dataTypes Data types
+ * @{
+ *
+ * According to Misra C
+ */
+    /* int8_t to uint64_t are defined in stdint.h */
+    typedef unsigned char           bool_t;     /**< bool_t */
+    typedef float                   float32_t;  /**< float32_t */
+    typedef long double             float64_t;  /**< float64_t */
+    typedef char                    char_t;     /**< char_t */
+    typedef unsigned char           oChar_t;    /**< oChar_t */
+    typedef unsigned char           domain_t;   /**< domain_t */
+/** @} */
+
+
+/**
+ * Return values of some CANopen functions. If function was executed
+ * successfully it returns 0 otherwise it returns <0.
+ */
+typedef enum{
+    CO_ERROR_NO                 = 0,    /**< Operation completed successfully */
+    CO_ERROR_ILLEGAL_ARGUMENT   = -1,   /**< Error in function arguments */
+    CO_ERROR_OUT_OF_MEMORY      = -2,   /**< Memory allocation failed */
+    CO_ERROR_TIMEOUT            = -3,   /**< Function timeout */
+    CO_ERROR_ILLEGAL_BAUDRATE   = -4,   /**< Illegal baudrate passed to function CO_CANmodule_init() */
+    CO_ERROR_RX_OVERFLOW        = -5,   /**< Previous message was not processed yet */
+    CO_ERROR_RX_PDO_OVERFLOW    = -6,   /**< previous PDO was not processed yet */
+    CO_ERROR_RX_MSG_LENGTH      = -7,   /**< Wrong receive message length */
+    CO_ERROR_RX_PDO_LENGTH      = -8,   /**< Wrong receive PDO length */
+    CO_ERROR_TX_OVERFLOW        = -9,   /**< Previous message is still waiting, buffer full */
+    CO_ERROR_TX_PDO_WINDOW      = -10,  /**< Synchronous TPDO is outside window */
+    CO_ERROR_TX_UNCONFIGURED    = -11,  /**< Transmit buffer was not confugured properly */
+    CO_ERROR_PARAMETERS         = -12,  /**< Error in function function parameters */
+    CO_ERROR_DATA_CORRUPT       = -13,  /**< Stored data are corrupt */
+    CO_ERROR_CRC                = -14   /**< CRC does not match */
+}CO_ReturnError_t;
+
+
+/**
+ * CAN receive message structure as aligned in CAN module. It is different in
+ * different microcontrollers. It usually contains other variables.
+ */
+typedef struct{
+    /** CAN identifier. It must be read through CO_CANrxMsg_readIdent() function. */
+    uint32_t            ident;
+    uint8_t             DLC ;           /**< Length of CAN message */
+    uint8_t             data[8];        /**< 8 data bytes */
+}CO_CANrxMsg_t;
+
+
+/**
+ * Received message object
+ */
+typedef struct{
+    uint16_t            ident;          /**< Standard CAN Identifier (bits 0..10) + RTR (bit 11) */
+    uint16_t            mask;           /**< Standard Identifier mask with same alignment as ident */
+    void               *object;         /**< From CO_CANrxBufferInit() */
+    void              (*pFunct)(void *object, const CO_CANrxMsg_t *message);  /**< From CO_CANrxBufferInit() */
+}CO_CANrx_t;
+
+
+/**
+ * Transmit message object.
+ */
+typedef struct{
+    uint32_t            ident;          /**< CAN identifier as aligned in CAN module */
+    uint8_t             DLC ;           /**< Length of CAN message. (DLC may also be part of ident) */
+    uint8_t             data[8];        /**< 8 data bytes */
+    volatile bool_t     bufferFull;     /**< True if previous message is still in buffer */
+    /** Synchronous PDO messages has this flag set. It prevents them to be sent outside the synchronous window */
+    volatile bool_t     syncFlag;
+}CO_CANtx_t;
+
+
+/**
+ * CAN module object. It may be different in different microcontrollers.
+ */
+typedef struct{
+    int32_t             CANbaseAddress; /**< From CO_CANmodule_init() */
+    CO_CANrx_t         *rxArray;        /**< From CO_CANmodule_init() */
+    uint16_t            rxSize;         /**< From CO_CANmodule_init() */
+    CO_CANtx_t         *txArray;        /**< From CO_CANmodule_init() */
+    uint16_t            txSize;         /**< From CO_CANmodule_init() */
+    volatile bool_t     CANnormal;      /**< CAN module is in normal mode */
+    /** Value different than zero indicates, that CAN module hardware filters
+      * are used for CAN reception. If there is not enough hardware filters,
+      * they won't be used. In this case will be *all* received CAN messages
+      * processed by software. */
+    volatile bool_t     useCANrxFilters;
+    /** If flag is true, then message in transmitt buffer is synchronous PDO
+      * message, which will be aborted, if CO_clearPendingSyncPDOs() function
+      * will be called by application. This may be necessary if Synchronous
+      * window time was expired. */
+    volatile bool_t     bufferInhibitFlag;
+    /** Equal to 1, when the first transmitted message (bootup message) is in CAN TX buffers */
+    volatile bool_t     firstCANtxMessage;
+    /** Number of messages in transmit buffer, which are waiting to be copied to the CAN module */
+    volatile uint16_t   CANtxCount;
+    uint32_t            errOld;         /**< Previous state of CAN errors */
+    void               *em;             /**< Emergency object */
+}CO_CANmodule_t;
+
+
+/**
+ * Endianes.
+ *
+ * Depending on processor or compiler architecture, one of the two macros must
+ * be defined: CO_LITTLE_ENDIAN or CO_BIG_ENDIAN. CANopen itself is little endian.
+ */
+#define CO_LITTLE_ENDIAN
+
+
+/**
+ * Request CAN configuration (stopped) mode and *wait* untill it is set.
+ *
+ * @param CANbaseAddress CAN module base address.
+ */
+void CO_CANsetConfigurationMode(int32_t CANbaseAddress);
+
+
+/**
+ * Request CAN normal (opearational) mode and *wait* untill it is set.
+ *
+ * @param CANmodule This object.
+ */
+void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
+
+
+/**
+ * Initialize CAN module object.
+ *
+ * Function must be called in the communication reset section. CAN module must
+ * be in Configuration Mode before.
+ *
+ * @param CANmodule This object will be initialized.
+ * @param CANbaseAddress CAN module base address.
+ * @param rxArray Array for handling received CAN messages
+ * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
+ * @param txArray Array for handling transmitting CAN messages
+ * @param txSize Size of the above array. Must be equal to number of transmitting CAN objects.
+ * @param CANbitRate Valid values are (in kbps): 10, 20, 50, 125, 250, 500, 800, 1000.
+ * If value is illegal, bitrate defaults to 125.
+ *
+ * Return #CO_ReturnError_t: CO_ERROR_NO or CO_ERROR_ILLEGAL_ARGUMENT.
+ */
+CO_ReturnError_t CO_CANmodule_init(
+        CO_CANmodule_t         *CANmodule,
+        int32_t                 CANbaseAddress,
+        CO_CANrx_t              rxArray[],
+        uint16_t                rxSize,
+        CO_CANtx_t              txArray[],
+        uint16_t                txSize,
+        uint16_t                CANbitRate);
+
+
+/**
+ * Switch off CANmodule. Call at program exit.
+ *
+ * @param CANmodule CAN module object.
+ */
+void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
+
+
+/**
+ * Read CAN identifier from received message
+ *
+ * @param rxMsg Pointer to received message
+ * @return 11-bit CAN standard identifier.
+ */
+uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
+
+
+/**
+ * Configure CAN message receive buffer.
+ *
+ * Function configures specific CAN receive buffer. It sets CAN identifier
+ * and connects buffer with specific object. Function must be called for each
+ * member in _rxArray_ from CO_CANmodule_t.
+ *
+ * @param CANmodule This object.
+ * @param index Index of the specific buffer in _rxArray_.
+ * @param ident 11-bit standard CAN Identifier.
+ * @param mask 11-bit mask for identifier. Most usually set to 0x7FF.
+ * Received message (rcvMsg) will be accepted if the following
+ * condition is true: (((rcvMsgId ^ ident) & mask) == 0).
+ * @param rtr If true, 'Remote Transmit Request' messages will be accepted.
+ * @param object CANopen object, to which buffer is connected. It will be used as
+ * an argument to pFunct. Its type is (void), pFunct will change its
+ * type back to the correct object type.
+ * @param pFunct Pointer to function, which will be called, if received CAN
+ * message matches the identifier. It must be fast function.
+ *
+ * Return #CO_ReturnError_t: CO_ERROR_NO CO_ERROR_ILLEGAL_ARGUMENT or
+ * CO_ERROR_OUT_OF_MEMORY (not enough masks for configuration).
+ */
+CO_ReturnError_t CO_CANrxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        uint16_t                mask,
+        bool_t                  rtr,
+        void                   *object,
+        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
+
+
+/**
+ * Configure CAN message transmit buffer.
+ *
+ * Function configures specific CAN transmit buffer. Function must be called for
+ * each member in _txArray_ from CO_CANmodule_t.
+ *
+ * @param CANmodule This object.
+ * @param index Index of the specific buffer in _txArray_.
+ * @param ident 11-bit standard CAN Identifier.
+ * @param rtr If true, 'Remote Transmit Request' messages will be transmitted.
+ * @param noOfBytes Length of CAN message in bytes (0 to 8 bytes).
+ * @param syncFlag This flag bit is used for synchronous TPDO messages. If it is set,
+ * message will not be sent, if curent time is outside synchronous window.
+ *
+ * @return Pointer to CAN transmit message buffer. 8 bytes data array inside
+ * buffer should be written, before CO_CANsend() function is called.
+ * Zero is returned in case of wrong arguments.
+ */
+CO_CANtx_t *CO_CANtxBufferInit(
+        CO_CANmodule_t         *CANmodule,
+        uint16_t                index,
+        uint16_t                ident,
+        bool_t                  rtr,
+        uint8_t                 noOfBytes,
+        bool_t                  syncFlag);
+
+
+/**
+ * Send CAN message.
+ *
+ * @param CANmodule This object.
+ * @param buffer Pointer to transmit buffer, returned by CO_CANtxBufferInit().
+ * Data bytes must be written in buffer before function call.
+ *
+ * @return #CO_ReturnError_t: CO_ERROR_NO, CO_ERROR_TX_OVERFLOW or
+ * CO_ERROR_TX_PDO_WINDOW (Synchronous TPDO is outside window).
+ */
+CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
+
+
+/**
+ * Clear all synchronous TPDOs from CAN module transmit buffers.
+ *
+ * CANopen allows synchronous PDO communication only inside time between SYNC
+ * message and SYNC Window. If time is outside this window, new synchronous PDOs
+ * must not be sent and all pending sync TPDOs, which may be on CAN TX buffers,
+ * must be cleared.
+ *
+ * This function checks (and aborts transmission if necessary) CAN TX buffers
+ * when it is called. Function should be called by the stack in the moment,
+ * when SYNC time was just passed out of synchronous window.
+ *
+ * @param CANmodule This object.
+ */
+void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
+
+
+/**
+ * Verify all errors of CAN module.
+ *
+ * Function is called directly from CO_EM_process() function.
+ *
+ * @param CANmodule This object.
+ */
+void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
+
+
+/**
+ * Receives and transmits CAN messages.
+ *
+ * Function must be called directly from high priority CAN interrupt.
+ *
+ * @param CANmodule This object.
+ */
+void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
+
+
+/** @} */
+#endif

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -1,12 +1,10 @@
-/**
- * CAN module object for generic microcontroller.
- *
- * This file is a template for other microcontrollers.
+/*
+ * CAN module object for LPC1768 microcontroller using Mbed SDK.
  *
  * @file        CO_driver.h
  * @ingroup     CO_driver
- * @author      Janez Paternoster
- * @copyright   2004 - 2015 Janez Paternoster
+ * @author      Benoit Rapidel
+ * @copyright   2016 Benoit Rapidel
  *
  * This file is part of CANopenNode, an opensource CANopen Stack.
  * Project home page is <https://github.com/CANopenNode/CANopenNode>.


### PR DESCRIPTION
This adds LPC1768 driver for CANopenNode.

This is implemented using mbed SDK. This is currently tested on a mbed LPC1768 board and will be tested on a custom-made board with a LPC1768.

CAN Rx filters are not yet implemented on the mbed SDK for LPC1768 target and therefore not implemented in this driver.

Feel free to comment

Best regards
Ben