### PR TITLE
CO_init assumes node ID 16 if invalid

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -349,7 +349,11 @@ CO_ReturnError_t CO_init(
     CO_CANsetConfigurationMode(CANbaseAddress);
 
     /* Verify CANopen Node-ID */
-    if(nodeId<1 || nodeId>127) nodeId = 0x10;
+    if(nodeId<1 || nodeId>127)
+    {
+        CO_delete(CANbaseAddress);
+        return CO_ERROR_PARAMETERS;
+    }
 
 
     err = CO_CANmodule_init(


### PR DESCRIPTION
Assuming a valid node ID in the middle of the range is a very bad idea for production environment. Changed so it returns an error.
A different approach would be to use something like ID 127.