### PR TITLE
enhanced timing in emergency processing...

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -641,7 +641,8 @@ CO_NMT_reset_cmd_t CO_process(
             CO->emPr,
             NMTisPreOrOperational,
             timeDifference_ms * 10,
-            OD_inhibitTimeEMCY);
+            OD_inhibitTimeEMCY,
+            timerNext_ms);
 
 
     reset = CO_NMT_process(

--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -197,7 +197,8 @@ void CO_EM_process(
         CO_EMpr_t              *emPr,
         bool_t                  NMTisPreOrOperational,
         uint16_t                timeDifference_100us,
-        uint16_t                emInhTime)
+        uint16_t                emInhTime,
+        uint16_t               *timerNext_ms)
 {
 
     CO_EM_t *em = emPr->em;
@@ -231,47 +232,57 @@ void CO_EM_process(
     /* send Emergency message. */
     if(     NMTisPreOrOperational &&
             !emPr->CANtxBuff->bufferFull &&
-            emPr->inhibitEmTimer >= emInhTime &&
             (em->bufReadPtr != em->bufWritePtr || em->bufFull))
     {
         uint32_t preDEF;    /* preDefinedErrorField */
+        uint16_t diff;
         
-        /* add error register */
-        em->bufReadPtr[2] = *emPr->errorRegister;
+        if (emPr->inhibitEmTimer >= emInhTime) {
+            /* inhibit time elapsed, send message */
 
-        /* copy data to CAN emergency message */
-        CO_memcpy(emPr->CANtxBuff->data, em->bufReadPtr, 8U);
-        CO_memcpy((uint8_t*)&preDEF, em->bufReadPtr, 4U);
-        em->bufReadPtr += 8;
+            /* add error register */
+            em->bufReadPtr[2] = *emPr->errorRegister;
 
-        /* Update read buffer pointer and reset inhibit timer */
-        if(em->bufReadPtr == em->bufEnd){
-            em->bufReadPtr = em->buf;
+            /* copy data to CAN emergency message */
+            CO_memcpy(emPr->CANtxBuff->data, em->bufReadPtr, 8U);
+            CO_memcpy((uint8_t*)&preDEF, em->bufReadPtr, 4U);
+            em->bufReadPtr += 8;
+
+            /* Update read buffer pointer and reset inhibit timer */
+            if(em->bufReadPtr == em->bufEnd){
+                em->bufReadPtr = em->buf;
+            }
+            emPr->inhibitEmTimer = 0U;
+
+            /* verify message buffer overflow, then clear full flag */
+            if(em->bufFull == 2U){
+                em->bufFull = 0U;    /* will be updated below */
+                CO_errorReport(em, CO_EM_EMERGENCY_BUFFER_FULL, CO_EMC_GENERIC, 0U);
+            }
+            else{
+                em->bufFull = 0;
+            }
+
+            /* write to 'pre-defined error field' (object dictionary, index 0x1003) */
+            if(emPr->preDefErr){
+                uint8_t i;
+
+                if(emPr->preDefErrNoOfErrors < emPr->preDefErrSize)
+                    emPr->preDefErrNoOfErrors++;
+                for(i=emPr->preDefErrNoOfErrors-1; i>0; i--)
+                    emPr->preDefErr[i] = emPr->preDefErr[i-1];
+                emPr->preDefErr[0] = preDEF;
+            }
+
+            /* send CAN message */
+            CO_CANsend(emPr->CANdev, emPr->CANtxBuff);
         }
-        emPr->inhibitEmTimer = 0U;
 
-        /* verify message buffer overflow, then clear full flag */
-        if(em->bufFull == 2U){
-            em->bufFull = 0U;    /* will be updated below */
-            CO_errorReport(em, CO_EM_EMERGENCY_BUFFER_FULL, CO_EMC_GENERIC, 0U);
+        /* check again after inhibit time elapsed */
+        diff = (emInhTime + 9) / 10; /* time difference in ms, always round up */
+        if (*timerNext_ms > diff) {
+            *timerNext_ms = diff;
         }
-        else{
-            em->bufFull = 0;
-        }
-
-        /* write to 'pre-defined error field' (object dictionary, index 0x1003) */
-        if(emPr->preDefErr){
-            uint8_t i;
-
-            if(emPr->preDefErrNoOfErrors < emPr->preDefErrSize)
-                emPr->preDefErrNoOfErrors++;
-            for(i=emPr->preDefErrNoOfErrors-1; i>0; i--)
-                emPr->preDefErr[i] = emPr->preDefErr[i-1];
-            emPr->preDefErr[0] = preDEF;
-        }
-
-        /* send CAN message */
-        CO_CANsend(emPr->CANdev, emPr->CANtxBuff);
     }
 
     return;

--- a/stack/CO_Emergency.h
+++ b/stack/CO_Emergency.h
@@ -418,12 +418,14 @@ void CO_EM_initCallback(
  * @param NMTisPreOrOperational True if this node is NMT_PRE_OPERATIONAL or NMT_OPERATIONAL.
  * @param timeDifference_100us Time difference from previous function call in [100 * microseconds].
  * @param emInhTime _Inhibit time EMCY_ (object dictionary, index 0x1015).
+ * @param timerNext_ms Return value - info to OS - see CO_process().
  */
 void CO_EM_process(
         CO_EMpr_t              *emPr,
         bool_t                  NMTisPreOrOperational,
         uint16_t                timeDifference_100us,
-        uint16_t                emInhTime);
+        uint16_t                emInhTime,
+        uint16_t               *timerNext_ms);
 
 
 #endif


### PR DESCRIPTION
Currently, emergencies are checked only in the timer loop (default 50ms). _One_ emergency can be sent immediately by using emcy callback, but from the second onwards this will not work because of emcy inhibit time. This patch adds emergency message processing to the timerNext_ms functionallity, respecting inhibit time and emergency queue.

- emergency processing now affects CO_process() timerNext_ms
- timerNext_ms is gets set when either a message is ready to send, but inhibit time is not elapsed or when a message was sent to re-check the queue
- be aware that timer resolution is 1ms, whereas emergency inhibit time resolution is 100us. We round this up to the next ms.