### PR TITLE
Added guards for c++ compilation

### DIFF
--- a/CANopen.h
+++ b/CANopen.h
@@ -54,6 +54,9 @@
 #ifndef CANopen_H
 #define CANopen_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_CANopen CANopen stack
@@ -239,6 +242,9 @@ void CO_process_TPDO(
         bool_t                  syncWas,
         uint32_t                timeDifference_us);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_Emergency.h
+++ b/stack/CO_Emergency.h
@@ -47,6 +47,9 @@
 #ifndef CO_EMERGENCY_H
 #define CO_EMERGENCY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_Emergency Emergency
@@ -420,6 +423,10 @@ void CO_EM_process(
 
 
 #endif
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_HBconsumer.h
+++ b/stack/CO_HBconsumer.h
@@ -47,6 +47,9 @@
 #ifndef CO_HB_CONS_H
 #define CO_HB_CONS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_HBconsumer Heartbeat consumer
@@ -140,6 +143,9 @@ void CO_HBconsumer_process(
         bool_t                  NMTisPreOrOperational,
         uint16_t                timeDifference_ms);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_NMT_Heartbeat.h
+++ b/stack/CO_NMT_Heartbeat.h
@@ -47,6 +47,9 @@
 #ifndef CO_NMT_HEARTBEAT_H
 #define CO_NMT_HEARTBEAT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_NMT_Heartbeat NMT and Heartbeat
@@ -235,6 +238,9 @@ CO_NMT_reset_cmd_t CO_NMT_process(
         const uint8_t           errorBehavior[],
         uint16_t               *timerNext_ms);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_PDO.h
+++ b/stack/CO_PDO.h
@@ -47,6 +47,9 @@
 #ifndef CO_PDO_H
 #define CO_PDO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_PDO PDO
@@ -395,6 +398,9 @@ void CO_TPDO_process(
         bool_t                  syncWas,
         uint32_t                timeDifference_us);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_SDO.h
+++ b/stack/CO_SDO.h
@@ -47,6 +47,9 @@
 #ifndef CO_SDO_H
 #define CO_SDO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_SDO SDO server
@@ -930,6 +933,9 @@ uint32_t CO_SDO_readOD(CO_SDO_t *SDO, uint16_t SDOBufferSize);
  */
 uint32_t CO_SDO_writeOD(CO_SDO_t *SDO, uint16_t length);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_SDOmaster.h
+++ b/stack/CO_SDOmaster.h
@@ -48,6 +48,9 @@
 #ifndef CO_SDO_CLIENT_H
 #define CO_SDO_CLIENT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_SDOmaster SDO client
@@ -356,6 +359,9 @@ CO_SDOclient_return_t CO_SDOclientUpload(
  */
 void CO_SDOclientClose(CO_SDOclient_t *SDO_C);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_SYNC.h
+++ b/stack/CO_SYNC.h
@@ -47,6 +47,9 @@
 #ifndef CO_SYNC_H
 #define CO_SYNC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_SYNC SYNC
@@ -173,6 +176,9 @@ uint8_t CO_SYNC_process(
         uint32_t                timeDifference_us,
         uint32_t                ObjDict_synchronousWindowLength);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/CO_trace.h
+++ b/stack/CO_trace.h
@@ -47,6 +47,9 @@
 #ifndef CO_TRACE_H
 #define CO_TRACE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "CO_driver.h"
 #include "CO_SDO.h"
@@ -180,6 +183,9 @@ void CO_trace_init(
  */
 void CO_trace_process(CO_trace_t *trace, uint32_t timestamp);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/crc16-ccitt.h
+++ b/stack/crc16-ccitt.h
@@ -48,6 +48,9 @@
 #ifndef CRC16_CCITT_H
 #define CRC16_CCITT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_crc16_ccitt CRC 16 CCITT
@@ -77,6 +80,9 @@ unsigned short crc16_ccitt(
         unsigned int            blockLength,
         unsigned short          crc);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -49,6 +49,9 @@
 #ifndef CO_DRIVER_H
 #define CO_DRIVER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Include processor header file */
 #include <stddef.h>         /* for 'NULL' */
@@ -460,6 +463,9 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
  */
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif

--- a/stack/drvTemplate/eeprom.h
+++ b/stack/drvTemplate/eeprom.h
@@ -49,6 +49,9 @@
 #ifndef EEPROM_H
 #define EEPROM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup CO_eeprom Nonvolatile storage
@@ -117,6 +120,9 @@ void CO_EE_init_2(
  */
 void CO_EE_process(CO_EE_t *ee);
 
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 /** @} */
 #endif


### PR DESCRIPTION
This only has an effect if cpp compiler is used. C compiler doesn't have the "__cplusplus" macro set.