### PR TITLE
write invalid PDO mapping error codes...

### DIFF
--- a/stack/CO_PDO.c
+++ b/stack/CO_PDO.c
@@ -617,14 +617,14 @@ static CO_SDO_abortCode_t CO_ODF_RPDOmap(CO_ODF_arg_t *ODF_arg){
     if(*RPDO->operatingState == CO_NMT_OPERATIONAL && (RPDO->restrictionFlags & 0x02))
         return CO_SDO_AB_DATA_DEV_STATE;   /* Data cannot be transferred or stored to the application because of the present device state. */
     if(RPDO->valid)
-        return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
+        return CO_SDO_AB_UNSUPPORTED_ACCESS;  /* Unsupported access to an object. */
 
     /* numberOfMappedObjects */
     if(ODF_arg->subIndex == 0){
         uint8_t *value = (uint8_t*) ODF_arg->data;
 
         if(*value > 8)
-            return CO_SDO_AB_VALUE_HIGH;  /* Value of parameter written too high. */
+            return CO_SDO_AB_MAP_LEN;  /* Number and length of object to be mapped exceeds PDO length. */
 
         /* configure mapping */
         return CO_RPDOconfigMap(RPDO, *value);
@@ -639,7 +639,7 @@ static CO_SDO_abortCode_t CO_ODF_RPDOmap(CO_ODF_arg_t *ODF_arg){
         uint8_t MBvar;
 
         if(RPDO->dataLength)
-            return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
+            return CO_SDO_AB_UNSUPPORTED_ACCESS;  /* Unsupported access to an object. */
 
         /* verify if mapping is correct */
         return CO_PDOfindMap(
@@ -683,14 +683,14 @@ static CO_SDO_abortCode_t CO_ODF_TPDOmap(CO_ODF_arg_t *ODF_arg){
     if(*TPDO->operatingState == CO_NMT_OPERATIONAL && (TPDO->restrictionFlags & 0x02))
         return CO_SDO_AB_DATA_DEV_STATE;   /* Data cannot be transferred or stored to the application because of the present device state. */
     if(TPDO->valid)
-        return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
+        return CO_SDO_AB_UNSUPPORTED_ACCESS;  /* Unsupported access to an object. */
 
     /* numberOfMappedObjects */
     if(ODF_arg->subIndex == 0){
         uint8_t *value = (uint8_t*) ODF_arg->data;
 
         if(*value > 8)
-            return CO_SDO_AB_VALUE_HIGH;  /* Value of parameter written too high. */
+            return CO_SDO_AB_MAP_LEN;  /* Number and length of object to be mapped exceeds PDO length. */
 
         /* configure mapping */
         return CO_TPDOconfigMap(TPDO, *value);
@@ -705,7 +705,7 @@ static CO_SDO_abortCode_t CO_ODF_TPDOmap(CO_ODF_arg_t *ODF_arg){
         uint8_t MBvar;
 
         if(TPDO->dataLength)
-            return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
+            return CO_SDO_AB_UNSUPPORTED_ACCESS;  /* Unsupported access to an object. */
 
         /* verify if mapping is correct */
         return CO_PDOfindMap(


### PR DESCRIPTION
according to DSP310, those values should be returned (Page 28, 29).  There's nothing about this error behavior in CiA301, this only describes value errors, but not sequence errors in mapping change.

Please have a look at this, I don't know if you had something special in mind when selecting those error codes.
Test case PDO 24 still fails if executed together with the other test cases in sequence. This is because test case 23 does not clean up after running. If test case 24 is executed as single test, it runs sucessfull (meaning the expected error is triggered). In my opinion, this is a bug in the conformance test tool.