### PR TITLE
SDO upload block invalid sequence generated block size error...

### DIFF
--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -1317,7 +1317,7 @@ int8_t CO_SDO_process(
 
                 /* verify if response is too early */
                 if(ackseq > SDO->sequence){
-                    CO_SDO_abort(SDO, CO_SDO_AB_BLOCK_SIZE); /* Invalid block size (block mode only). */
+                    CO_SDO_abort(SDO, CO_SDO_AB_SEQ_NUM); /* Invalid sequence */
                     return -1;
                 }
 


### PR DESCRIPTION
instead of invalid sequence error. Fixes CANopen conformance test tool test case SDO 27

Please have a look at this, I think this is a copy&paste error from line 1388.