### PR TITLE
Fix minor typos in comments

### DIFF
--- a/CANopen.h
+++ b/CANopen.h
@@ -228,7 +228,7 @@ CO_ReturnError_t CO_CANopenInit(
         uint8_t                 nodeId);
 
 
-#else /* CO_NO_LSS_SERVER == 1 */
+#else /* CO_NO_LSS_SERVER != 1 */
 /**
  * Initialize CANopen stack.
  *
@@ -246,7 +246,7 @@ CO_ReturnError_t CO_init(
         uint8_t                 nodeId,
         uint16_t                bitRate);
 
-#endif /* CO_NO_LSS_SERVER == 1 */
+#endif /* CO_NO_LSS_SERVER != 1 */
 
 
 /**


### PR DESCRIPTION
The logic in the comments on lines 231 and 249 should be the opposite of line 178 in order for them to match the logic for the preprocessor directives.
(lines shown below without changes)
https://github.com/CANopenNode/CANopenNode/blob/3f1a6364539708b3b973e0388e789e7d6d66f8ac/CANopen.h#L178

https://github.com/CANopenNode/CANopenNode/blob/3f1a6364539708b3b973e0388e789e7d6d66f8ac/CANopen.h#L231

https://github.com/CANopenNode/CANopenNode/blob/3f1a6364539708b3b973e0388e789e7d6d66f8ac/CANopen.h#L249