### PR TITLE
Correct handling if there is more than one SDO client configured

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -707,7 +707,7 @@ void CO_delete(int32_t CANbaseAddress){
           free(CO_traceValueBuffers[i]);
       }
   #endif
-  #if CO_NO_SDO_CLIENT == 1
+  #if CO_NO_SDO_CLIENT != 0
       for(i=0; i<CO_NO_SDO_CLIENT; i++) {
           free(CO->SDOclient[i]);
       }


### PR DESCRIPTION
  #if CO_NO_SDO_CLIENT == 1
should be  
  #if CO_NO_SDO_CLIENT != 0

if the loop should make sense 

  #if CO_NO_SDO_CLIENT != 0
      for(i=0; i<CO_NO_SDO_CLIENT; i++) {
          free(CO->SDOclient[i]);
      }
