### PR TITLE
Emergency Message RX Callback

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -106,12 +106,13 @@
 
     #define CO_RXCAN_NMT       0                                      /*  index for NMT message */
     #define CO_RXCAN_SYNC      1                                      /*  index for SYNC message */
-    #define CO_RXCAN_RPDO     (CO_RXCAN_SYNC+CO_NO_SYNC)              /*  start index for RPDO messages */
+    #define CO_RXCAN_EMERG    (CO_RXCAN_SYNC+CO_NO_SYNC)              /*  index for Emergency message */
+    #define CO_RXCAN_RPDO     (CO_RXCAN_EMERG+CO_NO_EMERGENCY)        /*  start index for RPDO messages */
     #define CO_RXCAN_SDO_SRV  (CO_RXCAN_RPDO+CO_NO_RPDO)              /*  start index for SDO server message (request) */
     #define CO_RXCAN_SDO_CLI  (CO_RXCAN_SDO_SRV+CO_NO_SDO_SERVER)     /*  start index for SDO client message (response) */
     #define CO_RXCAN_CONS_HB  (CO_RXCAN_SDO_CLI+CO_NO_SDO_CLIENT)     /*  start index for Heartbeat Consumer messages */
     /* total number of received CAN messages */
-    #define CO_RXCAN_NO_MSGS (1+CO_NO_SYNC+CO_NO_RPDO+CO_NO_SDO_SERVER+CO_NO_SDO_CLIENT+CO_NO_HB_CONS)
+    #define CO_RXCAN_NO_MSGS (1+CO_NO_SYNC+CO_NO_EMERGENCY+CO_NO_RPDO+CO_NO_SDO_SERVER+CO_NO_SDO_CLIENT+CO_NO_HB_CONS)
 
     #define CO_TXCAN_NMT       0                                      /*  index for NMT master message */
     #define CO_TXCAN_SYNC      CO_TXCAN_NMT+CO_NO_NMT_MASTER          /*  index for SYNC message */
@@ -411,6 +412,8 @@ CO_ReturnError_t CO_init(
            &OD_errorRegister,
            &OD_preDefinedErrorField[0],
             ODL_preDefinedErrorField_arrayLength,
+            CO->CANmodule[0],
+            CO_RXCAN_EMERG,
             CO->CANmodule[0],
             CO_TXCAN_EMERG,
             CO_CAN_ID_EMERGENCY + nodeId);

--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -47,7 +47,29 @@
 #include "CO_driver.h"
 #include "CO_SDO.h"
 #include "CO_Emergency.h"
+#include "CANopen.h"
 
+
+/*
+ * Read received message from CAN module.
+ *
+ * Function will be called (by CAN receive interrupt) every time, when CAN
+ * message with correct identifier will be received. For more information and
+ * description of parameters see file CO_driver.h.
+ */
+static void CO_EM_receive(void *object, const CO_CANrxMsg_t *msg){
+    CO_EM_t *em;
+    uint8_t errorBit;
+    uint32_t infoCode;
+
+    em = (CO_EM_t*)object;
+
+    if(em->pFunctSignal!=NULL){
+        errorBit = msg->data[3];
+        CO_memcpySwap4(&infoCode, &msg->data[4]);
+        em->pFunctSignal(errorBit, infoCode);
+    }
+}
 
 /*
  * Function for accessing _Pre-Defined Error Field_ (index 0x1003) from SDO server.
@@ -129,15 +151,17 @@ CO_ReturnError_t CO_EM_init(
         uint8_t                *errorRegister,
         uint32_t               *preDefErr,
         uint8_t                 preDefErrSize,
-        CO_CANmodule_t         *CANdev,
+        CO_CANmodule_t         *CANdevRx,
+        uint16_t                CANdevRxIdx,
+        CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
         uint16_t                CANidTxEM)
 {
     uint8_t i;
 
     /* verify arguments */
