### PR TITLE
Compiler switch enables providing own CRC16 implemetation.

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -52,6 +52,9 @@
    be generated with calloc(). */
 /* #define CO_USE_GLOBALS */
 
+/* If defined, the user provides an own implemetation for calculating the
+ * CRC16 CCITT checksum. */
+/* #define CO_USE_OWN_CRC16 */
 
 #ifndef CO_USE_GLOBALS
     #include <stdlib.h> /*  for malloc, free */

--- a/stack/crc16-ccitt.c
+++ b/stack/crc16-ccitt.c
@@ -43,6 +43,7 @@
  * to do so, delete this exception statement from your version.
  */
 
+#ifndef CO_USE_OWN_CRC16
 
 #include "crc16-ccitt.h"
 
@@ -114,3 +115,5 @@ unsigned short crc16_ccitt(
     }
     return crc;
 }
+
+#endif /* CO_USE_OWN_CRC16 */

--- a/stack/crc16-ccitt.h
+++ b/stack/crc16-ccitt.h
@@ -72,6 +72,9 @@
  *
  * @return Calculated CRC.
  */
+#ifdef CO_USE_OWN_CRC16
+extern
+#endif
 unsigned short crc16_ccitt(
         const unsigned char     block[],
         unsigned int            blockLength,


### PR DESCRIPTION
This enables the stack user to use a different calculation method. This
is needed to save space (no table) or to use hardware crc unit.
Implementation can be located in driver directory.