### PR TITLE
manufacturer bit in error register didn't work

### DIFF
--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -202,6 +202,8 @@ void CO_EM_process(
 
     CO_EM_t *em = emPr->em;
     uint8_t errorRegister;
+    uint8_t errorMask;
+    uint8_t i;
 
     /* verify errors from driver and other */
     CO_CANverifyErrors(emPr->CANdev);
@@ -213,6 +215,7 @@ void CO_EM_process(
 
     /* calculate Error register */
     errorRegister = 0U;
+    errorMask = (uint8_t)~(CO_ERR_REG_GENERIC_ERR | CO_ERR_REG_COMM_ERR | CO_ERR_REG_MANUFACTURER);
     /* generic error */
     if(em->errorStatusBits[5]){
         errorRegister |= CO_ERR_REG_GENERIC_ERR;
@@ -221,7 +224,13 @@ void CO_EM_process(
     if(em->errorStatusBits[2] || em->errorStatusBits[3]){
         errorRegister |= CO_ERR_REG_COMM_ERR;
     }
-    *emPr->errorRegister = (*emPr->errorRegister & 0xEEU) | errorRegister;
+    /* Manufacturer */
+    for(i=6; i<em->errorStatusBitsSize; i++) {
+        if (em->errorStatusBits[i]) {
+            errorRegister |= CO_ERR_REG_MANUFACTURER;
+        }
+    }
+    *emPr->errorRegister = (*emPr->errorRegister & errorMask) | errorRegister;
 
     /* inhibit time */
     if(emPr->inhibitEmTimer < emInhTime){


### PR DESCRIPTION
This is better than the current solution, however if a user wants to implement a device profile, change to the source is still necessary to set device profile error bit.