### PR TITLE
emergency processing generates emcy queue overflow cleared message

### DIFF
--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -257,6 +257,7 @@ void CO_EM_process(
         }
         else{
             em->bufFull = 0;
+            CO_errorReset(em, CO_EM_EMERGENCY_BUFFER_FULL, 0);
         }
 
         /* write to 'pre-defined error field' (object dictionary, index 0x1003) */


### PR DESCRIPTION
This ensures that an queue overflow error is only active as long as the queue is actually overflown. Currently, this error remains active until reset and cannot be cleared.

