### PR TITLE
SYNC write OD 0x1019 add value check...

### DIFF
--- a/stack/CO_SYNC.c
+++ b/stack/CO_SYNC.c
@@ -210,7 +210,8 @@ static CO_SDO_abortCode_t CO_ODF_1019(CO_ODF_arg_t *ODF_arg){
     if(!ODF_arg->reading){
         uint8_t len = 0U;
 
-        if(SYNC->periodTime){
+        if((SYNC->periodTime) ||
+           (value == 1) || (value > 240 && value <= 255)){
             ret = CO_SDO_AB_DATA_DEV_STATE;
         }
         else{


### PR DESCRIPTION
according to DSP310, when writing a "reserved" value to this index, a error response should be created (page 39). There's nothing about this behavior in CiA301.

I think actively rejecting those values is a reasonable behaviour, so I implemented it.