-    if(em==NULL || emPr==NULL || SDO==NULL || errorStatusBits==NULL ||
-        errorStatusBitsSize<6U || errorRegister==NULL || preDefErr==NULL || CANdev==NULL){
+    if(em==NULL || emPr==NULL || SDO==NULL || errorStatusBits==NULL || errorStatusBitsSize<6U ||
+       errorRegister==NULL || preDefErr==NULL || CANdevTx==NULL || CANdevRx==NULL){
         return CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
@@ -166,15 +190,25 @@ CO_ReturnError_t CO_EM_init(
     CO_OD_configure(SDO, OD_H1003_PREDEF_ERR_FIELD, CO_ODF_1003, (void*)emPr, 0, 0U);
     CO_OD_configure(SDO, OD_H1014_COBID_EMERGENCY, CO_ODF_1014, (void*)&SDO->nodeId, 0, 0U);
 
+    /* configure SDO server CAN reception */
+    CO_CANrxBufferInit(
+            CANdevRx,               /* CAN device */
+            CANdevRxIdx,            /* rx buffer index */
+            CO_CAN_ID_EMERGENCY,    /* CAN identifier */
+            0x780,                  /* mask */
+            0,                      /* rtr */
+            (void*)em,              /* object passed to receive function */
+            CO_EM_receive);         /* this function will process received message */
+
     /* configure emergency message CAN transmission */
-    emPr->CANdev = CANdev;
+    emPr->CANdev = CANdevTx;
     emPr->CANdev->em = (void*)em; /* update pointer inside CAN device. */
     emPr->CANtxBuff = CO_CANtxBufferInit(
-            CANdev,             /* CAN device */
+            CANdevTx,            /* CAN device */
             CANdevTxIdx,        /* index of specific buffer inside CAN module */
             CANidTxEM,          /* CAN identifier */
             0,                  /* rtr */
-            8U,                  /* number of data bytes */
+            8U,                 /* number of data bytes */
             0);                 /* synchronous message flag bit */
 
     return CO_ERROR_NO;
@@ -184,7 +218,7 @@ CO_ReturnError_t CO_EM_init(
 /******************************************************************************/
 void CO_EM_initCallback(
         CO_EM_t                *em,
-        void                  (*pFunctSignal)(void))
+        void                  (*pFunctSignal)(const uint8_t errorBit, const uint32_t infoCode))
 {
     if(em != NULL){
         em->pFunctSignal = pFunctSignal;
@@ -235,7 +269,7 @@ void CO_EM_process(
             (em->bufReadPtr != em->bufWritePtr || em->bufFull))
     {
         uint32_t preDEF;    /* preDefinedErrorField */
-        
+
         /* add error register */
         em->bufReadPtr[2] = *emPr->errorRegister;
 
@@ -332,7 +366,7 @@ void CO_errorReport(CO_EM_t *em, const uint8_t errorBit, const uint16_t errorCod
 
             /* Optional signal to RTOS, which can resume task, which handles CO_EM_process */
             if(em->pFunctSignal != NULL) {
-                em->pFunctSignal();
+                em->pFunctSignal(errorBit, infoCode);
             }
         }
     }
@@ -391,7 +425,7 @@ void CO_errorReset(CO_EM_t *em, const uint8_t errorBit, const uint32_t infoCode)
 
             /* Optional signal to RTOS, which can resume task, which handles CO_EM_process */
             if(em->pFunctSignal != NULL) {
-                em->pFunctSignal();
+                em->pFunctSignal(errorBit, infoCode);
             }
         }
     }

--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -64,10 +64,10 @@ static void CO_EM_receive(void *object, const CO_CANrxMsg_t *msg){
 
     em = (CO_EM_t*)object;
 
-    if(em->pFunctSignal!=NULL){
+    if(em->pFunctSignal != NULL){
         CO_memcpySwap2(&errorCode, &msg->data[0]);
         CO_memcpySwap4(&infoCode, &msg->data[4]);
-        em->pFunctSignal(msg->ident,
+        em->pFunctSignal(msg->ident & 0x07FFU,
                          errorCode,
                          msg->data[2],
                          msg->data[3],
@@ -222,7 +222,7 @@ CO_ReturnError_t CO_EM_init(
 /******************************************************************************/
 void CO_EM_initCallback(
         CO_EM_t                *em,
-        void                  (*pFunctSignal)(const uint32_t ident,
+        void                  (*pFunctSignal)(const uint16_t ident,
                                               const uint16_t errorCode,
                                               const uint8_t errorRegister,
                                               const uint8_t errorBit,

--- a/stack/CO_Emergency.h
+++ b/stack/CO_Emergency.h
@@ -283,7 +283,7 @@ typedef struct{
     uint8_t             wrongErrorReport;   /**< Error in arguments to CO_errorReport() */
 
     /** From CO_EM_initCallback() or NULL */
-    void              (*pFunctSignal)(const uint32_t ident,
+    void              (*pFunctSignal)(const uint16_t ident,
                                       const uint16_t errorCode,
                                       const uint8_t errorRegister,
                                       const uint8_t errorBit,
@@ -415,7 +415,7 @@ CO_ReturnError_t CO_EM_init(
  */
 void CO_EM_initCallback(
         CO_EM_t                *em,
-        void                  (*pFunctSignal)(const uint32_t ident,
+        void                  (*pFunctSignal)(const uint16_t ident,
                                               const uint16_t errorCode,
                                               const uint8_t errorRegister,
                                               const uint8_t errorBit,

--- a/stack/CO_Emergency.h
+++ b/stack/CO_Emergency.h
@@ -271,16 +271,19 @@ typedef enum{
  * CO_EMpr_t object.
  */
 typedef struct{
-    uint8_t            *errorStatusBits;/**< From CO_EM_init() */
-    uint8_t             errorStatusBitsSize;/**< From CO_EM_init() */
+    uint8_t            *errorStatusBits;        /**< From CO_EM_init() */
+    uint8_t             errorStatusBitsSize;    /**< From CO_EM_init() */
+
     /** Internal buffer for storing unsent emergency messages.*/
     uint8_t             buf[CO_EM_INTERNAL_BUFFER_SIZE * 8];
-    uint8_t            *bufEnd;         /**< End+1 address of the above buffer */
-    uint8_t            *bufWritePtr;    /**< Write pointer in the above buffer */
-    uint8_t            *bufReadPtr;     /**< Read pointer in the above buffer */
-    uint8_t             bufFull;        /**< True if above buffer is full */
-    uint8_t             wrongErrorReport;/**< Error in arguments to CO_errorReport() */
-    void              (*pFunctSignal)(void);/**< From CO_EM_initCallback() or NULL */
+    uint8_t            *bufEnd;             /**< End+1 address of the above buffer */
+    uint8_t            *bufWritePtr;        /**< Write pointer in the above buffer */
+    uint8_t            *bufReadPtr;         /**< Read pointer in the above buffer */
+    uint8_t             bufFull;            /**< True if above buffer is full */
+    uint8_t             wrongErrorReport;   /**< Error in arguments to CO_errorReport() */
+
+    /** From CO_EM_initCallback() or NULL */
+    void              (*pFunctSignal)(const uint8_t errorBit, const uint32_t infoCode);
 }CO_EM_t;
 
 
@@ -372,7 +375,9 @@ typedef struct{
  * @param preDefErr Pointer to _Pre defined error field_ array from Object
  * dictionary, index 0x1003.
  * @param preDefErrSize Size of the above array.
- * @param CANdev CAN device for Emergency transmission.
+ * @param CANdevRx CAN device for Emergency reception.
+ * @param CANdevRxIdx Index of receive buffer in the above CAN device.
+ * @param CANdevTx CAN device for Emergency transmission.
  * @param CANdevTxIdx Index of transmit buffer in the above CAN device.
  * @param CANidTxEM CAN identifier for Emergency message.
  *
@@ -387,7 +392,9 @@ CO_ReturnError_t CO_EM_init(
         uint8_t                *errorRegister,
         uint32_t               *preDefErr,
         uint8_t                 preDefErrSize,
-        CO_CANmodule_t         *CANdev,
+        CO_CANmodule_t         *CANdevRx,
+        uint16_t                CANdevRxIdx,
+        CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
         uint16_t                CANidTxEM);
 
@@ -404,7 +411,7 @@ CO_ReturnError_t CO_EM_init(
  */
 void CO_EM_initCallback(
         CO_EM_t               *em,
-        void                  (*pFunctSignal)(void));
+        void                  (*pFunctSignal)(const uint8_t errorBit, const uint32_t infoCode));
 
 
 /**

--- a/stack/CO_Emergency.h
+++ b/stack/CO_Emergency.h
@@ -283,7 +283,11 @@ typedef struct{
     uint8_t             wrongErrorReport;   /**< Error in arguments to CO_errorReport() */
 
     /** From CO_EM_initCallback() or NULL */
-    void              (*pFunctSignal)(const uint8_t errorBit, const uint32_t infoCode);
+    void              (*pFunctSignal)(const uint32_t ident,
+                                      const uint16_t errorCode,
+                                      const uint8_t errorRegister,
+                                      const uint8_t errorBit,
+                                      const uint32_t infoCode);
 }CO_EM_t;
 
 
@@ -410,9 +414,12 @@ CO_ReturnError_t CO_EM_init(
  * @param pFunctSignal Pointer to the callback function. Not called if NULL.
  */
 void CO_EM_initCallback(
-        CO_EM_t               *em,
-        void                  (*pFunctSignal)(const uint8_t errorBit, const uint32_t infoCode));
-
+        CO_EM_t                *em,
+        void                  (*pFunctSignal)(const uint32_t ident,
+                                              const uint16_t errorCode,
+                                              const uint8_t errorRegister,
+                                              const uint8_t errorBit,
+                                              const uint32_t infoCode));
 
 /**
  * Process Error control and Emergency object.


### PR DESCRIPTION
A feature which I've found lacking was the inability to take action when another node on the network transmits an emergency message.  These commits expand the emergency message callback to function similarly to the NMT callback.  Instead of this callback being called only on transmission of an emergency message it is now called on reception of one as well.

For example, we wanted our master (in this case canopend) to report any emergency messages on the bus by passing them through the command socket.  

First we define a handler:
```
/* Handle CANopen emergency messages. */
void EM_report(const uint16_t ident,
               const uint16_t errorCode,
               const uint8_t errorRegister,
               const uint8_t errorBit,
               const uint32_t infoCode) {

    char buf[40];
    int len;

    len = sprintf(buf,
                  "EM: %04x %04x %02x %02x %08x\r\n",
                  ident,
                  errorCode,
                  errorRegister,
                  errorBit,
                  infoCode);

    CO_command_write(buf, len);
    taskMain_cbSignal();
}
```

Next we register it during setup:
`CO_EM_initCallback(CO->em, EM_report);`

Now whenever one of our nodes has a fault it is sent to the socket so action can be taken.