### PR TITLE
stack auto enters operational mode after init

### DIFF
--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -235,7 +235,18 @@ CO_NMT_reset_cmd_t CO_NMT_process(
             if(HBtime > NMT->firstHBTime) NMT->HBproducerTimer = HBtime - NMT->firstHBTime;
             else                          NMT->HBproducerTimer = 0;
 
-            NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
+            
+            if((NMTstartup & 0x01) == 1) // 1F80 bit 0 indicates if node is NMT manager 
+            {
+                //NMT manager may enter operational mode automatically if bit 3 is set true
+                if((NMTstartup & 0x04) == 0) 
+                    NMT->operatingState = CO_NMT_OPERATIONAL;
+                else
+                    NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
+            } else {
+                //slave node are only allowed to enter preop after boot
+                NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
+            }
         }
     }
 

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -235,8 +235,7 @@ CO_NMT_reset_cmd_t CO_NMT_process(
             if(HBtime > NMT->firstHBTime) NMT->HBproducerTimer = HBtime - NMT->firstHBTime;
             else                          NMT->HBproducerTimer = 0;
 
-            if((NMTstartup & 0x04) == 0) NMT->operatingState = CO_NMT_OPERATIONAL;
-            else                         NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
+            NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
         }
     }
 


### PR DESCRIPTION
I've noticed that when using the stack on slave nodes, the stack goes automatically into operational mode after boot. This happens when we setup the OD **1F80** record (which will contain the CANOpen state during boot) with value 0x00 (= CO_NMT_INITIALIZING).

The code that makes it automatically go into operational mode is in CO_NMT_Heartbeat.c; function CO_NMT_Process().
Currently we can adjust that behavior by setting the default value for the OD **1F80** record to 0x04 (= CO_NMT_STOPPED). 

However, that is not what CANOpen standard defines. From initialization mode the nodes are only allowed to enter pre-op mode. Only the master is allowed to set a node in operational mode:

[image CANOpen state machine](https://www.can-cia.org/fileadmin/resources/images/nmt-slave.gif)

I'd think the code would need to be as suggested: