### PR TITLE
Use a void pointer for the CAN device address

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -391,17 +391,17 @@ CO_ReturnError_t CO_new(void)
 
 /******************************************************************************/
 CO_ReturnError_t CO_CANinit(
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         uint16_t                bitRate)
 {
     CO_ReturnError_t err;
 
     CO->CANmodule[0]->CANnormal = false;
-    CO_CANsetConfigurationMode(CANdevicePtr);
+    CO_CANsetConfigurationMode(CANdriverState);
 
     err = CO_CANmodule_init(
             CO->CANmodule[0],
-            CANdevicePtr,
+            CANdriverState,
             CO_CANmodule_rxArray0,
             CO_RXCAN_NO_MSGS,
             CO_CANmodule_txArray0,
@@ -663,7 +663,7 @@ CO_ReturnError_t CO_CANopenInit(
 
 /******************************************************************************/
 CO_ReturnError_t CO_init(
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         uint8_t                 nodeId,
         uint16_t                bitRate)
 {
@@ -674,15 +674,15 @@ CO_ReturnError_t CO_init(
         return err;
     }
 
-    err = CO_CANinit(CANdevicePtr, bitRate);
+    err = CO_CANinit(CANdriverState, bitRate);
     if (err) {
-        CO_delete(CANdevicePtr);
+        CO_delete(CANdriverState);
         return err;
     }
 
     err = CO_CANopenInit(nodeId);
     if (err) {
-        CO_delete(CANdevicePtr);
+        CO_delete(CANdriverState);
         return err;
     }
 
@@ -691,12 +691,12 @@ CO_ReturnError_t CO_init(
 
 
 /******************************************************************************/
-void CO_delete(void *CANdevicePtr){
+void CO_delete(void *CANdriverState){
 #ifndef CO_USE_GLOBALS
     int16_t i;
 #endif
 
-    CO_CANsetConfigurationMode(CANdevicePtr);
+    CO_CANsetConfigurationMode(CANdriverState);
     CO_CANmodule_disable(CO->CANmodule[0]);
 
 #ifndef CO_USE_GLOBALS

--- a/CANopen.c
+++ b/CANopen.c
@@ -391,17 +391,17 @@ CO_ReturnError_t CO_new(void)
 
 /******************************************************************************/
 CO_ReturnError_t CO_CANinit(
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         uint16_t                bitRate)
 {
     CO_ReturnError_t err;
 
     CO->CANmodule[0]->CANnormal = false;
-    CO_CANsetConfigurationMode(CANbaseAddress);
+    CO_CANsetConfigurationMode(CANdevicePtr);
 
     err = CO_CANmodule_init(
             CO->CANmodule[0],
-            CANbaseAddress,
+            CANdevicePtr,
             CO_CANmodule_rxArray0,
             CO_RXCAN_NO_MSGS,
             CO_CANmodule_txArray0,
@@ -663,7 +663,7 @@ CO_ReturnError_t CO_CANopenInit(
 
 /******************************************************************************/
 CO_ReturnError_t CO_init(
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         uint8_t                 nodeId,
         uint16_t                bitRate)
 {
@@ -674,15 +674,15 @@ CO_ReturnError_t CO_init(
         return err;
     }
 
-    err = CO_CANinit(CANbaseAddress, bitRate);
+    err = CO_CANinit(CANdevicePtr, bitRate);
     if (err) {
-        CO_delete(CANbaseAddress);
+        CO_delete(CANdevicePtr);
         return err;
     }
 
     err = CO_CANopenInit(nodeId);
     if (err) {
-        CO_delete(CANbaseAddress);
+        CO_delete(CANdevicePtr);
         return err;
     }
 
@@ -691,12 +691,12 @@ CO_ReturnError_t CO_init(
 
 
 /******************************************************************************/
-void CO_delete(int32_t CANbaseAddress){
+void CO_delete(void *CANdevicePtr){
 #ifndef CO_USE_GLOBALS
     int16_t i;
 #endif
 
-    CO_CANsetConfigurationMode(CANbaseAddress);
+    CO_CANsetConfigurationMode(CANdevicePtr);
     CO_CANmodule_disable(CO->CANmodule[0]);
 
 #ifndef CO_USE_GLOBALS

--- a/CANopen.h
+++ b/CANopen.h
@@ -192,13 +192,13 @@ CO_ReturnError_t CO_new(void);
  *
  * Function must be called in the communication reset section.
  *
- * @param CANbaseAddress Address of the CAN module, passed to CO_CANmodule_init().
+ * @param CANdevicePtr Pointer to the CAN module, passed to CO_CANmodule_init().
  * @param bitRate CAN bit rate.
  * @return #CO_ReturnError_t: CO_ERROR_NO, CO_ERROR_ILLEGAL_ARGUMENT,
  * CO_ERROR_ILLEGAL_BAUDRATE, CO_ERROR_OUT_OF_MEMORY
  */
 CO_ReturnError_t CO_CANinit(
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         uint16_t                bitRate);
 
 
@@ -234,7 +234,7 @@ CO_ReturnError_t CO_CANopenInit(
  *
  * Function must be called in the communication reset section.
  *
- * @param CANbaseAddress Address of the CAN module, passed to CO_CANmodule_init().
+ * @param CANdevicePtr Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
  * @param nodeId Node ID of the CANopen device (1 ... 127).
  * @param bitRate CAN bit rate.
  *
@@ -242,7 +242,7 @@ CO_ReturnError_t CO_CANopenInit(
  * CO_ERROR_OUT_OF_MEMORY, CO_ERROR_ILLEGAL_BAUDRATE
  */
 CO_ReturnError_t CO_init(
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         uint8_t                 nodeId,
         uint16_t                bitRate);
 
@@ -252,9 +252,9 @@ CO_ReturnError_t CO_init(
 /**
  * Delete CANopen object and free memory. Must be called at program exit.
  *
- * @param CANbaseAddress Address of the CAN module, passed to CO_CANmodule_init().
+ * @param CANdevicePtr Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
  */
-void CO_delete(int32_t CANbaseAddress);
+void CO_delete(void *CANdevicePtr);
 
 
 /**

--- a/CANopen.h
+++ b/CANopen.h
@@ -192,13 +192,13 @@ CO_ReturnError_t CO_new(void);
  *
  * Function must be called in the communication reset section.
  *
- * @param CANdevicePtr Pointer to the CAN module, passed to CO_CANmodule_init().
+ * @param CANdriverState Pointer to the CAN module, passed to CO_CANmodule_init().
  * @param bitRate CAN bit rate.
  * @return #CO_ReturnError_t: CO_ERROR_NO, CO_ERROR_ILLEGAL_ARGUMENT,
  * CO_ERROR_ILLEGAL_BAUDRATE, CO_ERROR_OUT_OF_MEMORY
  */
 CO_ReturnError_t CO_CANinit(
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         uint16_t                bitRate);
 
 
@@ -234,7 +234,7 @@ CO_ReturnError_t CO_CANopenInit(
  *
  * Function must be called in the communication reset section.
  *
- * @param CANdevicePtr Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
+ * @param CANdriverState Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
  * @param nodeId Node ID of the CANopen device (1 ... 127).
  * @param bitRate CAN bit rate.
  *
@@ -242,7 +242,7 @@ CO_ReturnError_t CO_CANopenInit(
  * CO_ERROR_OUT_OF_MEMORY, CO_ERROR_ILLEGAL_BAUDRATE
  */
 CO_ReturnError_t CO_init(
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         uint8_t                 nodeId,
         uint16_t                bitRate);
 
@@ -252,9 +252,9 @@ CO_ReturnError_t CO_init(
 /**
  * Delete CANopen object and free memory. Must be called at program exit.
  *
- * @param CANdevicePtr Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
+ * @param CANdriverState Pointer to the user-defined CAN base structure, passed to CO_CANmodule_init().
  */
-void CO_delete(void *CANdevicePtr);
+void CO_delete(void *CANdriverState);
 
 
 /**

--- a/example/main.c
+++ b/example/main.c
@@ -51,6 +51,12 @@
 #define TMR_TASK_INTERVAL   (1000)          /* Interval of tmrTask thread in microseconds */
 #define INCREMENT_1MS(var)  (var++)         /* Increment 1ms variable in tmrTask */
 
+/**
+ * User-defined CAN base structure, passed as argument to CO_init.
+ */
+struct CANbase {
+    uintptr_t baseAddress;  /**< Base address of the CAN module */
+};
 
 /* Global variables and objects */
     volatile uint16_t   CO_timer1ms = 0U;   /* variable increments each millisecond */
@@ -76,10 +82,12 @@ int main (void){
         uint16_t timer1msPrevious;
 
         /* disable CAN and CAN interrupts */
-
+        struct CANbase canBase = {
+            .baseAddress = 0u,  /* CAN module address */
+        };
 
         /* initialize CANopen */
-        err = CO_init(0/* CAN module address */, 10/* NodeID */, 125 /* bit rate */);
+        err = CO_init(&canBase, 10/* NodeID */, 125 /* bit rate */);
         if(err != CO_ERROR_NO){
             while(1);
             /* CO_errorReport(CO->em, CO_EM_MEMORY_ALLOCATION_ERROR, CO_EMC_SOFTWARE_INTERNAL, err); */
@@ -122,7 +130,7 @@ int main (void){
 
 
     /* delete objects from memory */
-    CO_delete(0/* CAN module address */);
+    CO_delete((void*) 0/* CAN module address */);
 
 
     /* reset */

--- a/stack/LPC1768/CO_driver.cpp
+++ b/stack/LPC1768/CO_driver.cpp
@@ -81,7 +81,7 @@ void fromCANMessage(CANMessage *msg, CO_CANrxMsg_t *CO_msg) {
 }
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
     /* Put CAN module in configuration mode */
 }
 
@@ -100,7 +100,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -116,7 +116,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;

--- a/stack/LPC1768/CO_driver.cpp
+++ b/stack/LPC1768/CO_driver.cpp
@@ -81,7 +81,7 @@ void fromCANMessage(CANMessage *msg, CO_CANrxMsg_t *CO_msg) {
 }
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
     /* Put CAN module in configuration mode */
 }
 
@@ -100,7 +100,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -116,7 +116,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -130,7 +130,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    int32_t             CANbaseAddress;
+    void               *CANdevicePtr;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -150,14 +150,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -130,7 +130,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -150,14 +150,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/LPC177x_8x/CO_driver.c
+++ b/stack/LPC177x_8x/CO_driver.c
@@ -151,7 +151,7 @@ void CO_CANrxMsgHandler(void *object, const CO_CANrxMsg_t *message){
 }
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
 }
 
 
@@ -167,7 +167,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -183,7 +183,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;

--- a/stack/LPC177x_8x/CO_driver.c
+++ b/stack/LPC177x_8x/CO_driver.c
@@ -151,13 +151,13 @@ void CO_CANrxMsgHandler(void *object, const CO_CANrxMsg_t *message){
 }
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
-            
+
     Chip_CAN_SetAFMode(LPC_CANAF, CAN_AF_NORMAL_MODE);
 
     CANmodule->CANnormal = true;
@@ -167,7 +167,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -176,33 +176,33 @@ CO_ReturnError_t CO_CANmodule_init(
 {
     uint16_t i;
     uint8_t nodeId=0;
-    
+
     /* verify arguments */
     if(CANmodule==NULL || rxArray==NULL || txArray==NULL){
         return CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;
     CANmodule->txSize = txSize;
     CANmodule->CANnormal = false;
-#if AF_LUT_USED    
+#if AF_LUT_USED
     CANmodule->useCANrxFilters = (rxSize <= 32U) ? true : false;/* microcontroller dependent */
 #else
     CANmodule->useCANrxFilters = false;
-#endif    
+#endif
     CANmodule->bufferInhibitFlag = false;
     CANmodule->firstCANtxMessage = true;
     CANmodule->CANtxCount = 0U;
     CANmodule->errOld = 0U;
     CANmodule->em = NULL;
 
-     
+
     DEBUGOUT("CO_CANmodule_init Baud: %d\r\n",(CANbitRate * 1000));
-    
+
     for(i=0U; i<rxSize; i++){
         rxArray[i].ident = 0U;
         rxArray[i].pFunct = CO_CANrxMsgHandler;
@@ -214,7 +214,7 @@ CO_ReturnError_t CO_CANmodule_init(
     Chip_IOCON_PinMuxSet(LPC_IOCON, 0, 4, (IOCON_FUNC2 | IOCON_MODE_INACT | IOCON_DIGMODE_EN));
 	/* CAN_TD2*/
     Chip_IOCON_PinMuxSet(LPC_IOCON, 0, 5, (IOCON_FUNC2 | IOCON_MODE_INACT | IOCON_DIGMODE_EN ));
-   
+
     /* CAN_TERMINATION swapped over with nCAN_HEARTBEAT, so this pin is actually CAN_TERMINATION*/
     Chip_IOCON_PinMuxSet(LPC_IOCON, 1, 21, (IOCON_FUNC0 | IOCON_MODE_INACT ));
     Chip_GPIO_WriteDirBit(LPC_GPIO, 1, 21, true);
@@ -223,7 +223,7 @@ CO_ReturnError_t CO_CANmodule_init(
     Chip_IOCON_PinMuxSet(LPC_IOCON, CAN_RUN_LED_PORT, CAN_RUN_LED_PIN, IOCON_FUNC0);
     Chip_GPIO_WriteDirBit(LPC_GPIO, CAN_RUN_LED_PORT, CAN_RUN_LED_PIN, true);
     Chip_GPIO_WritePortBit(LPC_GPIO, CAN_RUN_LED_PORT,CAN_RUN_LED_PIN, true);
-    
+
     Chip_IOCON_PinMuxSet(LPC_IOCON, CAN_NODE_ID_0_PORT, CAN_NODE_ID_0_PIN, (IOCON_FUNC0 | IOCON_MODE_INACT));
     Chip_GPIO_WriteDirBit(LPC_GPIO, CAN_NODE_ID_0_PORT, CAN_NODE_ID_0_PIN, false);
     Chip_IOCON_PinMuxSet(LPC_IOCON, CAN_NODE_ID_1_PORT, CAN_NODE_ID_1_PIN, (IOCON_FUNC0 | IOCON_MODE_INACT));
@@ -234,7 +234,7 @@ CO_ReturnError_t CO_CANmodule_init(
     Chip_GPIO_WriteDirBit(LPC_GPIO, CAN_NODE_ID_3_PORT, CAN_NODE_ID_3_PIN, false);
     Chip_IOCON_PinMuxSet(LPC_IOCON, CAN_NODE_ID_4_PORT, CAN_NODE_ID_4_PIN, (IOCON_FUNC0 | IOCON_MODE_INACT));
     Chip_GPIO_WriteDirBit(LPC_GPIO, CAN_NODE_ID_4_PORT, CAN_NODE_ID_4_PIN, false);
-    
+
     nodeId = 0;
     nodeId |= (uint8_t)(Chip_GPIO_GetPinState(LPC_GPIO, CAN_NODE_ID_0_PORT, CAN_NODE_ID_0_PIN) ? 1: 0);
     nodeId |= (uint8_t)(Chip_GPIO_GetPinState(LPC_GPIO, CAN_NODE_ID_1_PORT, CAN_NODE_ID_1_PIN) ? (1<<1): 0);
@@ -244,7 +244,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
     DEBUGOUT("CO_CANmodule_init nodeId: 0x%x\r\n",nodeId);
     OD_CANNodeID = nodeId;
-    
+
     /* Configure CAN module registers */
 	Chip_CAN_Init(LPC_CAN, LPC_CANAF, LPC_CANAF_RAM);
     /* Configure CAN timing */
@@ -255,7 +255,7 @@ CO_ReturnError_t CO_CANmodule_init(
     /* Configure CAN module hardware filters */
     if(CANmodule->useCANrxFilters){
         DEBUGOUT("\tCAN Rx Acceptance Filters ON \r\n");
-#if AF_LUT_USED        
+#if AF_LUT_USED
         /* CAN module filters are used, they will be configured with */
         /* CO_CANrxBufferInit() functions, called by separate CANopen */
         /* init functions. */
@@ -270,11 +270,11 @@ CO_ReturnError_t CO_CANmodule_init(
 #else
         Chip_CAN_SetAFMode(LPC_CANAF, CAN_AF_NORMAL_MODE);
 #endif /*FULL_CAN_AF_USED*/
-        
-#else                
+
+#else
         DEBUGOUT("\tCAN Rx Acceptance Filters NOT OPERATIONAL for the debug stages\r\n");
         Chip_CAN_SetAFMode(LPC_CANAF, CAN_AF_BYBASS_MODE);
-#endif        
+#endif
     }
     else
 	{
@@ -282,12 +282,12 @@ CO_ReturnError_t CO_CANmodule_init(
         /* identifier will be received */
         /* Configure mask 0 so, that all messages with standard identifier are accepted */
         Chip_CAN_SetAFMode(LPC_CANAF, CAN_AF_BYBASS_MODE);
-                
+
         DEBUGOUT("\tCAN Rx Acceptance Filters Bypass \r\n");
     }
     /* configure CAN interrupt registers */
     NVIC_EnableIRQ(CAN_IRQn);
-    
+
     return CO_ERROR_NO;
 }
 
@@ -308,9 +308,9 @@ uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg){
 uint16_t CO_CAN_Get_My_NodeID(void){
 
     uint16_t     myNodeId=0;
-    
+
     myNodeId = Chip_GPIO_ReadPortBit(LPC_GPIO, CAN_NODE_ID_0_PORT, CAN_NODE_ID_0_PIN);
-    
+
     return myNodeId;
 }
 /******************************************************************************/
@@ -324,7 +324,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
         void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message))
 {
     CO_ReturnError_t ret = CO_ERROR_NO;
-    
+
     if((CANmodule!=NULL) && (object!=NULL) && (pFunct!=NULL) && (index < CANmodule->rxSize)){
         /* buffer, which will be configured */
         CO_CANrx_t *buffer = &CANmodule->rxArray[index];
@@ -359,7 +359,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
         bool_t                  syncFlag)
 {
     CO_CANtx_t *buffer = NULL;
-    
+
     if((CANmodule != NULL) && (index < CANmodule->txSize)){
         /* get specific buffer */
         buffer = &CANmodule->txArray[index];
@@ -382,7 +382,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
 	CAN_BUFFER_ID_T   TxBuf;
-    
+
     /* Verify overflow */
     if(buffer->bufferFull){
         if(!CANmodule->firstCANtxMessage){
@@ -391,16 +391,16 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
         }
         err = CO_ERROR_TX_OVERFLOW;
     }
-  
+
     CO_LOCK_CAN_SEND();
-    
+
     /* if CAN TX buffer is free, copy message to it */
     TxBuf = Chip_CAN_GetFreeTxBuf(LPC_CAN);
     if( TxBuf < CAN_BUFFER_LAST && CANmodule->CANtxCount == 0){
         CANmodule->bufferInhibitFlag = buffer->syncFlag;
         /* copy message and txRequest */
         Chip_CAN_Send(LPC_CAN, TxBuf,(CAN_MSG_T*)buffer);
-       
+
         /*DEBUGOUT("CO_CANsend!!!\r\n");*/
         /*PrintCANMsg((CAN_MSG_T*)buffer);*/
     }
@@ -422,12 +422,12 @@ void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule){
     uint32_t tpdoDeleted = 0U;
 
     CO_LOCK_CAN_SEND();
-    
+
     /* Abort message from CAN module, if there is synchronous TPDO.
      * Take special care with this functionality. */
     /*Check if any of the buffer is pending transmition and bufferInhibitFlag is true*/
     if(( 0 == (Chip_CAN_GetGlobalStatus(LPC_CAN) & CAN_GSR_TBS)) && CANmodule->bufferInhibitFlag){
-       
+
         /* if not already in progress, a pending Transmission Request for
             the selected Transmit Buffer is cancelled. */
         Chip_CAN_SetCmd(LPC_CAN, CAN_CMR_STB(CAN_BUFFER_1) | CAN_CMR_AT);
@@ -470,8 +470,8 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 
     /* get error counters from module. Id possible, function may use different way to
      * determine errors. */
-    rxErrors = CAN_GSR_RXERR(Chip_CAN_GetGlobalStatus(LPC_CAN)); 
-    txErrors = CAN_GSR_TXERR(Chip_CAN_GetGlobalStatus(LPC_CAN)); 
+    rxErrors = CAN_GSR_RXERR(Chip_CAN_GetGlobalStatus(LPC_CAN));
+    txErrors = CAN_GSR_TXERR(Chip_CAN_GetGlobalStatus(LPC_CAN));
     overflow = (Chip_CAN_GetGlobalStatus(LPC_CAN) & CAN_GSR_DOS) ; /*CAN Data Overrun Status */  CANmodule->txSize;
 
     err = ((uint32_t)txErrors << 16) | ((uint32_t)rxErrors << 8) | overflow;
@@ -532,19 +532,19 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
     CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
     bool_t msgMatched = false;
     CAN_BUFFER_ID_T   TxBuf;
-                
+
     /*Read the int status register */
     IntStatus = Chip_CAN_GetIntStatus(LPC_CAN);
 
-    
+
     /* receive interrupt */
     if(IntStatus & CAN_ICR_RI){
- 
+
         /* get message from module */
         Chip_CAN_Receive(LPC_CAN,(CAN_MSG_T*)&RcvMsgBuf);
         rcvMsg = &RcvMsgBuf;
         rcvMsgIdent = rcvMsg->ident;
-         
+
 #if AF_LUT_USED   /*Implement once AF will be used*/
         if(CANmodule->useCANrxFilters){
 
@@ -560,7 +560,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
             }
         }
         else
-#endif            
+#endif
         {
             /* CAN module filters are not used, message with any standard 11-bit identifier */
             /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
@@ -572,18 +572,18 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
                 }
                 buffer++;
             }
-            
+
         }
 
         /* Call specific function, which will process the message */
         if(msgMatched && (buffer != NULL) && (buffer->pFunct != NULL)){
-        
+
             buffer->pFunct(buffer->object, rcvMsg);
         }
 		else
 		{
-			DEBUGOUT("Unsupported Message Received!!!\r\n");  
-            PrintCANMsg((CAN_MSG_T*)rcvMsg); 
+			DEBUGOUT("Unsupported Message Received!!!\r\n");
+            PrintCANMsg((CAN_MSG_T*)rcvMsg);
 		}
 
         /* Clear interrupt flag */
@@ -703,7 +703,7 @@ static void PrintAFLUT(void)
 	CAN_EXT_ID_ENTRY_T ExtEntry;
 	CAN_STD_ID_RANGE_ENTRY_T StdGrpEntry;
 	CAN_EXT_ID_RANGE_ENTRY_T ExtGrpEntry;
-   
+
     DEBUGOUT("Print AF LUT... \r\n");
 #if FULL_CAN_AF_USED
 	/* Full CAN Table */
@@ -771,7 +771,7 @@ static void ChangeAFLUT(void)
 	CAN_STD_ID_RANGE_ENTRY_T StdGrpEntry = {{CAN_CTRL_NO, 0, 0x7A0}, {CAN_CTRL_NO, 0, 0x7B0}};
 	CAN_EXT_ID_RANGE_ENTRY_T ExtGrpEntry = {{CAN_CTRL_NO, ((1 << 11) | 0x7A0)}, {CAN_CTRL_NO, ((1 << 11) | 0x7B0)}};
 
-	
+
 #if FULL_CAN_AF_USED
 	/* Edit Full CAN Table */
 	Chip_CAN_InsertFullCANEntry(LPC_CANAF, LPC_CANAF_RAM, &FullEntry);
@@ -835,7 +835,7 @@ static void ChangeAFLUT(void)
 	Chip_CAN_RemoveGroupEXTEntry(LPC_CANAF, LPC_CANAF_RAM, Chip_CAN_GetEntriesNum(LPC_CANAF, LPC_CANAF_RAM, CANAF_RAM_EFF_GRP_SEC) - 1);
 	Chip_CAN_RemoveGroupEXTEntry(LPC_CANAF, LPC_CANAF_RAM, Chip_CAN_GetEntriesNum(LPC_CANAF, LPC_CANAF_RAM, CANAF_RAM_EFF_GRP_SEC) / 2);
 	PrintAFLUT();
-#endif    
+#endif
 }
 
 #endif

--- a/stack/LPC177x_8x/CO_driver.h
+++ b/stack/LPC177x_8x/CO_driver.h
@@ -153,7 +153,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    uint16_t            CANbaseAddress;
+    void               *CANdevicePtr;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -173,14 +173,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/LPC177x_8x/CO_driver.h
+++ b/stack/LPC177x_8x/CO_driver.h
@@ -153,7 +153,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -173,14 +173,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/MCF5282/CO_driver.c
+++ b/stack/MCF5282/CO_driver.c
@@ -52,7 +52,7 @@ extern const CO_CANbitRateData_t  CO_CANbitRateData[8];
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
 
     /* sets the module as running */
     MCF_FlexCAN_CANMCR &= ~MCF_FlexCAN_CANMCR_STOP;
@@ -80,7 +80,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -96,7 +96,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->CANmsgBuffSize = nb_CANbuff;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -209,7 +209,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANbaseAddress);
+    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
 }
 
 
@@ -248,7 +248,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
 
         /* Set CAN hardware module filter and mask. */
         if(CANmodule->useCANrxFilters){
-            //filters are not used. 
+            //filters are not used.
         }
     }
     else{
@@ -290,7 +290,6 @@ CO_CANtx_t *CO_CANtxBufferInit(
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANbaseAddress;
     uint8_t i;
 
     /* Verify overflow */

--- a/stack/MCF5282/CO_driver.c
+++ b/stack/MCF5282/CO_driver.c
@@ -52,7 +52,7 @@ extern const CO_CANbitRateData_t  CO_CANbitRateData[8];
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
 
     /* sets the module as running */
     MCF_FlexCAN_CANMCR &= ~MCF_FlexCAN_CANMCR_STOP;
@@ -80,7 +80,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -96,7 +96,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->CANmsgBuffSize = nb_CANbuff;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -209,7 +209,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
+    CO_CANsetConfigurationMode(CANmodule->CANdriverState);
 }
 
 

--- a/stack/MCF5282/CO_driver.h
+++ b/stack/MCF5282/CO_driver.h
@@ -359,7 +359,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    uint16_t            CANbaseAddress;
+    void               *CANdevicePtr;
     CO_CANrxMsg_t      *CANmsgBuff;
     uint8_t             CANmsgBuffSize;
     CO_CANrx_t         *rxArray;
@@ -381,7 +381,7 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
@@ -393,7 +393,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/MCF5282/CO_driver.h
+++ b/stack/MCF5282/CO_driver.h
@@ -359,7 +359,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     CO_CANrxMsg_t      *CANmsgBuff;
     uint8_t             CANmsgBuffSize;
     CO_CANrx_t         *rxArray;
@@ -381,7 +381,7 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
@@ -393,7 +393,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/PIC24_dsPIC33/CO_driver.c
+++ b/stack/PIC24_dsPIC33/CO_driver.c
@@ -120,29 +120,29 @@
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
-    uint16_t C_CTRL1copy = CAN_REG(CANdevicePtr, C_CTRL1);
+void CO_CANsetConfigurationMode(void *CANdriverState){
+    uint16_t C_CTRL1copy = CAN_REG(CANdriverState, C_CTRL1);
 
     /* set REQOP = 0x4 */
     C_CTRL1copy &= 0xFCFF;
     C_CTRL1copy |= 0x0400;
-    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1copy;
+    CAN_REG(CANdriverState, C_CTRL1) = C_CTRL1copy;
 
     /* while OPMODE != 4 */
-    while((CAN_REG(CANdevicePtr, C_CTRL1) & 0x00E0) != 0x0080);
+    while((CAN_REG(CANdriverState, C_CTRL1) & 0x00E0) != 0x0080);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
-    uint16_t C_CTRL1copy = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
+    uint16_t C_CTRL1copy = CAN_REG(CANmodule->CANdriverState, C_CTRL1);
 
     /* set REQOP = 0x0 */
     C_CTRL1copy &= 0xF8FF;
-    CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1copy;
+    CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1copy;
 
     /* while OPMODE != 0 */
-    while((CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) & 0x00E0) != 0x0000);
+    while((CAN_REG(CANmodule->CANdriverState, C_CTRL1) & 0x00E0) != 0x0000);
 
     CANmodule->CANnormal = true;
 }
@@ -151,7 +151,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -176,7 +176,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Get global addresses for CAN module 1 or 2. */
-    if(CANdevicePtr == ADDR_CAN1) {
+    if(CANdriverState == ADDR_CAN1) {
         DMArxBaseAddress = CO_CAN1_DMA0;
         DMAtxBaseAddress = CO_CAN1_DMA1;
         CANmsgBuff = &CO_CAN1msg[0];
@@ -187,7 +187,7 @@ CO_ReturnError_t CO_CANmodule_init(
     #endif
     }
 #if CO_CAN2msgBuffSize > 0
-    else if(((uintptr_t) CANdevicePtr) == ADDR_CAN2) {
+    else if(((uintptr_t) CANdriverState) == ADDR_CAN2) {
         DMArxBaseAddress = CO_CAN2_DMA0;
         DMAtxBaseAddress = CO_CAN2_DMA1;
         CANmsgBuff = &CO_CAN2msg[0];
@@ -203,7 +203,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->CANmsgBuff = CANmsgBuff;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -227,8 +227,8 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control registers */
-    CAN_REG(CANdevicePtr, C_CTRL1) = 0x0400;
-    CAN_REG(CANdevicePtr, C_CTRL2) = 0x0000;
+    CAN_REG(CANdriverState, C_CTRL1) = 0x0400;
+    CAN_REG(CANdriverState, C_CTRL2) = 0x0000;
 
 
     /* Configure CAN timing */
@@ -245,40 +245,40 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     if(CO_CANbitRateData[i].scale == 2)
-        CAN_REG(CANdevicePtr, C_CTRL1) |= 0x0800;
+        CAN_REG(CANdriverState, C_CTRL1) |= 0x0800;
 
-    CAN_REG(CANdevicePtr, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
+    CAN_REG(CANdriverState, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
                                         (CO_CANbitRateData[i].BRP - 1);
 
-    CAN_REG(CANdevicePtr, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
+    CAN_REG(CANdriverState, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
                                         0x0080 |
                                         (CO_CANbitRateData[i].phSeg1 - 1) << 3 |
                                         (CO_CANbitRateData[i].PROP - 1);
 
 
     /* setup RX and TX control registers */
-    CAN_REG(CANdevicePtr, C_CTRL1) &= 0xFFFE;     /* WIN = 0 - use buffer registers */
-    CAN_REG(CANdevicePtr, C_RXFUL1) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXFUL2) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXOVF1) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXOVF2) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TR01CON) = 0x0080;    /* use one buffer for transmission */
-    CAN_REG(CANdevicePtr, C_TR23CON) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TR45CON) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TR67CON) = 0x0000;
+    CAN_REG(CANdriverState, C_CTRL1) &= 0xFFFE;     /* WIN = 0 - use buffer registers */
+    CAN_REG(CANdriverState, C_RXFUL1) = 0x0000;
+    CAN_REG(CANdriverState, C_RXFUL2) = 0x0000;
+    CAN_REG(CANdriverState, C_RXOVF1) = 0x0000;
+    CAN_REG(CANdriverState, C_RXOVF2) = 0x0000;
+    CAN_REG(CANdriverState, C_TR01CON) = 0x0080;    /* use one buffer for transmission */
+    CAN_REG(CANdriverState, C_TR23CON) = 0x0000;
+    CAN_REG(CANdriverState, C_TR45CON) = 0x0000;
+    CAN_REG(CANdriverState, C_TR67CON) = 0x0000;
 
 
     /* CAN module hardware filters */
-    CAN_REG(CANdevicePtr, C_CTRL1) |= 0x0001;     /* WIN = 1 - use filter registers */
-    CAN_REG(CANdevicePtr, C_FEN1) = 0xFFFF;       /* enable all 16 filters */
-    CAN_REG(CANdevicePtr, C_FMSKSEL1) = 0x0000;   /* all filters are using mask 0 */
-    CAN_REG(CANdevicePtr, C_FMSKSEL2) = 0x0000;
-    CAN_REG(CANdevicePtr, C_BUFPNT1) = 0xFFFF;    /* use FIFO for all filters */
-    CAN_REG(CANdevicePtr, C_BUFPNT2) = 0xFFFF;
-    CAN_REG(CANdevicePtr, C_BUFPNT3) = 0xFFFF;
-    CAN_REG(CANdevicePtr, C_BUFPNT4) = 0xFFFF;
+    CAN_REG(CANdriverState, C_CTRL1) |= 0x0001;     /* WIN = 1 - use filter registers */
+    CAN_REG(CANdriverState, C_FEN1) = 0xFFFF;       /* enable all 16 filters */
+    CAN_REG(CANdriverState, C_FMSKSEL1) = 0x0000;   /* all filters are using mask 0 */
+    CAN_REG(CANdriverState, C_FMSKSEL2) = 0x0000;
+    CAN_REG(CANdriverState, C_BUFPNT1) = 0xFFFF;    /* use FIFO for all filters */
+    CAN_REG(CANdriverState, C_BUFPNT2) = 0xFFFF;
+    CAN_REG(CANdriverState, C_BUFPNT3) = 0xFFFF;
+    CAN_REG(CANdriverState, C_BUFPNT4) = 0xFFFF;
     /* set all filters to 0 */
-    pRXF = &CAN_REG(CANdevicePtr, C_RXF0SID);
+    pRXF = &CAN_REG(CANdriverState, C_RXF0SID);
     for(i=0; i<16; i++){
         *pRXF = 0x0000;
         pRXF += 2;
@@ -288,44 +288,44 @@ CO_ReturnError_t CO_CANmodule_init(
         /* CO_CANrxBufferInit() functions, called by separate CANopen */
         /* init functions. */
         /* All mask bits are 1, so received message must match filter */
-        CAN_REG(CANdevicePtr, C_RXM0SID) = 0xFFE8;
-        CAN_REG(CANdevicePtr, C_RXM1SID) = 0xFFE8;
-        CAN_REG(CANdevicePtr, C_RXM2SID) = 0xFFE8;
+        CAN_REG(CANdriverState, C_RXM0SID) = 0xFFE8;
+        CAN_REG(CANdriverState, C_RXM1SID) = 0xFFE8;
+        CAN_REG(CANdriverState, C_RXM2SID) = 0xFFE8;
     }
     else{
         /* CAN module filters are not used, all messages with standard 11-bit */
         /* identifier will be received */
         /* Set masks so, that all messages with standard identifier are accepted */
-        CAN_REG(CANdevicePtr, C_RXM0SID) = 0x0008;
-        CAN_REG(CANdevicePtr, C_RXM1SID) = 0x0008;
-        CAN_REG(CANdevicePtr, C_RXM2SID) = 0x0008;
+        CAN_REG(CANdriverState, C_RXM0SID) = 0x0008;
+        CAN_REG(CANdriverState, C_RXM1SID) = 0x0008;
+        CAN_REG(CANdriverState, C_RXM2SID) = 0x0008;
     }
 
     /* WIN = 0 - use buffer registers for default */
-    CAN_REG(CANdevicePtr, C_CTRL1) &= 0xFFFE;
+    CAN_REG(CANdriverState, C_CTRL1) &= 0xFFFE;
 
 
     /* Configure DMA controller */
     /* Set size of buffer in DMA RAM (FIFO Area Starts with Tx/Rx buffer TRB1 (FSA = 1)) */
     /* Use maximum 16 buffers, because we have 16-bit system. */
     if (CANmsgBuffSize >= 16) {
-        CAN_REG(CANdevicePtr, C_FCTRL) = 0x8001;
+        CAN_REG(CANdriverState, C_FCTRL) = 0x8001;
         CANmodule->CANmsgBuffSize = 16;
     }
     else if(CANmsgBuffSize >= 12) {
-        CAN_REG(CANdevicePtr, C_FCTRL) = 0x6001;
+        CAN_REG(CANdriverState, C_FCTRL) = 0x6001;
         CANmodule->CANmsgBuffSize = 12;
     }
     else if(CANmsgBuffSize >=  8) {
-        CAN_REG(CANdevicePtr, C_FCTRL) = 0x4001;
+        CAN_REG(CANdriverState, C_FCTRL) = 0x4001;
         CANmodule->CANmsgBuffSize = 8;
     }
     else if(CANmsgBuffSize >=  6) {
-        CAN_REG(CANdevicePtr, C_FCTRL) = 0x2001;
+        CAN_REG(CANdriverState, C_FCTRL) = 0x2001;
         CANmodule->CANmsgBuffSize = 6;
     }
     else if(CANmsgBuffSize >=  4) {
-        CAN_REG(CANdevicePtr, C_FCTRL) = 0x0001;
+        CAN_REG(CANdriverState, C_FCTRL) = 0x0001;
         CANmodule->CANmsgBuffSize = 4;
     }
     else {
@@ -334,9 +334,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* DMA chanel initialization for ECAN reception */
     DMA_REG(DMArxBaseAddress, DMA_CON) = 0x0020;
-    DMA_REG(DMArxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdevicePtr, C_RXD);
+    DMA_REG(DMArxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdriverState, C_RXD);
     DMA_REG(DMArxBaseAddress, DMA_CNT) = 7;
-    DMA_REG(DMArxBaseAddress, DMA_REQ) = (CANdevicePtr==ADDR_CAN1) ? 34 : 55;
+    DMA_REG(DMArxBaseAddress, DMA_REQ) = (CANdriverState==ADDR_CAN1) ? 34 : 55;
 
 #ifndef __HAS_EDS__
     DMA_REG(DMArxBaseAddress, DMA_STA) = CANmsgBuffDMAoffset;
@@ -349,9 +349,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* DMA chanel initialization for ECAN transmission */
     DMA_REG(DMAtxBaseAddress, DMA_CON) = 0x2020;
-    DMA_REG(DMAtxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdevicePtr, C_TXD);
+    DMA_REG(DMAtxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdriverState, C_TXD);
     DMA_REG(DMAtxBaseAddress, DMA_CNT) = 7;
-    DMA_REG(DMAtxBaseAddress, DMA_REQ) = (CANdevicePtr==ADDR_CAN1) ? 70 : 71;
+    DMA_REG(DMAtxBaseAddress, DMA_REQ) = (CANdriverState==ADDR_CAN1) ? 70 : 71;
 
 #ifndef __HAS_EDS__
     DMA_REG(DMAtxBaseAddress, DMA_STA) = CANmsgBuffDMAoffset;
@@ -365,9 +365,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* CAN interrupt registers */
     /* clear interrupt flags */
-    CAN_REG(CANdevicePtr, C_INTF) = 0x0000;
+    CAN_REG(CANdriverState, C_INTF) = 0x0000;
     /* enable receive and transmit interrupt */
-    CAN_REG(CANdevicePtr, C_INTE) = 0x0003;
+    CAN_REG(CANdriverState, C_INTE) = 0x0003;
     /* CAN interrupt (combined) must be configured by application */
 
     return CO_ERROR_NO;
@@ -376,7 +376,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
+    CO_CANsetConfigurationMode(CANmodule->CANdriverState);
 }
 
 
@@ -402,7 +402,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
         /* buffer, which will be configured */
         CO_CANrx_t *buffer = &CANmodule->rxArray[index];
         uint16_t RXF, RXM;
-        uint16_t addr = CANmodule->CANdevicePtr;
+        uint16_t addr = CANmodule->CANdriverState;
 
         /* Configure object variables */
         buffer->object = object;
@@ -524,11 +524,11 @@ CO_CANtx_t *CO_CANtxBufferInit(
 
 /* Copy message to CAN module - internal usage only.
  *
- * @param CANdevicePtr CAN module base address
+ * @param CANdriverState CAN module base address
  * @param dest Pointer to CAN module transmit buffer
  * @param src Pointer to source message
  */
-static void CO_CANsendToModule(void *CANdevicePtr, __eds__ CO_CANrxMsg_t *dest, CO_CANtx_t *src){
+static void CO_CANsendToModule(void *CANdriverState, __eds__ CO_CANrxMsg_t *dest, CO_CANtx_t *src){
     uint8_t DLC;
     __eds__ uint8_t *CANdataBuffer;
     uint8_t *pData;
@@ -548,17 +548,17 @@ static void CO_CANsendToModule(void *CANdevicePtr, __eds__ CO_CANrxMsg_t *dest, 
     for(; DLC>0; DLC--) *(CANdataBuffer++) = *(pData++);
 
     /* control register, transmit request */
-    C_CTRL1old = CAN_REG(CANdevicePtr, C_CTRL1);
-    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-    CAN_REG(CANdevicePtr, C_TR01CON) |= 0x08;
-    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1old;
+    C_CTRL1old = CAN_REG(CANdriverState, C_CTRL1);
+    CAN_REG(CANdriverState, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+    CAN_REG(CANdriverState, C_TR01CON) |= 0x08;
+    CAN_REG(CANdriverState, C_CTRL1) = C_CTRL1old;
 }
 
 
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANdevicePtr;
+    uint16_t addr = CANmodule->CANdriverState;
     volatile uint16_t C_CTRL1old, C_TR01CONcopy;
 
     /* Verify overflow */
@@ -601,10 +601,10 @@ void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule){
     /* Abort message from CAN module, if there is synchronous TPDO.
      * Take special care with this functionality. */
     if(CANmodule->bufferInhibitFlag){
-        volatile uint16_t C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
-        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-        CAN_REG(CANmodule->CANdevicePtr, C_TR01CON) &= 0xFFF7; /* clear TXREQ */
-        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
+        volatile uint16_t C_CTRL1old = CAN_REG(CANmodule->CANdriverState, C_CTRL1);
+        CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+        CAN_REG(CANmodule->CANdriverState, C_TR01CON) &= 0xFFF7; /* clear TXREQ */
+        CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old;
         CANmodule->bufferInhibitFlag = false;
         tpdoDeleted = 1U;
     }
@@ -637,8 +637,8 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     uint16_t err;
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-    err = CAN_REG(CANmodule->CANdevicePtr, C_INTF) >> 8;
-    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 4){
+    err = CAN_REG(CANmodule->CANdriverState, C_INTF) >> 8;
+    if(CAN_REG(CANmodule->CANdriverState, C_INTF) & 4){
         err |= 0x80;
     }
 
@@ -648,7 +648,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
         /* CAN RX bus overflow */
         if(err & 0xC0){
             CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-            CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFB;/* clear bits */
+            CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFB;/* clear bits */
         }
 
         /* CAN TX bus off */
@@ -694,22 +694,22 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
     /* receive interrupt (New CAN message is available in RX FIFO buffer) */
-    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 0x02) {
+    if(CAN_REG(CANmodule->CANdriverState, C_INTF) & 0x02) {
         uint16_t C_CTRL1old;
         uint16_t C_RXFUL1copy;
         uint16_t C_FIFOcopy;
         uint8_t FNRB, FBP;
 
         CO_DISABLE_INTERRUPTS();
-        C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
-        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-        C_RXFUL1copy = CAN_REG(CANmodule->CANdevicePtr, C_RXFUL1);
-        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
+        C_CTRL1old = CAN_REG(CANmodule->CANdriverState, C_CTRL1);
+        CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+        C_RXFUL1copy = CAN_REG(CANmodule->CANdriverState, C_RXFUL1);
+        CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old;
 
         /* We will service the buffers indicated by RXFUL copy, clear interrupt
          * flag now and let interrupt hit again if more messages are received */
-        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFD;
-        C_FIFOcopy = CAN_REG(CANmodule->CANdevicePtr, C_FIFO);
+        CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFD;
+        C_FIFOcopy = CAN_REG(CANmodule->CANdriverState, C_FIFO);
         CO_ENABLE_INTERRUPTS();
 
         /* FNRB tells us which buffer to read in FIFO */
@@ -778,23 +778,23 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
             /* Clear RXFUL flag */
             CO_DISABLE_INTERRUPTS();
-            C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
-            CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-            CAN_REG(CANmodule->CANdevicePtr, C_RXFUL1) &= ~(mask);
-            CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
+            C_CTRL1old = CAN_REG(CANmodule->CANdriverState, C_CTRL1);
+            CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+            CAN_REG(CANmodule->CANdriverState, C_RXFUL1) &= ~(mask);
+            CAN_REG(CANmodule->CANdriverState, C_CTRL1) = C_CTRL1old;
             CO_ENABLE_INTERRUPTS();
             C_RXFUL1copy &= ~(mask);
 
             /* Now update FNRB, it will point to a new buffer after RXFUL was cleared */
-            FNRB = (CAN_REG(CANmodule->CANdevicePtr, C_FIFO) & 0x3F);
+            FNRB = (CAN_REG(CANmodule->CANdriverState, C_FIFO) & 0x3F);
         }
     }
 
     /* transmit interrupt (TX buffer is free) */
-    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 0x01) {
+    if(CAN_REG(CANmodule->CANdriverState, C_INTF) & 0x01) {
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFE;
+        CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFE;
         /* First CAN message (bootup) was sent successfully */
         CANmodule->firstCANtxMessage = false;
         /* clear flag from previous message */
@@ -814,7 +814,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    CO_CANsendToModule(CANmodule->CANdevicePtr, CANmodule->CANmsgBuff, buffer);
+                    CO_CANsendToModule(CANmodule->CANdriverState, CANmodule->CANmsgBuff, buffer);
                     break;                      /* exit for loop */
                 }
                 buffer++;

--- a/stack/PIC24_dsPIC33/CO_driver.c
+++ b/stack/PIC24_dsPIC33/CO_driver.c
@@ -61,7 +61,7 @@
 
 
 /* Macro and Constants - CAN module registers and DMA registers - offset. */
-    #define CAN_REG(base, offset) (*((volatile uint16_t *) (base + offset)))
+    #define CAN_REG(base, offset) (*((volatile uint16_t *) (((uintptr_t) base) + offset)))
 
     #define C_CTRL1      0x00
     #define C_CTRL2      0x02
@@ -120,29 +120,29 @@
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
-    uint16_t C_CTRL1copy = CAN_REG(CANbaseAddress, C_CTRL1);
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
+    uint16_t C_CTRL1copy = CAN_REG(CANdevicePtr, C_CTRL1);
 
     /* set REQOP = 0x4 */
     C_CTRL1copy &= 0xFCFF;
     C_CTRL1copy |= 0x0400;
-    CAN_REG(CANbaseAddress, C_CTRL1) = C_CTRL1copy;
+    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1copy;
 
     /* while OPMODE != 4 */
-    while((CAN_REG(CANbaseAddress, C_CTRL1) & 0x00E0) != 0x0080);
+    while((CAN_REG(CANdevicePtr, C_CTRL1) & 0x00E0) != 0x0080);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
-    uint16_t C_CTRL1copy = CAN_REG(CANmodule->CANbaseAddress, C_CTRL1);
+    uint16_t C_CTRL1copy = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
 
     /* set REQOP = 0x0 */
     C_CTRL1copy &= 0xF8FF;
-    CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1copy;
+    CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1copy;
 
     /* while OPMODE != 0 */
-    while((CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) & 0x00E0) != 0x0000);
+    while((CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) & 0x00E0) != 0x0000);
 
     CANmodule->CANnormal = true;
 }
@@ -151,7 +151,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -176,7 +176,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Get global addresses for CAN module 1 or 2. */
-    if(CANbaseAddress == ADDR_CAN1) {
+    if(CANdevicePtr == ADDR_CAN1) {
         DMArxBaseAddress = CO_CAN1_DMA0;
         DMAtxBaseAddress = CO_CAN1_DMA1;
         CANmsgBuff = &CO_CAN1msg[0];
@@ -187,7 +187,7 @@ CO_ReturnError_t CO_CANmodule_init(
     #endif
     }
 #if CO_CAN2msgBuffSize > 0
-    else if(CANbaseAddress == ADDR_CAN2) {
+    else if(((uintptr_t) CANdevicePtr) == ADDR_CAN2) {
         DMArxBaseAddress = CO_CAN2_DMA0;
         DMAtxBaseAddress = CO_CAN2_DMA1;
         CANmsgBuff = &CO_CAN2msg[0];
@@ -203,7 +203,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->CANmsgBuff = CANmsgBuff;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -227,8 +227,8 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control registers */
-    CAN_REG(CANbaseAddress, C_CTRL1) = 0x0400;
-    CAN_REG(CANbaseAddress, C_CTRL2) = 0x0000;
+    CAN_REG(CANdevicePtr, C_CTRL1) = 0x0400;
+    CAN_REG(CANdevicePtr, C_CTRL2) = 0x0000;
 
 
     /* Configure CAN timing */
@@ -245,40 +245,40 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     if(CO_CANbitRateData[i].scale == 2)
-        CAN_REG(CANbaseAddress, C_CTRL1) |= 0x0800;
+        CAN_REG(CANdevicePtr, C_CTRL1) |= 0x0800;
 
-    CAN_REG(CANbaseAddress, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
+    CAN_REG(CANdevicePtr, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
                                         (CO_CANbitRateData[i].BRP - 1);
 
-    CAN_REG(CANbaseAddress, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
+    CAN_REG(CANdevicePtr, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
                                         0x0080 |
                                         (CO_CANbitRateData[i].phSeg1 - 1) << 3 |
                                         (CO_CANbitRateData[i].PROP - 1);
 
 
     /* setup RX and TX control registers */
-    CAN_REG(CANbaseAddress, C_CTRL1) &= 0xFFFE;     /* WIN = 0 - use buffer registers */
-    CAN_REG(CANbaseAddress, C_RXFUL1) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXFUL2) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXOVF1) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXOVF2) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TR01CON) = 0x0080;    /* use one buffer for transmission */
-    CAN_REG(CANbaseAddress, C_TR23CON) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TR45CON) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TR67CON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_CTRL1) &= 0xFFFE;     /* WIN = 0 - use buffer registers */
+    CAN_REG(CANdevicePtr, C_RXFUL1) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXFUL2) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXOVF1) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXOVF2) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TR01CON) = 0x0080;    /* use one buffer for transmission */
+    CAN_REG(CANdevicePtr, C_TR23CON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TR45CON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TR67CON) = 0x0000;
 
 
     /* CAN module hardware filters */
-    CAN_REG(CANbaseAddress, C_CTRL1) |= 0x0001;     /* WIN = 1 - use filter registers */
-    CAN_REG(CANbaseAddress, C_FEN1) = 0xFFFF;       /* enable all 16 filters */
-    CAN_REG(CANbaseAddress, C_FMSKSEL1) = 0x0000;   /* all filters are using mask 0 */
-    CAN_REG(CANbaseAddress, C_FMSKSEL2) = 0x0000;
-    CAN_REG(CANbaseAddress, C_BUFPNT1) = 0xFFFF;    /* use FIFO for all filters */
-    CAN_REG(CANbaseAddress, C_BUFPNT2) = 0xFFFF;
-    CAN_REG(CANbaseAddress, C_BUFPNT3) = 0xFFFF;
-    CAN_REG(CANbaseAddress, C_BUFPNT4) = 0xFFFF;
+    CAN_REG(CANdevicePtr, C_CTRL1) |= 0x0001;     /* WIN = 1 - use filter registers */
+    CAN_REG(CANdevicePtr, C_FEN1) = 0xFFFF;       /* enable all 16 filters */
+    CAN_REG(CANdevicePtr, C_FMSKSEL1) = 0x0000;   /* all filters are using mask 0 */
+    CAN_REG(CANdevicePtr, C_FMSKSEL2) = 0x0000;
+    CAN_REG(CANdevicePtr, C_BUFPNT1) = 0xFFFF;    /* use FIFO for all filters */
+    CAN_REG(CANdevicePtr, C_BUFPNT2) = 0xFFFF;
+    CAN_REG(CANdevicePtr, C_BUFPNT3) = 0xFFFF;
+    CAN_REG(CANdevicePtr, C_BUFPNT4) = 0xFFFF;
     /* set all filters to 0 */
-    pRXF = &CAN_REG(CANbaseAddress, C_RXF0SID);
+    pRXF = &CAN_REG(CANdevicePtr, C_RXF0SID);
     for(i=0; i<16; i++){
         *pRXF = 0x0000;
         pRXF += 2;
@@ -288,44 +288,44 @@ CO_ReturnError_t CO_CANmodule_init(
         /* CO_CANrxBufferInit() functions, called by separate CANopen */
         /* init functions. */
         /* All mask bits are 1, so received message must match filter */
-        CAN_REG(CANbaseAddress, C_RXM0SID) = 0xFFE8;
-        CAN_REG(CANbaseAddress, C_RXM1SID) = 0xFFE8;
-        CAN_REG(CANbaseAddress, C_RXM2SID) = 0xFFE8;
+        CAN_REG(CANdevicePtr, C_RXM0SID) = 0xFFE8;
+        CAN_REG(CANdevicePtr, C_RXM1SID) = 0xFFE8;
+        CAN_REG(CANdevicePtr, C_RXM2SID) = 0xFFE8;
     }
     else{
         /* CAN module filters are not used, all messages with standard 11-bit */
         /* identifier will be received */
         /* Set masks so, that all messages with standard identifier are accepted */
-        CAN_REG(CANbaseAddress, C_RXM0SID) = 0x0008;
-        CAN_REG(CANbaseAddress, C_RXM1SID) = 0x0008;
-        CAN_REG(CANbaseAddress, C_RXM2SID) = 0x0008;
+        CAN_REG(CANdevicePtr, C_RXM0SID) = 0x0008;
+        CAN_REG(CANdevicePtr, C_RXM1SID) = 0x0008;
+        CAN_REG(CANdevicePtr, C_RXM2SID) = 0x0008;
     }
 
     /* WIN = 0 - use buffer registers for default */
-    CAN_REG(CANbaseAddress, C_CTRL1) &= 0xFFFE;
+    CAN_REG(CANdevicePtr, C_CTRL1) &= 0xFFFE;
 
 
     /* Configure DMA controller */
     /* Set size of buffer in DMA RAM (FIFO Area Starts with Tx/Rx buffer TRB1 (FSA = 1)) */
     /* Use maximum 16 buffers, because we have 16-bit system. */
     if (CANmsgBuffSize >= 16) {
-        CAN_REG(CANbaseAddress, C_FCTRL) = 0x8001;
+        CAN_REG(CANdevicePtr, C_FCTRL) = 0x8001;
         CANmodule->CANmsgBuffSize = 16;
     }
     else if(CANmsgBuffSize >= 12) {
-        CAN_REG(CANbaseAddress, C_FCTRL) = 0x6001;
+        CAN_REG(CANdevicePtr, C_FCTRL) = 0x6001;
         CANmodule->CANmsgBuffSize = 12;
     }
     else if(CANmsgBuffSize >=  8) {
-        CAN_REG(CANbaseAddress, C_FCTRL) = 0x4001;
+        CAN_REG(CANdevicePtr, C_FCTRL) = 0x4001;
         CANmodule->CANmsgBuffSize = 8;
     }
     else if(CANmsgBuffSize >=  6) {
-        CAN_REG(CANbaseAddress, C_FCTRL) = 0x2001;
+        CAN_REG(CANdevicePtr, C_FCTRL) = 0x2001;
         CANmodule->CANmsgBuffSize = 6;
     }
     else if(CANmsgBuffSize >=  4) {
-        CAN_REG(CANbaseAddress, C_FCTRL) = 0x0001;
+        CAN_REG(CANdevicePtr, C_FCTRL) = 0x0001;
         CANmodule->CANmsgBuffSize = 4;
     }
     else {
@@ -334,9 +334,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* DMA chanel initialization for ECAN reception */
     DMA_REG(DMArxBaseAddress, DMA_CON) = 0x0020;
-    DMA_REG(DMArxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANbaseAddress, C_RXD);
+    DMA_REG(DMArxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdevicePtr, C_RXD);
     DMA_REG(DMArxBaseAddress, DMA_CNT) = 7;
-    DMA_REG(DMArxBaseAddress, DMA_REQ) = (CANbaseAddress==ADDR_CAN1) ? 34 : 55;
+    DMA_REG(DMArxBaseAddress, DMA_REQ) = (CANdevicePtr==ADDR_CAN1) ? 34 : 55;
 
 #ifndef __HAS_EDS__
     DMA_REG(DMArxBaseAddress, DMA_STA) = CANmsgBuffDMAoffset;
@@ -349,9 +349,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* DMA chanel initialization for ECAN transmission */
     DMA_REG(DMAtxBaseAddress, DMA_CON) = 0x2020;
-    DMA_REG(DMAtxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANbaseAddress, C_TXD);
+    DMA_REG(DMAtxBaseAddress, DMA_PAD) = (volatile uint16_t) &CAN_REG(CANdevicePtr, C_TXD);
     DMA_REG(DMAtxBaseAddress, DMA_CNT) = 7;
-    DMA_REG(DMAtxBaseAddress, DMA_REQ) = (CANbaseAddress==ADDR_CAN1) ? 70 : 71;
+    DMA_REG(DMAtxBaseAddress, DMA_REQ) = (CANdevicePtr==ADDR_CAN1) ? 70 : 71;
 
 #ifndef __HAS_EDS__
     DMA_REG(DMAtxBaseAddress, DMA_STA) = CANmsgBuffDMAoffset;
@@ -365,9 +365,9 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* CAN interrupt registers */
     /* clear interrupt flags */
-    CAN_REG(CANbaseAddress, C_INTF) = 0x0000;
+    CAN_REG(CANdevicePtr, C_INTF) = 0x0000;
     /* enable receive and transmit interrupt */
-    CAN_REG(CANbaseAddress, C_INTE) = 0x0003;
+    CAN_REG(CANdevicePtr, C_INTE) = 0x0003;
     /* CAN interrupt (combined) must be configured by application */
 
     return CO_ERROR_NO;
@@ -376,7 +376,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANbaseAddress);
+    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
 }
 
 
@@ -402,7 +402,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
         /* buffer, which will be configured */
         CO_CANrx_t *buffer = &CANmodule->rxArray[index];
         uint16_t RXF, RXM;
-        uint16_t addr = CANmodule->CANbaseAddress;
+        uint16_t addr = CANmodule->CANdevicePtr;
 
         /* Configure object variables */
         buffer->object = object;
@@ -524,11 +524,11 @@ CO_CANtx_t *CO_CANtxBufferInit(
 
 /* Copy message to CAN module - internal usage only.
  *
- * @param CANbaseAddress CAN module base address
+ * @param CANdevicePtr CAN module base address
  * @param dest Pointer to CAN module transmit buffer
  * @param src Pointer to source message
  */
-static void CO_CANsendToModule(uint16_t CANbaseAddress, __eds__ CO_CANrxMsg_t *dest, CO_CANtx_t *src){
+static void CO_CANsendToModule(void *CANdevicePtr, __eds__ CO_CANrxMsg_t *dest, CO_CANtx_t *src){
     uint8_t DLC;
     __eds__ uint8_t *CANdataBuffer;
     uint8_t *pData;
@@ -548,17 +548,17 @@ static void CO_CANsendToModule(uint16_t CANbaseAddress, __eds__ CO_CANrxMsg_t *d
     for(; DLC>0; DLC--) *(CANdataBuffer++) = *(pData++);
 
     /* control register, transmit request */
-    C_CTRL1old = CAN_REG(CANbaseAddress, C_CTRL1);
-    CAN_REG(CANbaseAddress, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-    CAN_REG(CANbaseAddress, C_TR01CON) |= 0x08;
-    CAN_REG(CANbaseAddress, C_CTRL1) = C_CTRL1old;
+    C_CTRL1old = CAN_REG(CANdevicePtr, C_CTRL1);
+    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+    CAN_REG(CANdevicePtr, C_TR01CON) |= 0x08;
+    CAN_REG(CANdevicePtr, C_CTRL1) = C_CTRL1old;
 }
 
 
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANbaseAddress;
+    uint16_t addr = CANmodule->CANdevicePtr;
     volatile uint16_t C_CTRL1old, C_TR01CONcopy;
 
     /* Verify overflow */
@@ -601,10 +601,10 @@ void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule){
     /* Abort message from CAN module, if there is synchronous TPDO.
      * Take special care with this functionality. */
     if(CANmodule->bufferInhibitFlag){
-        volatile uint16_t C_CTRL1old = CAN_REG(CANmodule->CANbaseAddress, C_CTRL1);
-        CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-        CAN_REG(CANmodule->CANbaseAddress, C_TR01CON) &= 0xFFF7; /* clear TXREQ */
-        CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old;
+        volatile uint16_t C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
+        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+        CAN_REG(CANmodule->CANdevicePtr, C_TR01CON) &= 0xFFF7; /* clear TXREQ */
+        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
         CANmodule->bufferInhibitFlag = false;
         tpdoDeleted = 1U;
     }
@@ -637,8 +637,8 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     uint16_t err;
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-    err = CAN_REG(CANmodule->CANbaseAddress, C_INTF) >> 8;
-    if(CAN_REG(CANmodule->CANbaseAddress, C_INTF) & 4){
+    err = CAN_REG(CANmodule->CANdevicePtr, C_INTF) >> 8;
+    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 4){
         err |= 0x80;
     }
 
@@ -648,7 +648,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
         /* CAN RX bus overflow */
         if(err & 0xC0){
             CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-            CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFB;/* clear bits */
+            CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFB;/* clear bits */
         }
 
         /* CAN TX bus off */
@@ -694,22 +694,22 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
     /* receive interrupt (New CAN message is available in RX FIFO buffer) */
-    if(CAN_REG(CANmodule->CANbaseAddress, C_INTF) & 0x02) {
+    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 0x02) {
         uint16_t C_CTRL1old;
         uint16_t C_RXFUL1copy;
         uint16_t C_FIFOcopy;
         uint8_t FNRB, FBP;
 
         CO_DISABLE_INTERRUPTS();
-        C_CTRL1old = CAN_REG(CANmodule->CANbaseAddress, C_CTRL1);
-        CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-        C_RXFUL1copy = CAN_REG(CANmodule->CANbaseAddress, C_RXFUL1);
-        CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old;
+        C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
+        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+        C_RXFUL1copy = CAN_REG(CANmodule->CANdevicePtr, C_RXFUL1);
+        CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
 
         /* We will service the buffers indicated by RXFUL copy, clear interrupt
          * flag now and let interrupt hit again if more messages are received */
-        CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFD;
-        C_FIFOcopy = CAN_REG(CANmodule->CANbaseAddress, C_FIFO);
+        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFD;
+        C_FIFOcopy = CAN_REG(CANmodule->CANdevicePtr, C_FIFO);
         CO_ENABLE_INTERRUPTS();
 
         /* FNRB tells us which buffer to read in FIFO */
@@ -778,23 +778,23 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
             /* Clear RXFUL flag */
             CO_DISABLE_INTERRUPTS();
-            C_CTRL1old = CAN_REG(CANmodule->CANbaseAddress, C_CTRL1);
-            CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
-            CAN_REG(CANmodule->CANbaseAddress, C_RXFUL1) &= ~(mask);
-            CAN_REG(CANmodule->CANbaseAddress, C_CTRL1) = C_CTRL1old;
+            C_CTRL1old = CAN_REG(CANmodule->CANdevicePtr, C_CTRL1);
+            CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old & 0xFFFE;     /* WIN = 0 - use buffer registers */
+            CAN_REG(CANmodule->CANdevicePtr, C_RXFUL1) &= ~(mask);
+            CAN_REG(CANmodule->CANdevicePtr, C_CTRL1) = C_CTRL1old;
             CO_ENABLE_INTERRUPTS();
             C_RXFUL1copy &= ~(mask);
 
             /* Now update FNRB, it will point to a new buffer after RXFUL was cleared */
-            FNRB = (CAN_REG(CANmodule->CANbaseAddress, C_FIFO) & 0x3F);
+            FNRB = (CAN_REG(CANmodule->CANdevicePtr, C_FIFO) & 0x3F);
         }
     }
 
     /* transmit interrupt (TX buffer is free) */
-    if(CAN_REG(CANmodule->CANbaseAddress, C_INTF) & 0x01) {
+    if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 0x01) {
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFE;
+        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFE;
         /* First CAN message (bootup) was sent successfully */
         CANmodule->firstCANtxMessage = false;
         /* clear flag from previous message */
@@ -814,7 +814,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule) {
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    CO_CANsendToModule(CANmodule->CANbaseAddress, CANmodule->CANmsgBuff, buffer);
+                    CO_CANsendToModule(CANmodule->CANdevicePtr, CANmodule->CANmsgBuff, buffer);
                     break;                      /* exit for loop */
                 }
                 buffer++;

--- a/stack/PIC24_dsPIC33/CO_driver.h
+++ b/stack/PIC24_dsPIC33/CO_driver.h
@@ -444,7 +444,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     __eds__ CO_CANrxMsg_t *CANmsgBuff;  /* dsPIC33F specific: CAN message buffer for CAN module */
     uint8_t             CANmsgBuffSize; /* dsPIC33F specific: Size of the above buffer */
     CO_CANrx_t         *rxArray;
@@ -466,14 +466,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/PIC24_dsPIC33/CO_driver.h
+++ b/stack/PIC24_dsPIC33/CO_driver.h
@@ -444,7 +444,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    uint16_t            CANbaseAddress;
+    void               *CANdevicePtr;
     __eds__ CO_CANrxMsg_t *CANmsgBuff;  /* dsPIC33F specific: CAN message buffer for CAN module */
     uint8_t             CANmsgBuffSize; /* dsPIC33F specific: Size of the above buffer */
     CO_CANrx_t         *rxArray;
@@ -466,14 +466,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/PIC32/CO_driver.c
+++ b/stack/PIC32/CO_driver.c
@@ -54,7 +54,7 @@ unsigned int CO_interruptStatus = 0;
 /**
  * Macro and Constants - CAN module registers
  */
-    #define CAN_REG(base, offset) (*((volatile uint32_t *) ((base) + _CAN1_BASE_ADDRESS + (offset))))
+    #define CAN_REG(base, offset) (*((volatile uint32_t *) (((uintptr_t) base) + _CAN1_BASE_ADDRESS + (offset))))
 
     #define CLR          0x04
     #define SET          0x08
@@ -91,20 +91,20 @@ unsigned int CO_interruptStatus = 0;
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
-    uint32_t C_CONcopy = CAN_REG(CANbaseAddress, C_CON);
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
+    uint32_t C_CONcopy = CAN_REG(CANdevicePtr, C_CON);
 
     /* switch ON can module */
     C_CONcopy |= 0x00008000;
-    CAN_REG(CANbaseAddress, C_CON) = C_CONcopy;
+    CAN_REG(CANdevicePtr, C_CON) = C_CONcopy;
 
     /* request configuration mode */
     C_CONcopy &= 0xF8FFFFFF;
     C_CONcopy |= 0x04000000;
-    CAN_REG(CANbaseAddress, C_CON) = C_CONcopy;
+    CAN_REG(CANdevicePtr, C_CON) = C_CONcopy;
 
     /* wait for configuration mode */
-    while((CAN_REG(CANbaseAddress, C_CON) & 0x00E00000) != 0x00800000);
+    while((CAN_REG(CANdevicePtr, C_CON) & 0x00E00000) != 0x00800000);
 }
 
 
@@ -112,10 +112,10 @@ void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 
     /* request normal mode */
-    CAN_REG(CANmodule->CANbaseAddress, C_CON+CLR) = 0x07000000;
+    CAN_REG(CANmodule->CANdevicePtr, C_CON+CLR) = 0x07000000;
 
     /* wait for normal mode */
-    while((CAN_REG(CANmodule->CANbaseAddress, C_CON) & 0x00E00000) != 0x00000000);
+    while((CAN_REG(CANmodule->CANdevicePtr, C_CON) & 0x00E00000) != 0x00000000);
 
     CANmodule->CANnormal = true;
 }
@@ -124,7 +124,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -139,7 +139,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->CANmsgBuffSize = 33; /* Must be the same as size of CANmodule->CANmsgBuff array. */
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -170,13 +170,13 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control register (configuration mode, receive timer stamp is enabled, module is on) */
-    CAN_REG(CANbaseAddress, C_CON) = 0x04108000;
+    CAN_REG(CANdevicePtr, C_CON) = 0x04108000;
 
 
     /* Configure FIFO */
-    CAN_REG(CANbaseAddress, C_FIFOBA) = CO_KVA_TO_PA(CANmodule->CANmsgBuff);/* FIFO base address */
-    CAN_REG(CANbaseAddress, C_FIFOCON) = (NO_CAN_RXF==32) ? 0x001F0000 : 0x000F0000;     /* FIFO0: receive FIFO, 32(16) buffers */
-    CAN_REG(CANbaseAddress, C_FIFOCON+0x40) = 0x00000080;/* FIFO1: transmit FIFO, 1 buffer */
+    CAN_REG(CANdevicePtr, C_FIFOBA) = CO_KVA_TO_PA(CANmodule->CANmsgBuff);/* FIFO base address */
+    CAN_REG(CANdevicePtr, C_FIFOCON) = (NO_CAN_RXF==32) ? 0x001F0000 : 0x000F0000;     /* FIFO0: receive FIFO, 32(16) buffers */
+    CAN_REG(CANdevicePtr, C_FIFOCON+0x40) = 0x00000080;/* FIFO1: transmit FIFO, 1 buffer */
 
 
     /* Configure CAN timing */
@@ -191,7 +191,7 @@ CO_ReturnError_t CO_CANmodule_init(
         case 800:  i=6; break;
         case 1000: i=7; break;
     }
-    CAN_REG(CANbaseAddress, C_CFG) =
+    CAN_REG(CANdevicePtr, C_CFG) =
         ((uint32_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 16 |  /* SEG2PH */
         0x00008000                                            |  /* SEG2PHTS = 1, SAM = 0 */
         ((uint32_t)(CO_CANbitRateData[i].phSeg1 - 1)) << 11 |  /* SEG1PH */
@@ -203,35 +203,35 @@ CO_ReturnError_t CO_CANmodule_init(
     /* CAN module hardware filters */
     /* clear all filter control registers (disable filters, mask 0 and FIFO 0 selected for all filters) */
     for(i=0; i<(NO_CAN_RXF/4); i++)
-        CAN_REG(CANbaseAddress, C_FLTCON+i*0x10) = 0x00000000;
+        CAN_REG(CANdevicePtr, C_FLTCON+i*0x10) = 0x00000000;
     if(CANmodule->useCANrxFilters){
         /* CAN module filters are used, they will be configured with */
         /* CO_CANrxBufferInit() functions, called by separate CANopen */
         /* init functions. */
         /* Configure all masks so, that received message must match filter */
-        CAN_REG(CANbaseAddress, C_RXM) = 0xFFE80000;
-        CAN_REG(CANbaseAddress, C_RXM+0x10) = 0xFFE80000;
-        CAN_REG(CANbaseAddress, C_RXM+0x20) = 0xFFE80000;
-        CAN_REG(CANbaseAddress, C_RXM+0x30) = 0xFFE80000;
+        CAN_REG(CANdevicePtr, C_RXM) = 0xFFE80000;
+        CAN_REG(CANdevicePtr, C_RXM+0x10) = 0xFFE80000;
+        CAN_REG(CANdevicePtr, C_RXM+0x20) = 0xFFE80000;
+        CAN_REG(CANdevicePtr, C_RXM+0x30) = 0xFFE80000;
     }
     else{
         /* CAN module filters are not used, all messages with standard 11-bit */
         /* identifier will be received */
         /* Configure mask 0 so, that all messages with standard identifier are accepted */
-        CAN_REG(CANbaseAddress, C_RXM) = 0x00080000;
+        CAN_REG(CANdevicePtr, C_RXM) = 0x00080000;
         /* configure one filter for FIFO 0 and enable it */
-        CAN_REG(CANbaseAddress, C_RXF) = 0x00000000;
-        CAN_REG(CANbaseAddress, C_FLTCON) = 0x00000080;
+        CAN_REG(CANdevicePtr, C_RXF) = 0x00000000;
+        CAN_REG(CANdevicePtr, C_FLTCON) = 0x00000080;
     }
 
 
     /* CAN interrupt registers */
     /* Enable 'RX buffer not empty' (RXNEMPTYIE) interrupt in FIFO 0 (third layer interrupt) */
-    CAN_REG(CANbaseAddress, C_FIFOINT) = 0x00010000;
+    CAN_REG(CANdevicePtr, C_FIFOINT) = 0x00010000;
     /* Enable 'Tx buffer empty' (TXEMPTYIE) interrupt in FIFO 1 (third layer interrupt) */
-    CAN_REG(CANbaseAddress, C_FIFOINT+0x40) = 0x00000000; /* will be enabled in CO_CANsend */
+    CAN_REG(CANdevicePtr, C_FIFOINT+0x40) = 0x00000000; /* will be enabled in CO_CANsend */
     /* Enable receive (RBIE) and transmit (TBIE) buffer interrupt (secont layer interrupt) */
-    CAN_REG(CANbaseAddress, C_INT) = 0x00030000;
+    CAN_REG(CANdevicePtr, C_INT) = 0x00030000;
     /* CAN interrupt (first layer) must be configured by application */
 
     return CO_ERROR_NO;
@@ -240,7 +240,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANbaseAddress);
+    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
 }
 
 
@@ -284,7 +284,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
             volatile uint32_t *pRXM0, *pRXM1, *pRXM2, *pRXM3;
             volatile uint8_t *pFLTCON;
             uint8_t selectMask;
-            uint16_t addr = CANmodule->CANbaseAddress;
+            uint16_t addr = CANmodule->CANdevicePtr;
 
             /* get correct part of the filter control register */
             pFLTCON = (volatile uint8_t*)(&CAN_REG(addr, C_FLTCON)); /* pointer to first filter control register */
@@ -374,7 +374,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANbaseAddress;
+    uint16_t addr = CANmodule->CANdevicePtr;
     volatile uint32_t* TX_FIFOcon = &CAN_REG(addr, C_FIFOCON+0x40);
     volatile uint32_t* TX_FIFOconSet = &CAN_REG(addr, C_FIFOCON+0x48);
     uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(addr, C_FIFOUA+0x40));
@@ -420,8 +420,8 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
 /******************************************************************************/
 void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule){
     uint32_t tpdoDeleted = 0U;
-    volatile uint32_t* TX_FIFOcon = &CAN_REG(CANmodule->CANbaseAddress, C_FIFOCON+0x40);
-    volatile uint32_t* TX_FIFOconClr = &CAN_REG(CANmodule->CANbaseAddress, C_FIFOCON+0x44);
+    volatile uint32_t* TX_FIFOcon = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x40);
+    volatile uint32_t* TX_FIFOconClr = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x44);
 
     CO_LOCK_CAN_SEND();
     /* Abort message from CAN module, if there is synchronous TPDO.
@@ -462,11 +462,11 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
     uint32_t err;
 
-    TREC = CAN_REG(CANmodule->CANbaseAddress, C_TREC);
+    TREC = CAN_REG(CANmodule->CANdevicePtr, C_TREC);
     rxErrors = (uint8_t) TREC;
     txErrors = (uint8_t) (TREC>>8);
     if(TREC&0x00200000) txErrors = 256; /* bus off */
-    overflow = (CAN_REG(CANmodule->CANbaseAddress, C_FIFOINT)&0x8) ? 1 : 0;
+    overflow = (CAN_REG(CANmodule->CANdevicePtr, C_FIFOINT)&0x8) ? 1 : 0;
 
     err = ((uint32_t)txErrors << 16) | ((uint32_t)rxErrors << 8) | overflow;
 
@@ -518,7 +518,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
     uint8_t ICODE;
-    ICODE = (uint8_t) CAN_REG(CANmodule->CANbaseAddress, C_VEC) & 0x7F;
+    ICODE = (uint8_t) CAN_REG(CANmodule->CANdevicePtr, C_VEC) & 0x7F;
 
     /* receive interrupt (New CAN message is available in RX FIFO 0 buffer) */
     if(ICODE == 0){
@@ -528,7 +528,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) CO_PA_TO_KVA1(CAN_REG(CANmodule->CANbaseAddress, C_FIFOUA));
+        rcvMsg = (CO_CANrxMsg_t*) CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdevicePtr, C_FIFOUA));
         rcvMsgIdent = rcvMsg->ident;
         if(rcvMsg->RTR) rcvMsgIdent |= 0x0800;
         if(CANmodule->useCANrxFilters){
@@ -562,7 +562,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         }
 
         /* Update the message buffer pointer */
-        CAN_REG(CANmodule->CANbaseAddress, C_FIFOCON+0x08) = 0x2000;   /* set UINC */
+        CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x08) = 0x2000;   /* set UINC */
     }
 
 
@@ -587,9 +587,9 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(CANmodule->CANbaseAddress, C_FIFOUA+0x40));
+                    uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdevicePtr, C_FIFOUA+0x40));
                     uint32_t* message = (uint32_t*) buffer;
-                    volatile uint32_t* TX_FIFOconSet = &CAN_REG(CANmodule->CANbaseAddress, C_FIFOCON+0x48);
+                    volatile uint32_t* TX_FIFOconSet = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x48);
                     *(TXmsgBuffer++) = *(message++);
                     *(TXmsgBuffer++) = *(message++);
                     *(TXmsgBuffer++) = *(message++);
@@ -609,7 +609,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
         /* if no more messages, disable 'Tx buffer empty' (TXEMPTYIE) interrupt */
         if(CANmodule->CANtxCount == 0U){
-            CAN_REG(CANmodule->CANbaseAddress, C_FIFOINT+0x44) = 0x01000000;
+            CAN_REG(CANmodule->CANdevicePtr, C_FIFOINT+0x44) = 0x01000000;
         }
     }
 }

--- a/stack/PIC32/CO_driver.c
+++ b/stack/PIC32/CO_driver.c
@@ -91,20 +91,20 @@ unsigned int CO_interruptStatus = 0;
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
-    uint32_t C_CONcopy = CAN_REG(CANdevicePtr, C_CON);
+void CO_CANsetConfigurationMode(void *CANdriverState){
+    uint32_t C_CONcopy = CAN_REG(CANdriverState, C_CON);
 
     /* switch ON can module */
     C_CONcopy |= 0x00008000;
-    CAN_REG(CANdevicePtr, C_CON) = C_CONcopy;
+    CAN_REG(CANdriverState, C_CON) = C_CONcopy;
 
     /* request configuration mode */
     C_CONcopy &= 0xF8FFFFFF;
     C_CONcopy |= 0x04000000;
-    CAN_REG(CANdevicePtr, C_CON) = C_CONcopy;
+    CAN_REG(CANdriverState, C_CON) = C_CONcopy;
 
     /* wait for configuration mode */
-    while((CAN_REG(CANdevicePtr, C_CON) & 0x00E00000) != 0x00800000);
+    while((CAN_REG(CANdriverState, C_CON) & 0x00E00000) != 0x00800000);
 }
 
 
@@ -112,10 +112,10 @@ void CO_CANsetConfigurationMode(void *CANdevicePtr){
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 
     /* request normal mode */
-    CAN_REG(CANmodule->CANdevicePtr, C_CON+CLR) = 0x07000000;
+    CAN_REG(CANmodule->CANdriverState, C_CON+CLR) = 0x07000000;
 
     /* wait for normal mode */
-    while((CAN_REG(CANmodule->CANdevicePtr, C_CON) & 0x00E00000) != 0x00000000);
+    while((CAN_REG(CANmodule->CANdriverState, C_CON) & 0x00E00000) != 0x00000000);
 
     CANmodule->CANnormal = true;
 }
@@ -124,7 +124,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -139,7 +139,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->CANmsgBuffSize = 33; /* Must be the same as size of CANmodule->CANmsgBuff array. */
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
@@ -170,13 +170,13 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control register (configuration mode, receive timer stamp is enabled, module is on) */
-    CAN_REG(CANdevicePtr, C_CON) = 0x04108000;
+    CAN_REG(CANdriverState, C_CON) = 0x04108000;
 
 
     /* Configure FIFO */
-    CAN_REG(CANdevicePtr, C_FIFOBA) = CO_KVA_TO_PA(CANmodule->CANmsgBuff);/* FIFO base address */
-    CAN_REG(CANdevicePtr, C_FIFOCON) = (NO_CAN_RXF==32) ? 0x001F0000 : 0x000F0000;     /* FIFO0: receive FIFO, 32(16) buffers */
-    CAN_REG(CANdevicePtr, C_FIFOCON+0x40) = 0x00000080;/* FIFO1: transmit FIFO, 1 buffer */
+    CAN_REG(CANdriverState, C_FIFOBA) = CO_KVA_TO_PA(CANmodule->CANmsgBuff);/* FIFO base address */
+    CAN_REG(CANdriverState, C_FIFOCON) = (NO_CAN_RXF==32) ? 0x001F0000 : 0x000F0000;     /* FIFO0: receive FIFO, 32(16) buffers */
+    CAN_REG(CANdriverState, C_FIFOCON+0x40) = 0x00000080;/* FIFO1: transmit FIFO, 1 buffer */
 
 
     /* Configure CAN timing */
@@ -191,7 +191,7 @@ CO_ReturnError_t CO_CANmodule_init(
         case 800:  i=6; break;
         case 1000: i=7; break;
     }
-    CAN_REG(CANdevicePtr, C_CFG) =
+    CAN_REG(CANdriverState, C_CFG) =
         ((uint32_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 16 |  /* SEG2PH */
         0x00008000                                            |  /* SEG2PHTS = 1, SAM = 0 */
         ((uint32_t)(CO_CANbitRateData[i].phSeg1 - 1)) << 11 |  /* SEG1PH */
@@ -203,35 +203,35 @@ CO_ReturnError_t CO_CANmodule_init(
     /* CAN module hardware filters */
     /* clear all filter control registers (disable filters, mask 0 and FIFO 0 selected for all filters) */
     for(i=0; i<(NO_CAN_RXF/4); i++)
-        CAN_REG(CANdevicePtr, C_FLTCON+i*0x10) = 0x00000000;
+        CAN_REG(CANdriverState, C_FLTCON+i*0x10) = 0x00000000;
     if(CANmodule->useCANrxFilters){
         /* CAN module filters are used, they will be configured with */
         /* CO_CANrxBufferInit() functions, called by separate CANopen */
         /* init functions. */
         /* Configure all masks so, that received message must match filter */
-        CAN_REG(CANdevicePtr, C_RXM) = 0xFFE80000;
-        CAN_REG(CANdevicePtr, C_RXM+0x10) = 0xFFE80000;
-        CAN_REG(CANdevicePtr, C_RXM+0x20) = 0xFFE80000;
-        CAN_REG(CANdevicePtr, C_RXM+0x30) = 0xFFE80000;
+        CAN_REG(CANdriverState, C_RXM) = 0xFFE80000;
+        CAN_REG(CANdriverState, C_RXM+0x10) = 0xFFE80000;
+        CAN_REG(CANdriverState, C_RXM+0x20) = 0xFFE80000;
+        CAN_REG(CANdriverState, C_RXM+0x30) = 0xFFE80000;
     }
     else{
         /* CAN module filters are not used, all messages with standard 11-bit */
         /* identifier will be received */
         /* Configure mask 0 so, that all messages with standard identifier are accepted */
-        CAN_REG(CANdevicePtr, C_RXM) = 0x00080000;
+        CAN_REG(CANdriverState, C_RXM) = 0x00080000;
         /* configure one filter for FIFO 0 and enable it */
-        CAN_REG(CANdevicePtr, C_RXF) = 0x00000000;
-        CAN_REG(CANdevicePtr, C_FLTCON) = 0x00000080;
+        CAN_REG(CANdriverState, C_RXF) = 0x00000000;
+        CAN_REG(CANdriverState, C_FLTCON) = 0x00000080;
     }
 
 
     /* CAN interrupt registers */
     /* Enable 'RX buffer not empty' (RXNEMPTYIE) interrupt in FIFO 0 (third layer interrupt) */
-    CAN_REG(CANdevicePtr, C_FIFOINT) = 0x00010000;
+    CAN_REG(CANdriverState, C_FIFOINT) = 0x00010000;
     /* Enable 'Tx buffer empty' (TXEMPTYIE) interrupt in FIFO 1 (third layer interrupt) */
-    CAN_REG(CANdevicePtr, C_FIFOINT+0x40) = 0x00000000; /* will be enabled in CO_CANsend */
+    CAN_REG(CANdriverState, C_FIFOINT+0x40) = 0x00000000; /* will be enabled in CO_CANsend */
     /* Enable receive (RBIE) and transmit (TBIE) buffer interrupt (secont layer interrupt) */
-    CAN_REG(CANdevicePtr, C_INT) = 0x00030000;
+    CAN_REG(CANdriverState, C_INT) = 0x00030000;
     /* CAN interrupt (first layer) must be configured by application */
 
     return CO_ERROR_NO;
@@ -240,7 +240,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
+    CO_CANsetConfigurationMode(CANmodule->CANdriverState);
 }
 
 
@@ -284,7 +284,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
             volatile uint32_t *pRXM0, *pRXM1, *pRXM2, *pRXM3;
             volatile uint8_t *pFLTCON;
             uint8_t selectMask;
-            uint16_t addr = CANmodule->CANdevicePtr;
+            uint16_t addr = CANmodule->CANdriverState;
 
             /* get correct part of the filter control register */
             pFLTCON = (volatile uint8_t*)(&CAN_REG(addr, C_FLTCON)); /* pointer to first filter control register */
@@ -374,7 +374,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANdevicePtr;
+    uint16_t addr = CANmodule->CANdriverState;
     volatile uint32_t* TX_FIFOcon = &CAN_REG(addr, C_FIFOCON+0x40);
     volatile uint32_t* TX_FIFOconSet = &CAN_REG(addr, C_FIFOCON+0x48);
     uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(addr, C_FIFOUA+0x40));
@@ -420,8 +420,8 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
 /******************************************************************************/
 void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule){
     uint32_t tpdoDeleted = 0U;
-    volatile uint32_t* TX_FIFOcon = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x40);
-    volatile uint32_t* TX_FIFOconClr = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x44);
+    volatile uint32_t* TX_FIFOcon = &CAN_REG(CANmodule->CANdriverState, C_FIFOCON+0x40);
+    volatile uint32_t* TX_FIFOconClr = &CAN_REG(CANmodule->CANdriverState, C_FIFOCON+0x44);
 
     CO_LOCK_CAN_SEND();
     /* Abort message from CAN module, if there is synchronous TPDO.
@@ -462,11 +462,11 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
     uint32_t err;
 
-    TREC = CAN_REG(CANmodule->CANdevicePtr, C_TREC);
+    TREC = CAN_REG(CANmodule->CANdriverState, C_TREC);
     rxErrors = (uint8_t) TREC;
     txErrors = (uint8_t) (TREC>>8);
     if(TREC&0x00200000) txErrors = 256; /* bus off */
-    overflow = (CAN_REG(CANmodule->CANdevicePtr, C_FIFOINT)&0x8) ? 1 : 0;
+    overflow = (CAN_REG(CANmodule->CANdriverState, C_FIFOINT)&0x8) ? 1 : 0;
 
     err = ((uint32_t)txErrors << 16) | ((uint32_t)rxErrors << 8) | overflow;
 
@@ -518,7 +518,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
     uint8_t ICODE;
-    ICODE = (uint8_t) CAN_REG(CANmodule->CANdevicePtr, C_VEC) & 0x7F;
+    ICODE = (uint8_t) CAN_REG(CANmodule->CANdriverState, C_VEC) & 0x7F;
 
     /* receive interrupt (New CAN message is available in RX FIFO 0 buffer) */
     if(ICODE == 0){
@@ -528,7 +528,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdevicePtr, C_FIFOUA));
+        rcvMsg = (CO_CANrxMsg_t*) CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdriverState, C_FIFOUA));
         rcvMsgIdent = rcvMsg->ident;
         if(rcvMsg->RTR) rcvMsgIdent |= 0x0800;
         if(CANmodule->useCANrxFilters){
@@ -562,7 +562,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         }
 
         /* Update the message buffer pointer */
-        CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x08) = 0x2000;   /* set UINC */
+        CAN_REG(CANmodule->CANdriverState, C_FIFOCON+0x08) = 0x2000;   /* set UINC */
     }
 
 
@@ -587,9 +587,9 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdevicePtr, C_FIFOUA+0x40));
+                    uint32_t* TXmsgBuffer = CO_PA_TO_KVA1(CAN_REG(CANmodule->CANdriverState, C_FIFOUA+0x40));
                     uint32_t* message = (uint32_t*) buffer;
-                    volatile uint32_t* TX_FIFOconSet = &CAN_REG(CANmodule->CANdevicePtr, C_FIFOCON+0x48);
+                    volatile uint32_t* TX_FIFOconSet = &CAN_REG(CANmodule->CANdriverState, C_FIFOCON+0x48);
                     *(TXmsgBuffer++) = *(message++);
                     *(TXmsgBuffer++) = *(message++);
                     *(TXmsgBuffer++) = *(message++);
@@ -609,7 +609,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
         /* if no more messages, disable 'Tx buffer empty' (TXEMPTYIE) interrupt */
         if(CANmodule->CANtxCount == 0U){
-            CAN_REG(CANmodule->CANdevicePtr, C_FIFOINT+0x44) = 0x01000000;
+            CAN_REG(CANmodule->CANdriverState, C_FIFOINT+0x44) = 0x01000000;
         }
     }
 }

--- a/stack/PIC32/CO_driver.h
+++ b/stack/PIC32/CO_driver.h
@@ -365,7 +365,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     CO_CANrxMsg_t       CANmsgBuff[33]; /* PIC32 specific: CAN message buffer for CAN module. 32 buffers for receive, 1 buffer for transmit */
     uint8_t             CANmsgBuffSize; /* PIC32 specific: Size of the above buffer == 33. Take care initial value! */
     CO_CANrx_t         *rxArray;
@@ -387,7 +387,7 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
@@ -401,7 +401,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/PIC32/CO_driver.h
+++ b/stack/PIC32/CO_driver.h
@@ -365,7 +365,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    uint16_t            CANbaseAddress;
+    void               *CANdevicePtr;
     CO_CANrxMsg_t       CANmsgBuff[33]; /* PIC32 specific: CAN message buffer for CAN module. 32 buffers for receive, 1 buffer for transmit */
     uint8_t             CANmsgBuffSize; /* PIC32 specific: Size of the above buffer == 33. Take care initial value! */
     CO_CANrx_t         *rxArray;
@@ -387,7 +387,7 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
@@ -401,7 +401,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/SAM3X/CO_driver.c
+++ b/stack/SAM3X/CO_driver.c
@@ -71,16 +71,16 @@ void reset_mailbox_conf(can_mb_conf_t *p_mailbox)
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(Can *CANbaseAddress)
+void CO_CANsetConfigurationMode(void *CANdevicePtr)
 {
-  CO_UNUSED(CANbaseAddress);
+  CO_UNUSED(CANdevicePtr);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 {
-  CO_UNUSED(CANmodule->CANbaseAddress);
+  CO_UNUSED(CANmodule->CANdevicePtr);
 
     CANmodule->CANnormal = true;
 }
@@ -89,7 +89,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        Can                    *CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -105,7 +105,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
   /* Configure object variables */
-  CANmodule->CANbaseAddress = CANbaseAddress;
+  CANmodule->CANdevicePtr = CANdevicePtr;
   CANmodule->rxArray = rxArray;
   CANmodule->rxSize = rxSize;
   CANmodule->txArray = txArray;
@@ -130,7 +130,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
   /* Configure CAN module registers */
 
-  if (CANmodule->CANbaseAddress == CAN0)
+  if (((uintptr_t) CANmodule->CANdevicePtr) == CAN0)
   {
     /* CAN0 Transceiver */
     static sn65hvd234_ctrl_t can0_transceiver;
@@ -163,7 +163,7 @@ CO_ReturnError_t CO_CANmodule_init(
       NVIC_EnableIRQ(CAN0_IRQn);
     }
 
-    can_reset_all_mailbox(CANmodule->CANbaseAddress);
+    can_reset_all_mailbox(CANmodule->CANdevicePtr);
 
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
@@ -182,10 +182,10 @@ CO_ReturnError_t CO_CANmodule_init(
       /* Standard mode only, not extended mode */
       CANmodule->rxMbConf[i].ul_id_msk = CAN_MAM_MIDvA_Msk;
       CANmodule->rxMbConf[i].ul_id = CAN_MID_MIDvA(0);
-      can_mailbox_init(CANmodule->CANbaseAddress, &CANmodule->rxMbConf[i]);
+      can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
 
       /* Enable CAN0 mailbox number i interrupt. */
-      can_enable_interrupt(CANmodule->CANbaseAddress, (0x1u << i));
+      can_enable_interrupt(CANmodule->CANdevicePtr, (0x1u << i));
     }
 
     /* Init last CAN0 mailbox, number 7, as transmit mailbox */
@@ -195,10 +195,10 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->txMbConf.uc_tx_prio = 14;
     CANmodule->txMbConf.uc_id_ver = 0;
     CANmodule->txMbConf.ul_id_msk = 0;
-    can_mailbox_init(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+    can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
   }
 
-  if (CANmodule->CANbaseAddress == CAN1)
+  if (CANmodule->CANdevicePtr == CAN1)
   {
     /* CAN1 Transceiver */
     static sn65hvd234_ctrl_t can1_transceiver;
@@ -229,7 +229,7 @@ CO_ReturnError_t CO_CANmodule_init(
       NVIC_EnableIRQ(CAN1_IRQn);
     }
 
-    can_reset_all_mailbox(CANmodule->CANbaseAddress);
+    can_reset_all_mailbox(CANmodule->CANdevicePtr);
 
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
@@ -249,10 +249,10 @@ CO_ReturnError_t CO_CANmodule_init(
       /* Standard mode only, not extended mode */
       CANmodule->rxMbConf[i].ul_id_msk = CAN_MAM_MIDvA_Msk;
       CANmodule->rxMbConf[i].ul_id = CAN_MID_MIDvA(0);
-      can_mailbox_init(CANmodule->CANbaseAddress, &CANmodule->rxMbConf[i]);
+      can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
 
       /* Enable CAN1 mailbox number i interrupt. */
-      can_enable_interrupt(CANmodule->CANbaseAddress, (0x1u << i));
+      can_enable_interrupt(CANmodule->CANdevicePtr, (0x1u << i));
     }
 
     /* Init last CAN1 mailbox, number 7, as transmit mailbox */
@@ -262,7 +262,7 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->txMbConf.uc_tx_prio = 14;
     CANmodule->txMbConf.uc_id_ver = 0;
     CANmodule->txMbConf.ul_id_msk = 0;
-    can_mailbox_init(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+    can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
   }
 
   return CO_ERROR_NO;
@@ -273,7 +273,7 @@ CO_ReturnError_t CO_CANmodule_init(
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 {
   /* Turn the module off  */
-  can_disable(CANmodule->CANbaseAddress);
+  can_disable(CANmodule->CANdevicePtr);
 }
 
 
@@ -372,7 +372,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
   CO_LOCK_CAN_SEND();
 
   /* If CAN TX buffer is free, copy message to it */
-  if (((can_mailbox_get_status(CANmodule->CANbaseAddress, CANMB_TX) & CAN_MSR_MRDY) == CAN_MSR_MRDY) && (CANmodule->CANtxCount == 0))
+  if (((can_mailbox_get_status(CANmodule->CANdevicePtr, CANMB_TX) & CAN_MSR_MRDY) == CAN_MSR_MRDY) && (CANmodule->CANtxCount == 0))
   {
     CANmodule->bufferInhibitFlag = buffer->syncFlag;
 
@@ -383,18 +383,18 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     CANmodule->txMbConf.uc_length = buffer->DLC;
 
     if (buffer->rtr)
-      can_mailbox_tx_remote_frame(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+      can_mailbox_tx_remote_frame(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
     else
-      can_mailbox_write(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+      can_mailbox_write(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
 
-    can_global_send_transfer_cmd(CANmodule->CANbaseAddress, 1 << CANMB_TX);
+    can_global_send_transfer_cmd(CANmodule->CANdevicePtr, 1 << CANMB_TX);
   }
   else /* If no buffer is free, message will be sent by interrupt */
   {
     buffer->bufferFull = true;
     CANmodule->CANtxCount++;
   }
-  can_enable_interrupt(CANmodule->CANbaseAddress, 0x1u << CANMB_TX);
+  can_enable_interrupt(CANmodule->CANdevicePtr, 0x1u << CANMB_TX);
   CO_UNLOCK_CAN_SEND();
 
   return err;
@@ -446,9 +446,9 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
   /* get error counters from module. Id possible, function may use different way to
   * determine errors. */
 
-  rxErrors = can_get_rx_error_cnt(CANmodule->CANbaseAddress);
+  rxErrors = can_get_rx_error_cnt(CANmodule->CANdevicePtr);
 
-  txErrors = can_get_tx_error_cnt(CANmodule->CANbaseAddress);
+  txErrors = can_get_tx_error_cnt(CANmodule->CANdevicePtr);
 
   //overflow = CANmodule->txSize;
 
@@ -516,12 +516,12 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
 {
   uint32_t ul_status;
 
-  ul_status = can_get_status(CANmodule->CANbaseAddress);
+  ul_status = can_get_status(CANmodule->CANdevicePtr);
   if (ul_status & GLOBAL_MAILBOX_MASK)
   {
     for (uint8_t i = 0; i < CANMB_NUMBER; i++)
     {
-      ul_status = can_mailbox_get_status(CANmodule->CANbaseAddress, i);
+      ul_status = can_mailbox_get_status(CANmodule->CANdevicePtr, i);
       if ((ul_status & CAN_MSR_MRDY) == CAN_MSR_MRDY) //Mailbox Ready Bit
       {
         //Handle interrupt
@@ -537,7 +537,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
 
           CANmodule->rxMbConf[i].ul_mb_idx = i;
           CANmodule->rxMbConf[i].ul_status = ul_status;
-          can_mailbox_read(CANmodule->CANbaseAddress, &CANmodule->rxMbConf[i]);
+          can_mailbox_read(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
 
 
           /* Get message from module here */
@@ -617,11 +617,11 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
                 CANmodule->txMbConf.uc_length = buffer->DLC;
 
                 if (buffer->rtr)
-                  can_mailbox_tx_remote_frame(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+                  can_mailbox_tx_remote_frame(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
                 else
-                  can_mailbox_write(CANmodule->CANbaseAddress, &CANmodule->txMbConf);
+                  can_mailbox_write(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
 
-                can_global_send_transfer_cmd(CANmodule->CANbaseAddress, 1 << CANMB_TX);
+                can_global_send_transfer_cmd(CANmodule->CANdevicePtr, 1 << CANMB_TX);
 
                 break; /* Exit for loop */
               }
@@ -636,7 +636,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
           else
           {
             /* Nothing more to send */
-            can_disable_interrupt(CANmodule->CANbaseAddress, 0x1u << CANMB_TX);
+            can_disable_interrupt(CANmodule->CANdevicePtr, 0x1u << CANMB_TX);
           }
         }
         break;

--- a/stack/SAM3X/CO_driver.c
+++ b/stack/SAM3X/CO_driver.c
@@ -71,16 +71,16 @@ void reset_mailbox_conf(can_mb_conf_t *p_mailbox)
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr)
+void CO_CANsetConfigurationMode(void *CANdriverState)
 {
-  CO_UNUSED(CANdevicePtr);
+  CO_UNUSED(CANdriverState);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 {
-  CO_UNUSED(CANmodule->CANdevicePtr);
+  CO_UNUSED(CANmodule->CANdriverState);
 
     CANmodule->CANnormal = true;
 }
@@ -89,7 +89,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -105,7 +105,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
   /* Configure object variables */
-  CANmodule->CANdevicePtr = CANdevicePtr;
+  CANmodule->CANdriverState = CANdriverState;
   CANmodule->rxArray = rxArray;
   CANmodule->rxSize = rxSize;
   CANmodule->txArray = txArray;
@@ -130,7 +130,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
   /* Configure CAN module registers */
 
-  if (((uintptr_t) CANmodule->CANdevicePtr) == CAN0)
+  if (((uintptr_t) CANmodule->CANdriverState) == CAN0)
   {
     /* CAN0 Transceiver */
     static sn65hvd234_ctrl_t can0_transceiver;
@@ -163,7 +163,7 @@ CO_ReturnError_t CO_CANmodule_init(
       NVIC_EnableIRQ(CAN0_IRQn);
     }
 
-    can_reset_all_mailbox(CANmodule->CANdevicePtr);
+    can_reset_all_mailbox(CANmodule->CANdriverState);
 
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
@@ -182,10 +182,10 @@ CO_ReturnError_t CO_CANmodule_init(
       /* Standard mode only, not extended mode */
       CANmodule->rxMbConf[i].ul_id_msk = CAN_MAM_MIDvA_Msk;
       CANmodule->rxMbConf[i].ul_id = CAN_MID_MIDvA(0);
-      can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
+      can_mailbox_init(CANmodule->CANdriverState, &CANmodule->rxMbConf[i]);
 
       /* Enable CAN0 mailbox number i interrupt. */
-      can_enable_interrupt(CANmodule->CANdevicePtr, (0x1u << i));
+      can_enable_interrupt(CANmodule->CANdriverState, (0x1u << i));
     }
 
     /* Init last CAN0 mailbox, number 7, as transmit mailbox */
@@ -195,10 +195,10 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->txMbConf.uc_tx_prio = 14;
     CANmodule->txMbConf.uc_id_ver = 0;
     CANmodule->txMbConf.ul_id_msk = 0;
-    can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+    can_mailbox_init(CANmodule->CANdriverState, &CANmodule->txMbConf);
   }
 
-  if (CANmodule->CANdevicePtr == CAN1)
+  if (CANmodule->CANdriverState == CAN1)
   {
     /* CAN1 Transceiver */
     static sn65hvd234_ctrl_t can1_transceiver;
@@ -229,7 +229,7 @@ CO_ReturnError_t CO_CANmodule_init(
       NVIC_EnableIRQ(CAN1_IRQn);
     }
 
-    can_reset_all_mailbox(CANmodule->CANdevicePtr);
+    can_reset_all_mailbox(CANmodule->CANdriverState);
 
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
@@ -249,10 +249,10 @@ CO_ReturnError_t CO_CANmodule_init(
       /* Standard mode only, not extended mode */
       CANmodule->rxMbConf[i].ul_id_msk = CAN_MAM_MIDvA_Msk;
       CANmodule->rxMbConf[i].ul_id = CAN_MID_MIDvA(0);
-      can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
+      can_mailbox_init(CANmodule->CANdriverState, &CANmodule->rxMbConf[i]);
 
       /* Enable CAN1 mailbox number i interrupt. */
-      can_enable_interrupt(CANmodule->CANdevicePtr, (0x1u << i));
+      can_enable_interrupt(CANmodule->CANdriverState, (0x1u << i));
     }
 
     /* Init last CAN1 mailbox, number 7, as transmit mailbox */
@@ -262,7 +262,7 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->txMbConf.uc_tx_prio = 14;
     CANmodule->txMbConf.uc_id_ver = 0;
     CANmodule->txMbConf.ul_id_msk = 0;
-    can_mailbox_init(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+    can_mailbox_init(CANmodule->CANdriverState, &CANmodule->txMbConf);
   }
 
   return CO_ERROR_NO;
@@ -273,7 +273,7 @@ CO_ReturnError_t CO_CANmodule_init(
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 {
   /* Turn the module off  */
-  can_disable(CANmodule->CANdevicePtr);
+  can_disable(CANmodule->CANdriverState);
 }
 
 
@@ -372,7 +372,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
   CO_LOCK_CAN_SEND();
 
   /* If CAN TX buffer is free, copy message to it */
-  if (((can_mailbox_get_status(CANmodule->CANdevicePtr, CANMB_TX) & CAN_MSR_MRDY) == CAN_MSR_MRDY) && (CANmodule->CANtxCount == 0))
+  if (((can_mailbox_get_status(CANmodule->CANdriverState, CANMB_TX) & CAN_MSR_MRDY) == CAN_MSR_MRDY) && (CANmodule->CANtxCount == 0))
   {
     CANmodule->bufferInhibitFlag = buffer->syncFlag;
 
@@ -383,18 +383,18 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     CANmodule->txMbConf.uc_length = buffer->DLC;
 
     if (buffer->rtr)
-      can_mailbox_tx_remote_frame(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+      can_mailbox_tx_remote_frame(CANmodule->CANdriverState, &CANmodule->txMbConf);
     else
-      can_mailbox_write(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+      can_mailbox_write(CANmodule->CANdriverState, &CANmodule->txMbConf);
 
-    can_global_send_transfer_cmd(CANmodule->CANdevicePtr, 1 << CANMB_TX);
+    can_global_send_transfer_cmd(CANmodule->CANdriverState, 1 << CANMB_TX);
   }
   else /* If no buffer is free, message will be sent by interrupt */
   {
     buffer->bufferFull = true;
     CANmodule->CANtxCount++;
   }
-  can_enable_interrupt(CANmodule->CANdevicePtr, 0x1u << CANMB_TX);
+  can_enable_interrupt(CANmodule->CANdriverState, 0x1u << CANMB_TX);
   CO_UNLOCK_CAN_SEND();
 
   return err;
@@ -446,9 +446,9 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
   /* get error counters from module. Id possible, function may use different way to
   * determine errors. */
 
-  rxErrors = can_get_rx_error_cnt(CANmodule->CANdevicePtr);
+  rxErrors = can_get_rx_error_cnt(CANmodule->CANdriverState);
 
-  txErrors = can_get_tx_error_cnt(CANmodule->CANdevicePtr);
+  txErrors = can_get_tx_error_cnt(CANmodule->CANdriverState);
 
   //overflow = CANmodule->txSize;
 
@@ -516,12 +516,12 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
 {
   uint32_t ul_status;
 
-  ul_status = can_get_status(CANmodule->CANdevicePtr);
+  ul_status = can_get_status(CANmodule->CANdriverState);
   if (ul_status & GLOBAL_MAILBOX_MASK)
   {
     for (uint8_t i = 0; i < CANMB_NUMBER; i++)
     {
-      ul_status = can_mailbox_get_status(CANmodule->CANdevicePtr, i);
+      ul_status = can_mailbox_get_status(CANmodule->CANdriverState, i);
       if ((ul_status & CAN_MSR_MRDY) == CAN_MSR_MRDY) //Mailbox Ready Bit
       {
         //Handle interrupt
@@ -537,7 +537,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
 
           CANmodule->rxMbConf[i].ul_mb_idx = i;
           CANmodule->rxMbConf[i].ul_status = ul_status;
-          can_mailbox_read(CANmodule->CANdevicePtr, &CANmodule->rxMbConf[i]);
+          can_mailbox_read(CANmodule->CANdriverState, &CANmodule->rxMbConf[i]);
 
 
           /* Get message from module here */
@@ -617,11 +617,11 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
                 CANmodule->txMbConf.uc_length = buffer->DLC;
 
                 if (buffer->rtr)
-                  can_mailbox_tx_remote_frame(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+                  can_mailbox_tx_remote_frame(CANmodule->CANdriverState, &CANmodule->txMbConf);
                 else
-                  can_mailbox_write(CANmodule->CANdevicePtr, &CANmodule->txMbConf);
+                  can_mailbox_write(CANmodule->CANdriverState, &CANmodule->txMbConf);
 
-                can_global_send_transfer_cmd(CANmodule->CANdevicePtr, 1 << CANMB_TX);
+                can_global_send_transfer_cmd(CANmodule->CANdriverState, 1 << CANMB_TX);
 
                 break; /* Exit for loop */
               }
@@ -636,7 +636,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule)
           else
           {
             /* Nothing more to send */
-            can_disable_interrupt(CANmodule->CANdevicePtr, 0x1u << CANMB_TX);
+            can_disable_interrupt(CANmodule->CANdriverState, 0x1u << CANMB_TX);
           }
         }
         break;

--- a/stack/SAM3X/CO_driver.h
+++ b/stack/SAM3X/CO_driver.h
@@ -144,7 +144,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    Can                *CANbaseAddress;
+    Can                *CANdevicePtr;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -166,14 +166,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(Can *CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        Can                    *CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/SAM3X/CO_driver.h
+++ b/stack/SAM3X/CO_driver.h
@@ -144,7 +144,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    Can                *CANdevicePtr;
+    Can                *CANdriverState;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -166,14 +166,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/STM32/CO_driver.c
+++ b/stack/STM32/CO_driver.c
@@ -86,7 +86,7 @@ void CanLedsSet(eCoLeds led)
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
 }
 
 
@@ -99,7 +99,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -117,7 +117,7 @@ CO_ReturnError_t CO_CANmodule_init(
         return CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;
@@ -131,7 +131,7 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->em = 0;
 
 		// Replaced magic number 0x03 by (CAN_IT_TME | CAN_IT_FMP0) JvL
-    CAN_ITConfig(CANmodule->CANdevicePtr, (CAN_IT_TME | CAN_IT_FMP0), DISABLE);
+    CAN_ITConfig(CANmodule->CANdriverState, (CAN_IT_TME | CAN_IT_FMP0), DISABLE);
 
     for (i = 0; i < rxSize; i++)
     {
@@ -151,7 +151,7 @@ CO_ReturnError_t CO_CANmodule_init(
         CO_CANconfigGPIO();
 
     /* Init CAN controler */
-    CAN_DeInit(CANmodule->CANdevicePtr);
+    CAN_DeInit(CANmodule->CANdriverState);
     CAN_StructInit(&CAN_InitStruct);
     switch (CANbitRate)
     {
@@ -179,7 +179,7 @@ CO_ReturnError_t CO_CANmodule_init(
     CAN_InitStruct.CAN_NART = ENABLE;   // No Automatic retransmision
 
    /* CO - Changed VJ Start */
-    result = CAN_Init(CANmodule->CANdevicePtr, &CAN_InitStruct);
+    result = CAN_Init(CANmodule->CANdriverState, &CAN_InitStruct);
     if (result == 0)
         {
        // TRACE_DEBUG_WP("res=%d\n\r", result);
@@ -210,9 +210,9 @@ CO_ReturnError_t CO_CANmodule_init(
     NVIC_InitStructure.NVIC_IRQChannel = CAN1_TX_INTERRUPTS;
     NVIC_Init(&NVIC_InitStructure);
 
-   // CAN_OperatingModeRequest(CANmodule->CANdevicePtr, CAN_Mode_Normal); // Not needed as after init Can_init functions puts the controller in normal mode - VJ
+   // CAN_OperatingModeRequest(CANmodule->CANdriverState, CAN_Mode_Normal); // Not needed as after init Can_init functions puts the controller in normal mode - VJ
 
-    CAN_ITConfig(CANmodule->CANdevicePtr, 0x03, ENABLE);
+    CAN_ITConfig(CANmodule->CANdriverState, 0x03, ENABLE);
 
     return CO_ERROR_NO;
 }
@@ -220,7 +220,7 @@ CO_ReturnError_t CO_CANmodule_init(
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 {
-    CAN_DeInit(CANmodule->CANdevicePtr);
+    CAN_DeInit(CANmodule->CANdriverState);
 }
 
 /******************************************************************************/
@@ -304,23 +304,23 @@ int8_t getFreeTxBuff(CO_CANmodule_t *CANmodule)
 {
     uint8_t txBuff = CAN_TXMAILBOX_0;
 
-    //if (CAN_TransmitStatus(CANmodule->CANdevicePtr, txBuff) == CAN_TxStatus_Ok)
+    //if (CAN_TransmitStatus(CANmodule->CANdriverState, txBuff) == CAN_TxStatus_Ok)
     for (txBuff = CAN_TXMAILBOX_0; txBuff <= (CAN_TXMAILBOX_2 + 1); txBuff++)
     {
         switch (txBuff)
         {
         case (CAN_TXMAILBOX_0 ):
-            if (CANmodule->CANdevicePtr->TSR & CAN_TSR_TME0 )
+            if (CANmodule->CANdriverState->TSR & CAN_TSR_TME0 )
                 return txBuff;
             else
                 break;
         case (CAN_TXMAILBOX_1 ):
-            if (CANmodule->CANdevicePtr->TSR & CAN_TSR_TME1 )
+            if (CANmodule->CANdriverState->TSR & CAN_TSR_TME1 )
                 return txBuff;
             else
                 break;
         case (CAN_TXMAILBOX_2 ):
-            if (CANmodule->CANdevicePtr->TSR & CAN_TSR_TME2 )
+            if (CANmodule->CANdriverState->TSR & CAN_TSR_TME2 )
                 return txBuff;
             else
                 break;
@@ -360,7 +360,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
         buffer->bufferFull = 1;
         CANmodule->CANtxCount++;
         // vsechny buffery jsou plny, musime povolit preruseni od vysilace, odvysilat az v preruseni
-        CAN_ITConfig(CANmodule->CANdevicePtr, CAN_IT_TME, ENABLE);
+        CAN_ITConfig(CANmodule->CANdriverState, CAN_IT_TME, ENABLE);
     }
     CO_UNLOCK_CAN_SEND();
 
@@ -380,18 +380,18 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
    uint32_t err;
    CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-   err = CANmodule->CANdevicePtr->ESR;
-   // if(CAN_REG(CANmodule->CANdevicePtr, C_INTF) & 4) err |= 0x80;
+   err = CANmodule->CANdriverState->ESR;
+   // if(CAN_REG(CANmodule->CANdriverState, C_INTF) & 4) err |= 0x80;
 
    if(CANmodule->errOld != err)
    {
       CANmodule->errOld = err;
 
       //CAN RX bus overflow
-      if(CANmodule->CANdevicePtr->RF0R & 0x08)
+      if(CANmodule->CANdriverState->RF0R & 0x08)
       {
          CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-         CANmodule->CANdevicePtr->RF0R &=~0x08;//clear bits
+         CANmodule->CANdriverState->RF0R &=~0x08;//clear bits
       }
 
       //CAN TX bus off
@@ -429,7 +429,7 @@ void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule)
 {
 	CanRxMsg      CAN1_RxMsg;
 
-	CAN_Receive(CANmodule->CANdevicePtr, CAN_FilterFIFO0, &CAN1_RxMsg);
+	CAN_Receive(CANmodule->CANdriverState, CAN_FilterFIFO0, &CAN1_RxMsg);
 	{
 	        uint16_t index;
 	        uint8_t msgMatched = 0;
@@ -457,7 +457,7 @@ void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule)
 
      int8_t txBuff;
     /* Clear interrupt flag */
-    CAN_ITConfig(CANmodule->CANdevicePtr, CAN_IT_TME, DISABLE); // Transmit mailbox empty interrupt
+    CAN_ITConfig(CANmodule->CANdriverState, CAN_IT_TME, DISABLE); // Transmit mailbox empty interrupt
     /* First CAN message (bootup) was sent successfully */
     CANmodule->firstCANtxMessage = 0;
     /* clear flag from previous message */
@@ -511,8 +511,8 @@ static void CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer, ui
     CAN1_TxMsg.StdId = ((buffer->ident) >> 21);
     CAN1_TxMsg.RTR = CAN_RTR_DATA;
 
-    CAN_Transmit(CANmodule->CANdevicePtr, &CAN1_TxMsg);
-    CAN_ITConfig(CANmodule->CANdevicePtr, CAN_IT_TME, ENABLE);
+    CAN_Transmit(CANmodule->CANdriverState, &CAN1_TxMsg);
+    CAN_ITConfig(CANmodule->CANdriverState, CAN_IT_TME, ENABLE);
 
     /*Test code, VJ using Drivers End*/
 

--- a/stack/STM32/CO_driver.h
+++ b/stack/STM32/CO_driver.h
@@ -181,7 +181,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    CAN_TypeDef        *CANdevicePtr;         /* STM32F4xx specific */
+    CAN_TypeDef        *CANdriverState;         /* STM32F4xx specific */
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -213,13 +213,13 @@ void CanLedsSet(eCoLeds led);
 
 
 /* Request CAN configuration or normal mode */
-//void CO_CANsetConfigurationMode(CAN_TypeDef *CANdevicePtr);
+//void CO_CANsetConfigurationMode(CAN_TypeDef *CANdriverState);
 //void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/STM32/CO_driver.h
+++ b/stack/STM32/CO_driver.h
@@ -75,7 +75,7 @@
     #define CO_LOCK_OD()            __set_PRIMASK(1);
     #define CO_UNLOCK_OD()          __set_PRIMASK(0);
 
-    
+
 #define CLOCK_CAN                   RCC_APB1Periph_CAN1
 
 #define CAN_REMAP_2                 /* Select CAN1 remap 2 */
@@ -181,7 +181,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    CAN_TypeDef        *CANbaseAddress;         /* STM32F4xx specific */
+    CAN_TypeDef        *CANdevicePtr;         /* STM32F4xx specific */
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -213,13 +213,13 @@ void CanLedsSet(eCoLeds led);
 
 
 /* Request CAN configuration or normal mode */
-//void CO_CANsetConfigurationMode(CAN_TypeDef *CANbaseAddress);
+//void CO_CANsetConfigurationMode(CAN_TypeDef *CANdevicePtr);
 //void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        CAN_TypeDef            *CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/STM32F3/CO_driver.c
+++ b/stack/STM32F3/CO_driver.c
@@ -66,7 +66,8 @@ static uint8_t CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(CAN_TypeDef* CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
+    (void) CANdevicePtr;
 }
 
 
@@ -79,7 +80,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        CAN_TypeDef            *CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -97,7 +98,7 @@ CO_ReturnError_t CO_CANmodule_init(
         return CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;
@@ -109,14 +110,14 @@ CO_ReturnError_t CO_CANmodule_init(
     CANmodule->CANtxCount = 0;
     CANmodule->errOld = 0;
     CANmodule->em = 0;
-	
-    CAN_ITConfig(CANmodule->CANbaseAddress, (CAN_IT_TME | CAN_IT_FMP0), DISABLE);
+
+    CAN_ITConfig(CANmodule->CANdevicePtr, (CAN_IT_TME | CAN_IT_FMP0), DISABLE);
 
     for (i = 0; i < rxSize; i++) {
         CANmodule->rxArray[i].ident = 0;
         CANmodule->rxArray[i].pFunct = 0;
     }
-    
+
     for (i = 0; i < txSize; i++) {
         CANmodule->txArray[i].bufferFull = 0;
     }
@@ -128,9 +129,9 @@ CO_ReturnError_t CO_CANmodule_init(
     CO_CANconfigGPIO();
 
     /* Init CAN controler */
-    CAN_DeInit(CANmodule->CANbaseAddress);
+    CAN_DeInit(CANmodule->CANdevicePtr);
     CAN_StructInit(&CAN_InitStruct);
- 
+
     switch (CANbitRate) {
         case 1000: CAN_InitStruct.CAN_Prescaler = 2;
             break;
@@ -150,13 +151,13 @@ CO_ReturnError_t CO_CANmodule_init(
         case 10: CAN_InitStruct.CAN_Prescaler = 200;
             break;
     }
-    
+
     CAN_InitStruct.CAN_SJW = CAN_SJW_1tq;     // changed by VJ, old value = CAN_SJW_1tq;
     CAN_InitStruct.CAN_BS1 = CAN_BS1_13tq;    // changed by VJ, old value = CAN_BS1_3tq;
     CAN_InitStruct.CAN_BS2 = CAN_BS2_2tq;     // changed by VJ, old value = CAN_BS2_2tq;
     CAN_InitStruct.CAN_NART = ENABLE;         // No Automatic retransmision
 
-    result = CAN_Init(CANmodule->CANbaseAddress, &CAN_InitStruct);
+    result = CAN_Init(CANmodule->CANdevicePtr, &CAN_InitStruct);
     if (result == 0) {
        return CO_ERROR_TIMEOUT;  /* CO- Return Init failed */
     }
@@ -185,7 +186,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
     /* Can_init function of ST Driver puts the controller into the normal mode */
 
-    CAN_ITConfig(CANmodule->CANbaseAddress, (CAN_IT_TME | CAN_IT_FMP0), ENABLE);
+    CAN_ITConfig(CANmodule->CANdevicePtr, (CAN_IT_TME | CAN_IT_FMP0), ENABLE);
 
     return CO_ERROR_NO;
 }
@@ -193,7 +194,7 @@ CO_ReturnError_t CO_CANmodule_init(
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 {
-    CAN_DeInit(CANmodule->CANbaseAddress);
+    CAN_DeInit(CANmodule->CANdevicePtr);
 }
 
 /******************************************************************************/
@@ -282,7 +283,7 @@ CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     }
 
     CO_LOCK_CAN_SEND();
-    
+
     /* First try to transmit the message immediately if mailbox is free.
      * Only one TX mailbox is used of the three available in the hardware */
     CANmodule->bufferInhibitFlag = buffer->syncFlag;
@@ -306,13 +307,13 @@ void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule)
 
     CO_LOCK_CAN_SEND();
     /* Abort message from CAN module, if there is synchronous TPDO. */
-    state = CAN_TransmitStatus(CANmodule->CANbaseAddress, CO_CAN_TXMAILBOX);
+    state = CAN_TransmitStatus(CANmodule->CANdevicePtr, CO_CAN_TXMAILBOX);
     if((state == CAN_TxStatus_Pending) && (CANmodule->bufferInhibitFlag)) {
-        CAN_CancelTransmit(CANmodule->CANbaseAddress, CO_CAN_TXMAILBOX);
+        CAN_CancelTransmit(CANmodule->CANdevicePtr, CO_CAN_TXMAILBOX);
         CANmodule->bufferInhibitFlag = false;
         tpdoDeleted = 1U;
     }
-    
+
     /* delete also pending synchronous TPDOs in TX buffers */
     if(CANmodule->CANtxCount != 0U){
         uint16_t i;
@@ -342,15 +343,15 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
     uint32_t err;
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-    err = CANmodule->CANbaseAddress->ESR;
+    err = CANmodule->CANdevicePtr->ESR;
 
     if(CANmodule->errOld != err) {
         CANmodule->errOld = err;
 
         /* CAN RX bus overflow */
-        if(CANmodule->CANbaseAddress->RF0R & 0x10) {
+        if(CANmodule->CANdevicePtr->RF0R & 0x10) {
             CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-            CANmodule->CANbaseAddress->RF0R &=~0x10;//clear bits
+            CANmodule->CANdevicePtr->RF0R &=~0x10;//clear bits
         }
 
         /* CAN TX bus off */
@@ -360,7 +361,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
         else {
             CO_errorReset(em, CO_EM_CAN_TX_BUS_OFF, err);
         }
-        
+
         /* CAN TX or RX bus passive */
         if(err & 0x02) {
             if(!CANmodule->firstCANtxMessage) CO_errorReport(em, CO_EM_CAN_TX_BUS_PASSIVE, CO_EMC_CAN_PASSIVE, err);
@@ -391,8 +392,8 @@ void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule)
     uint8_t msgMatched = 0;
     CO_CANrx_t *msgBuff = CANmodule->rxArray;
 
-	CAN_Receive(CANmodule->CANbaseAddress, CAN_FilterFIFO0, &CAN1_RxMsg);
-    
+	CAN_Receive(CANmodule->CANdevicePtr, CAN_FilterFIFO0, &CAN1_RxMsg);
+
     for (index = 0; index < CANmodule->rxSize; index++) {
         uint16_t msg = (CAN1_RxMsg.StdId << 2) | (CAN1_RxMsg.RTR ? 2 : 0);
 
@@ -402,7 +403,7 @@ void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule)
         }
         msgBuff++;
     }
-    
+
     /* Call specific function, which will process the message */
     if (msgMatched && msgBuff->pFunct) {
         msgBuff->pFunct(msgBuff->object, (CO_CANrxMsg_t*) &CAN1_RxMsg);
@@ -415,10 +416,10 @@ void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule)
 {
     /* First CAN message (bootup) was sent successfully */
     CANmodule->firstCANtxMessage = 0;
-    
+
     /* clear flag from previous message */
     CANmodule->bufferInhibitFlag = 0;
-    
+
     /* Are there any new messages waiting to be send */
     if (CANmodule->CANtxCount > 0) {
         uint16_t i;             /* index of transmitting message */
@@ -431,7 +432,7 @@ void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule)
             if(buffer->bufferFull) {
                 buffer->bufferFull = 0;
                 CANmodule->CANtxCount--;
-                
+
                 /* Copy message to CAN buffer */
                 CANmodule->bufferInhibitFlag = buffer->syncFlag;
                 CO_CANsendToModule(CANmodule, buffer);
@@ -451,8 +452,8 @@ static uint8_t CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     CAN_TxMailBox_TypeDef* txMbox;
 
     /* Checks if the transmit mailbox is available */
-    if ((CANmodule->CANbaseAddress->TSR & CAN_TSR_TME0) == CAN_TSR_TME0) {
-        txMbox = &CANmodule->CANbaseAddress->sTxMailBox[CO_CAN_TXMAILBOX];
+    if ((CANmodule->CANdevicePtr->TSR & CAN_TSR_TME0) == CAN_TSR_TME0) {
+        txMbox = &CANmodule->CANdevicePtr->sTxMailBox[CO_CAN_TXMAILBOX];
     }
     else {
         return CAN_TxStatus_NoMailBox;
@@ -466,21 +467,21 @@ static uint8_t CO_CANsendToModule(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     buffer->DLC &= (uint8_t)0x0000000F;
     txMbox->TDTR &= (uint32_t)0xFFFFFFF0;
     txMbox->TDTR |= buffer->DLC;
-    
+
     /* Data field */
-    txMbox->TDLR = (((uint32_t)buffer->data[3] << 24) |  
+    txMbox->TDLR = (((uint32_t)buffer->data[3] << 24) |
                     ((uint32_t)buffer->data[2] << 16) |
-                    ((uint32_t)buffer->data[1] << 8) | 
+                    ((uint32_t)buffer->data[1] << 8) |
                     ((uint32_t)buffer->data[0]));
-                    
-    txMbox->TDHR = (((uint32_t)buffer->data[7] << 24) | 
+
+    txMbox->TDHR = (((uint32_t)buffer->data[7] << 24) |
                     ((uint32_t)buffer->data[6] << 16) |
                     ((uint32_t)buffer->data[5] << 8) |
                     ((uint32_t)buffer->data[4]));
-                    
+
     /* Request transmission */
     txMbox->TIR |= 1;
-    
+
     return 0;
 }
 
@@ -501,9 +502,9 @@ static void CO_CANconfigGPIO (void)
 	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_Level_1;
 	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
 	GPIO_InitStruct.GPIO_PuPd = GPIO_PuPd_NOPULL;
-	
+
 	GPIO_Init(GPIO_CAN, &GPIO_InitStruct);
-    
+
     /* Map to correct alternative function (9 == CAN) */
 	GPIO_PinAFConfig(GPIO_CAN, GPIO_PinSource_CAN_RX, GPIO_AF_9);
 	GPIO_PinAFConfig(GPIO_CAN, GPIO_PinSource_CAN_TX, GPIO_AF_9);

--- a/stack/STM32F3/CO_driver.h
+++ b/stack/STM32F3/CO_driver.h
@@ -174,7 +174,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    CAN_TypeDef        *CANbaseAddress;         /* STM32F4xx specific */
+    CAN_TypeDef        *CANdevicePtr;         /* STM32F4xx specific */
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -194,13 +194,13 @@ typedef struct{
 /* Exported functions -----------------------------------------------------------*/
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(CAN_TypeDef* CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        CAN_TypeDef            *CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/STM32F3/CO_driver.h
+++ b/stack/STM32F3/CO_driver.h
@@ -174,7 +174,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    CAN_TypeDef        *CANdevicePtr;         /* STM32F4xx specific */
+    CAN_TypeDef        *CANdriverState;         /* STM32F4xx specific */
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -194,13 +194,13 @@ typedef struct{
 /* Exported functions -----------------------------------------------------------*/
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/drvTemplate/CO_driver.c
+++ b/stack/drvTemplate/CO_driver.c
@@ -51,7 +51,7 @@
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
     /* Put CAN module in configuration mode */
 }
 
@@ -67,7 +67,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -82,7 +82,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;

--- a/stack/drvTemplate/CO_driver.c
+++ b/stack/drvTemplate/CO_driver.c
@@ -51,7 +51,7 @@
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
     /* Put CAN module in configuration mode */
 }
 
@@ -67,7 +67,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -82,7 +82,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;

--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -283,7 +283,7 @@ typedef struct{
  * CAN module object. It may be different in different microcontrollers.
  */
 typedef struct{
-    void               *CANdevicePtr; /**< From CO_CANmodule_init() */
+    void               *CANdriverState; /**< From CO_CANmodule_init() */
     CO_CANrx_t         *rxArray;        /**< From CO_CANmodule_init() */
     uint16_t            rxSize;         /**< From CO_CANmodule_init() */
     CO_CANtx_t         *txArray;        /**< From CO_CANmodule_init() */
@@ -320,9 +320,9 @@ typedef struct{
 /**
  * Request CAN configuration (stopped) mode and *wait* untill it is set.
  *
- * @param CANdevicePtr User-provided CAN module structure.
+ * @param CANdriverState User-provided CAN module structure.
  */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 
 
 /**
@@ -340,7 +340,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANdevicePtr User-provided CAN module structure..
+ * @param CANdriverState User-provided CAN module structure..
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -352,7 +352,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -283,7 +283,7 @@ typedef struct{
  * CAN module object. It may be different in different microcontrollers.
  */
 typedef struct{
-    int32_t             CANbaseAddress; /**< From CO_CANmodule_init() */
+    void               *CANdevicePtr; /**< From CO_CANmodule_init() */
     CO_CANrx_t         *rxArray;        /**< From CO_CANmodule_init() */
     uint16_t            rxSize;         /**< From CO_CANmodule_init() */
     CO_CANtx_t         *txArray;        /**< From CO_CANmodule_init() */
@@ -309,7 +309,7 @@ typedef struct{
 
 
 /**
- * Endianes.
+ * Endianness.
  *
  * Depending on processor or compiler architecture, one of the two macros must
  * be defined: CO_LITTLE_ENDIAN or CO_BIG_ENDIAN. CANopen itself is little endian.
@@ -320,9 +320,9 @@ typedef struct{
 /**
  * Request CAN configuration (stopped) mode and *wait* untill it is set.
  *
- * @param CANbaseAddress CAN module base address.
+ * @param CANdevicePtr User-provided CAN module structure.
  */
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 
 
 /**
@@ -340,7 +340,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANbaseAddress CAN module base address.
+ * @param CANdevicePtr User-provided CAN module structure..
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -352,7 +352,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/dsPIC30F/CO_driver.c
+++ b/stack/dsPIC30F/CO_driver.c
@@ -52,7 +52,7 @@ extern const CO_CANbitRateData_t  CO_CANbitRateData[8];
 /**
  * Macro and Constants - CAN module registers - offset.
  */
-    #define CAN_REG(base, offset) (*((volatile uint16_t *) (base + offset)))
+    #define CAN_REG(base, offset) (*((volatile uint16_t *) (((uintptr_t) base) + offset)))
 
     #define C_RXF0SID    0x00
     #define C_RXF0EIDH   0x02
@@ -102,29 +102,29 @@ extern const CO_CANbitRateData_t  CO_CANbitRateData[8];
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress){
-    uint16_t C_CTRLcopy = CAN_REG(CANbaseAddress, C_CTRL);
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
+    uint16_t C_CTRLcopy = CAN_REG(CANdevicePtr, C_CTRL);
 
     /* set REQOP = 0x4 */
     C_CTRLcopy &= 0xFCFF;
     C_CTRLcopy |= 0x0400;
-    CAN_REG(CANbaseAddress, C_CTRL) = C_CTRLcopy;
+    CAN_REG(CANdevicePtr, C_CTRL) = C_CTRLcopy;
 
     /* while OPMODE != 4 */
-    while((CAN_REG(CANbaseAddress, C_CTRL) & 0x00E0) != 0x0080);
+    while((CAN_REG(CANdevicePtr, C_CTRL) & 0x00E0) != 0x0080);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
-    uint16_t C_CTRLcopy = CAN_REG(CANmodule->CANbaseAddress, C_CTRL);
+    uint16_t C_CTRLcopy = CAN_REG(CANmodule->CANdevicePtr, C_CTRL);
 
     /* set REQOP = 0x0 */
     C_CTRLcopy &= 0xF8FF;
-    CAN_REG(CANmodule->CANbaseAddress, C_CTRL) = C_CTRLcopy;
+    CAN_REG(CANmodule->CANdevicePtr, C_CTRL) = C_CTRLcopy;
 
     /* while OPMODE != 0 */
-    while((CAN_REG(CANmodule->CANbaseAddress, C_CTRL) & 0x00E0) != 0x0000);
+    while((CAN_REG(CANmodule->CANdevicePtr, C_CTRL) & 0x00E0) != 0x0000);
 
     CANmodule->CANnormal = true;
 }
@@ -133,7 +133,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -148,7 +148,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANbaseAddress = CANbaseAddress;
+    CANmodule->CANdevicePtr = CANdevicePtr;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;
@@ -171,7 +171,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control register */
-    CAN_REG(CANbaseAddress, C_CTRL) = 0x0400;
+    CAN_REG(CANdevicePtr, C_CTRL) = 0x0400;
 
 
     /* Configure CAN timing */
@@ -188,44 +188,44 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     if(CO_CANbitRateData[i].scale == 1)
-        CAN_REG(CANbaseAddress, C_CTRL) |= 0x0800;
+        CAN_REG(CANdevicePtr, C_CTRL) |= 0x0800;
 
-    CAN_REG(CANbaseAddress, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
+    CAN_REG(CANdevicePtr, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
                                          (CO_CANbitRateData[i].BRP - 1);
 
-    CAN_REG(CANbaseAddress, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
+    CAN_REG(CANdevicePtr, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
                                         0x0080 |
                                         (CO_CANbitRateData[i].phSeg1 - 1) << 3 |
                                         (CO_CANbitRateData[i].PROP - 1);
 
 
     /* setup RX and TX control registers */
-    CAN_REG(CANbaseAddress, C_RXBUF0 + C_RXCON) = 0x0040;
-    CAN_REG(CANbaseAddress, C_RXBUF1 + C_RXCON) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TXBUF0 + C_TXCON) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TXBUF1 + C_TXCON) = 0x0000;
-    CAN_REG(CANbaseAddress, C_TXBUF2 + C_TXCON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXBUF0 + C_RXCON) = 0x0040;
+    CAN_REG(CANdevicePtr, C_RXBUF1 + C_RXCON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TXBUF0 + C_TXCON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TXBUF1 + C_TXCON) = 0x0000;
+    CAN_REG(CANdevicePtr, C_TXBUF2 + C_TXCON) = 0x0000;
 
 
     /* CAN module hardware filters */
-    CAN_REG(CANbaseAddress, C_RXF0SID) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXF1SID) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXF2SID) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXF3SID) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXF4SID) = 0x0000;
-    CAN_REG(CANbaseAddress, C_RXF5SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF0SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF1SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF2SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF3SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF4SID) = 0x0000;
+    CAN_REG(CANdevicePtr, C_RXF5SID) = 0x0000;
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
     /* Set masks so, that all messages with standard identifier are accepted */
-    CAN_REG(CANbaseAddress, C_RXM0SID) = 0x0001;
-    CAN_REG(CANbaseAddress, C_RXM1SID) = 0x0001;
+    CAN_REG(CANdevicePtr, C_RXM0SID) = 0x0001;
+    CAN_REG(CANdevicePtr, C_RXM1SID) = 0x0001;
 
 
     /* CAN interrupt registers */
     /* clear interrupt flags */
-    CAN_REG(CANbaseAddress, C_INTF) = 0x0000;
+    CAN_REG(CANdevicePtr, C_INTF) = 0x0000;
     /* enable both two receive interrupts and one transmit interrupt for TX0 */
-    CAN_REG(CANbaseAddress, C_INTE) = 0x0007;
+    CAN_REG(CANdevicePtr, C_INTE) = 0x0007;
     /* CAN interrupt (combined) must be configured by application */
 
     return CO_ERROR_NO;
@@ -234,7 +234,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANbaseAddress);
+    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
 }
 
 
@@ -354,7 +354,7 @@ static void CO_CANsendToModule(uint16_t dest, CO_CANtx_t *src){
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANbaseAddress;
+    uint16_t addr = CANmodule->CANdevicePtr;
 
     /* Verify overflow */
     if(buffer->bufferFull){
@@ -394,7 +394,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     uint8_t err;
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-    err = CAN_REG(CANmodule->CANbaseAddress, C_INTF)>>8;
+    err = CAN_REG(CANmodule->CANdevicePtr, C_INTF)>>8;
 
     if(CANmodule->errOld != err){
         CANmodule->errOld = err;
@@ -402,7 +402,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
         /* CAN RX bus overflow */
         if(err & 0xC0){
             CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-            CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0x3FFF;/* clear bits */
+            CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0x3FFF;/* clear bits */
         }
 
         /* CAN TX bus off */
@@ -447,7 +447,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
     uint16_t ICODE;
-    ICODE = CAN_REG(CANmodule->CANbaseAddress, C_CTRL) & 0xE;
+    ICODE = CAN_REG(CANmodule->CANdevicePtr, C_CTRL) & 0xE;
 
     /* receive interrupt 0 (New CAN messagge is available in RX buffer 0) */
     if(ICODE == 0xC){
@@ -457,7 +457,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANbaseAddress + C_RXBUF0);
+        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdevicePtr + C_RXBUF0);
         rcvMsgIdent = rcvMsg->ident;
         /* CAN module filters are not used, message with any standard 11-bit identifier */
         /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
@@ -479,7 +479,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         rcvMsg->CON &= 0xFF7F;
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFE;
+        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFE;
     }
 
 
@@ -491,7 +491,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANbaseAddress + C_RXBUF1);
+        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdevicePtr + C_RXBUF1);
         rcvMsgIdent = rcvMsg->ident;
         /* CAN module filters are not used, message with any standard 11-bit identifier */
         /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
@@ -513,20 +513,20 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         rcvMsg->CON &= 0xFF7F;
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFD;
+        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFD;
     }
 
 
     /* transmit interrupt (TX buffer is free) */
     else if(ICODE == 0x8){
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANbaseAddress, C_INTF) &= 0xFFFB;
+        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFB;
         /* First CAN message (bootup) was sent successfully */
         CANmodule->firstCANtxMessage = false;
         /* clear flag from previous message */
         CANmodule->bufferInhibitFlag = false;
         /* Are there any new messages waiting to be send and buffer is free */
-        if(CANmodule->CANtxCount > 0U && (CAN_REG(CANmodule->CANbaseAddress, C_TXBUF0 + C_TXCON) & 0x8) == 0){
+        if(CANmodule->CANtxCount > 0U && (CAN_REG(CANmodule->CANdevicePtr, C_TXBUF0 + C_TXCON) & 0x8) == 0){
             uint16_t i;             /* index of transmitting message */
 
             /* first buffer */
@@ -540,7 +540,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    CO_CANsendToModule(CANmodule->CANbaseAddress + C_TXBUF0, buffer);
+                    CO_CANsendToModule(CANmodule->CANdevicePtr + C_TXBUF0, buffer);
                     break;                      /* exit for loop */
                 }
                 buffer++;

--- a/stack/dsPIC30F/CO_driver.c
+++ b/stack/dsPIC30F/CO_driver.c
@@ -102,29 +102,29 @@ extern const CO_CANbitRateData_t  CO_CANbitRateData[8];
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
-    uint16_t C_CTRLcopy = CAN_REG(CANdevicePtr, C_CTRL);
+void CO_CANsetConfigurationMode(void *CANdriverState){
+    uint16_t C_CTRLcopy = CAN_REG(CANdriverState, C_CTRL);
 
     /* set REQOP = 0x4 */
     C_CTRLcopy &= 0xFCFF;
     C_CTRLcopy |= 0x0400;
-    CAN_REG(CANdevicePtr, C_CTRL) = C_CTRLcopy;
+    CAN_REG(CANdriverState, C_CTRL) = C_CTRLcopy;
 
     /* while OPMODE != 4 */
-    while((CAN_REG(CANdevicePtr, C_CTRL) & 0x00E0) != 0x0080);
+    while((CAN_REG(CANdriverState, C_CTRL) & 0x00E0) != 0x0080);
 }
 
 
 /******************************************************************************/
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
-    uint16_t C_CTRLcopy = CAN_REG(CANmodule->CANdevicePtr, C_CTRL);
+    uint16_t C_CTRLcopy = CAN_REG(CANmodule->CANdriverState, C_CTRL);
 
     /* set REQOP = 0x0 */
     C_CTRLcopy &= 0xF8FF;
-    CAN_REG(CANmodule->CANdevicePtr, C_CTRL) = C_CTRLcopy;
+    CAN_REG(CANmodule->CANdriverState, C_CTRL) = C_CTRLcopy;
 
     /* while OPMODE != 0 */
-    while((CAN_REG(CANmodule->CANdevicePtr, C_CTRL) & 0x00E0) != 0x0000);
+    while((CAN_REG(CANmodule->CANdriverState, C_CTRL) & 0x00E0) != 0x0000);
 
     CANmodule->CANnormal = true;
 }
@@ -133,7 +133,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -148,7 +148,7 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     /* Configure object variables */
-    CANmodule->CANdevicePtr = CANdevicePtr;
+    CANmodule->CANdriverState = CANdriverState;
     CANmodule->rxArray = rxArray;
     CANmodule->rxSize = rxSize;
     CANmodule->txArray = txArray;
@@ -171,7 +171,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure control register */
-    CAN_REG(CANdevicePtr, C_CTRL) = 0x0400;
+    CAN_REG(CANdriverState, C_CTRL) = 0x0400;
 
 
     /* Configure CAN timing */
@@ -188,44 +188,44 @@ CO_ReturnError_t CO_CANmodule_init(
     }
 
     if(CO_CANbitRateData[i].scale == 1)
-        CAN_REG(CANdevicePtr, C_CTRL) |= 0x0800;
+        CAN_REG(CANdriverState, C_CTRL) |= 0x0800;
 
-    CAN_REG(CANdevicePtr, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
+    CAN_REG(CANdriverState, C_CFG1) = (CO_CANbitRateData[i].SJW - 1) << 6 |
                                          (CO_CANbitRateData[i].BRP - 1);
 
-    CAN_REG(CANdevicePtr, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
+    CAN_REG(CANdriverState, C_CFG2) = ((uint16_t)(CO_CANbitRateData[i].phSeg2 - 1)) << 8 |
                                         0x0080 |
                                         (CO_CANbitRateData[i].phSeg1 - 1) << 3 |
                                         (CO_CANbitRateData[i].PROP - 1);
 
 
     /* setup RX and TX control registers */
-    CAN_REG(CANdevicePtr, C_RXBUF0 + C_RXCON) = 0x0040;
-    CAN_REG(CANdevicePtr, C_RXBUF1 + C_RXCON) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TXBUF0 + C_TXCON) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TXBUF1 + C_TXCON) = 0x0000;
-    CAN_REG(CANdevicePtr, C_TXBUF2 + C_TXCON) = 0x0000;
+    CAN_REG(CANdriverState, C_RXBUF0 + C_RXCON) = 0x0040;
+    CAN_REG(CANdriverState, C_RXBUF1 + C_RXCON) = 0x0000;
+    CAN_REG(CANdriverState, C_TXBUF0 + C_TXCON) = 0x0000;
+    CAN_REG(CANdriverState, C_TXBUF1 + C_TXCON) = 0x0000;
+    CAN_REG(CANdriverState, C_TXBUF2 + C_TXCON) = 0x0000;
 
 
     /* CAN module hardware filters */
-    CAN_REG(CANdevicePtr, C_RXF0SID) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXF1SID) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXF2SID) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXF3SID) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXF4SID) = 0x0000;
-    CAN_REG(CANdevicePtr, C_RXF5SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF0SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF1SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF2SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF3SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF4SID) = 0x0000;
+    CAN_REG(CANdriverState, C_RXF5SID) = 0x0000;
     /* CAN module filters are not used, all messages with standard 11-bit */
     /* identifier will be received */
     /* Set masks so, that all messages with standard identifier are accepted */
-    CAN_REG(CANdevicePtr, C_RXM0SID) = 0x0001;
-    CAN_REG(CANdevicePtr, C_RXM1SID) = 0x0001;
+    CAN_REG(CANdriverState, C_RXM0SID) = 0x0001;
+    CAN_REG(CANdriverState, C_RXM1SID) = 0x0001;
 
 
     /* CAN interrupt registers */
     /* clear interrupt flags */
-    CAN_REG(CANdevicePtr, C_INTF) = 0x0000;
+    CAN_REG(CANdriverState, C_INTF) = 0x0000;
     /* enable both two receive interrupts and one transmit interrupt for TX0 */
-    CAN_REG(CANdevicePtr, C_INTE) = 0x0007;
+    CAN_REG(CANdriverState, C_INTE) = 0x0007;
     /* CAN interrupt (combined) must be configured by application */
 
     return CO_ERROR_NO;
@@ -234,7 +234,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
-    CO_CANsetConfigurationMode(CANmodule->CANdevicePtr);
+    CO_CANsetConfigurationMode(CANmodule->CANdriverState);
 }
 
 
@@ -354,7 +354,7 @@ static void CO_CANsendToModule(uint16_t dest, CO_CANtx_t *src){
 /******************************************************************************/
 CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer){
     CO_ReturnError_t err = CO_ERROR_NO;
-    uint16_t addr = CANmodule->CANdevicePtr;
+    uint16_t addr = CANmodule->CANdriverState;
 
     /* Verify overflow */
     if(buffer->bufferFull){
@@ -394,7 +394,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     uint8_t err;
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
 
-    err = CAN_REG(CANmodule->CANdevicePtr, C_INTF)>>8;
+    err = CAN_REG(CANmodule->CANdriverState, C_INTF)>>8;
 
     if(CANmodule->errOld != err){
         CANmodule->errOld = err;
@@ -402,7 +402,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
         /* CAN RX bus overflow */
         if(err & 0xC0){
             CO_errorReport(em, CO_EM_CAN_RXB_OVERFLOW, CO_EMC_CAN_OVERRUN, err);
-            CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0x3FFF;/* clear bits */
+            CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0x3FFF;/* clear bits */
         }
 
         /* CAN TX bus off */
@@ -447,7 +447,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
     uint16_t ICODE;
-    ICODE = CAN_REG(CANmodule->CANdevicePtr, C_CTRL) & 0xE;
+    ICODE = CAN_REG(CANmodule->CANdriverState, C_CTRL) & 0xE;
 
     /* receive interrupt 0 (New CAN messagge is available in RX buffer 0) */
     if(ICODE == 0xC){
@@ -457,7 +457,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdevicePtr + C_RXBUF0);
+        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdriverState + C_RXBUF0);
         rcvMsgIdent = rcvMsg->ident;
         /* CAN module filters are not used, message with any standard 11-bit identifier */
         /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
@@ -479,7 +479,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         rcvMsg->CON &= 0xFF7F;
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFE;
+        CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFE;
     }
 
 
@@ -491,7 +491,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         CO_CANrx_t *buffer = NULL;  /* receive message buffer from CO_CANmodule_t object. */
         bool_t msgMatched = false;
 
-        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdevicePtr + C_RXBUF1);
+        rcvMsg = (CO_CANrxMsg_t*) (CANmodule->CANdriverState + C_RXBUF1);
         rcvMsgIdent = rcvMsg->ident;
         /* CAN module filters are not used, message with any standard 11-bit identifier */
         /* has been received. Search rxArray form CANmodule for the same CAN-ID. */
@@ -513,20 +513,20 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
         rcvMsg->CON &= 0xFF7F;
 
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFD;
+        CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFD;
     }
 
 
     /* transmit interrupt (TX buffer is free) */
     else if(ICODE == 0x8){
         /* Clear interrupt flag */
-        CAN_REG(CANmodule->CANdevicePtr, C_INTF) &= 0xFFFB;
+        CAN_REG(CANmodule->CANdriverState, C_INTF) &= 0xFFFB;
         /* First CAN message (bootup) was sent successfully */
         CANmodule->firstCANtxMessage = false;
         /* clear flag from previous message */
         CANmodule->bufferInhibitFlag = false;
         /* Are there any new messages waiting to be send and buffer is free */
-        if(CANmodule->CANtxCount > 0U && (CAN_REG(CANmodule->CANdevicePtr, C_TXBUF0 + C_TXCON) & 0x8) == 0){
+        if(CANmodule->CANtxCount > 0U && (CAN_REG(CANmodule->CANdriverState, C_TXBUF0 + C_TXCON) & 0x8) == 0){
             uint16_t i;             /* index of transmitting message */
 
             /* first buffer */
@@ -540,7 +540,7 @@ void CO_CANinterrupt(CO_CANmodule_t *CANmodule){
 
                     /* Copy message to CAN buffer */
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
-                    CO_CANsendToModule(CANmodule->CANdevicePtr + C_TXBUF0, buffer);
+                    CO_CANsendToModule(CANmodule->CANdriverState + C_TXBUF0, buffer);
                     break;                      /* exit for loop */
                 }
                 buffer++;

--- a/stack/dsPIC30F/CO_driver.h
+++ b/stack/dsPIC30F/CO_driver.h
@@ -385,7 +385,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    uint16_t            CANbaseAddress;
+    void               *CANdevicePtr;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -405,14 +405,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/dsPIC30F/CO_driver.h
+++ b/stack/dsPIC30F/CO_driver.h
@@ -385,7 +385,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -405,14 +405,14 @@ typedef struct{
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/eCos/CO_driver.c
+++ b/stack/eCos/CO_driver.c
@@ -156,7 +156,7 @@ static void reportErrorReturnCode(Cyg_ErrNo ErrCode, CO_CANmodule_t *CANmodule,
  * Set mode of CAN controller (configuration, active...)
  * This function properly handles errors when setting mode
  */
-static void setCAN_Mode(cyg_can_mode mode, void *CANdevicePtr)
+static void setCAN_Mode(cyg_can_mode mode, void *CANdriverState)
 {
 	if (!can_module)
 	{
@@ -176,16 +176,16 @@ static void setCAN_Mode(cyg_can_mode mode, void *CANdevicePtr)
 
 
 //=============================================================================
-void CO_CANsetConfigurationMode(void *CANdevicePtr)
+void CO_CANsetConfigurationMode(void *CANdriverState)
 {
-	setCAN_Mode(CYGNUM_CAN_MODE_CONFIG, CANdevicePtr);
+	setCAN_Mode(CYGNUM_CAN_MODE_CONFIG, CANdriverState);
 }
 
 
 //=============================================================================
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 {
-	setCAN_Mode(CYGNUM_CAN_MODE_START, CANmodule->CANdevicePtr);
+	setCAN_Mode(CYGNUM_CAN_MODE_START, CANmodule->CANdriverState);
 
     CANmodule->CANnormal = true;
 }
@@ -510,7 +510,7 @@ Cyg_ErrNo canInit(CO_CANmodule_t* CANmodule, uint16_t CANbitRate)
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/eCos/CO_driver.c
+++ b/stack/eCos/CO_driver.c
@@ -156,7 +156,7 @@ static void reportErrorReturnCode(Cyg_ErrNo ErrCode, CO_CANmodule_t *CANmodule,
  * Set mode of CAN controller (configuration, active...)
  * This function properly handles errors when setting mode
  */
-static void setCAN_Mode(cyg_can_mode mode, uint16_t CANbaseAddress)
+static void setCAN_Mode(cyg_can_mode mode, void *CANdevicePtr)
 {
 	if (!can_module)
 	{
@@ -176,16 +176,16 @@ static void setCAN_Mode(cyg_can_mode mode, uint16_t CANbaseAddress)
 
 
 //=============================================================================
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress)
+void CO_CANsetConfigurationMode(void *CANdevicePtr)
 {
-	setCAN_Mode(CYGNUM_CAN_MODE_CONFIG, CANbaseAddress);
+	setCAN_Mode(CYGNUM_CAN_MODE_CONFIG, CANdevicePtr);
 }
 
 
 //=============================================================================
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 {
-	setCAN_Mode(CYGNUM_CAN_MODE_START, CANmodule->CANbaseAddress);
+	setCAN_Mode(CYGNUM_CAN_MODE_START, CANmodule->CANdevicePtr);
 
     CANmodule->CANnormal = true;
 }
@@ -510,7 +510,7 @@ Cyg_ErrNo canInit(CO_CANmodule_t* CANmodule, uint16_t CANbitRate)
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/eCos/CO_driver.h
+++ b/stack/eCos/CO_driver.h
@@ -195,14 +195,14 @@ extern "C"
 #endif
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(uint16_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 int16_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        uint16_t                CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t             *rxArray,
         uint16_t                rxSize,
         CO_CANtx_t             *txArray,

--- a/stack/eCos/CO_driver.h
+++ b/stack/eCos/CO_driver.h
@@ -195,14 +195,14 @@ extern "C"
 #endif
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 int16_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t             *rxArray,
         uint16_t                rxSize,
         CO_CANtx_t             *txArray,

--- a/stack/neuberger-socketCAN/CO_driver.c
+++ b/stack/neuberger-socketCAN/CO_driver.c
@@ -73,7 +73,7 @@ pthread_mutex_t CO_EMCY_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t CO_OD_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #ifndef CO_DRIVER_MULTI_INTERFACE
-static CO_ReturnError_t CO_CANmodule_addInterface(CO_CANmodule_t *CANmodule, void *CANdevicePtr);
+static CO_ReturnError_t CO_CANmodule_addInterface(CO_CANmodule_t *CANmodule, void *CANdriverState);
 #endif
 
 #ifdef CO_DRIVER_MULTI_INTERFACE
@@ -194,7 +194,7 @@ static CO_ReturnError_t setRxFilters(CO_CANmodule_t *CANmodule)
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr)
+void CO_CANsetConfigurationMode(void *CANdriverState)
 {
     /* Can't do anything because no object is provided */
 }
@@ -220,7 +220,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule)
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -293,7 +293,7 @@ CO_ReturnError_t CO_CANmodule_init(
         rxArray[i].object = NULL;
         rxArray[i].pFunct = NULL;
 #ifdef CO_DRIVER_MULTI_INTERFACE
-        rxArray[i].CANdevicePtr = NULL;
+        rxArray[i].CANdriverState = NULL;
         rxArray[i].timestamp.tv_sec = 0;
         rxArray[i].timestamp.tv_nsec = 0;
 #endif
@@ -301,7 +301,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
 #ifndef CO_DRIVER_MULTI_INTERFACE
     /* add one interface */
-    ret = CO_CANmodule_addInterface(CANmodule, CANdevicePtr);
+    ret = CO_CANmodule_addInterface(CANmodule, CANdriverState);
     if (ret != CO_ERROR_NO) {
         CO_CANmodule_disable(CANmodule);
     }
@@ -318,7 +318,7 @@ static
 #endif
 CO_ReturnError_t CO_CANmodule_addInterface(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr)
+        void                   *CANdriverState)
 {
     int32_t ret;
     int32_t tmp;
@@ -347,8 +347,8 @@ CO_ReturnError_t CO_CANmodule_addInterface(
     }
     interface = &CANmodule->CANinterfaces[CANmodule->CANinterfaceCount - 1];
 
-    interface->CANdevicePtr = CANdevicePtr;
-    ifName = if_indextoname(CANdevicePtr, interface->ifName);
+    interface->CANdriverState = CANdriverState;
+    ifName = if_indextoname(CANdriverState, interface->ifName);
     if (ifName == NULL) {
         log_printf(LOG_DEBUG, DBG_ERRNO, "if_indextoname()");
         return CO_ERROR_ILLEGAL_ARGUMENT;
@@ -396,7 +396,7 @@ CO_ReturnError_t CO_CANmodule_addInterface(
     /* bind socket */
     memset(&sockAddr, 0, sizeof(sockAddr));
     sockAddr.can_family = AF_CAN;
-    sockAddr.can_ifindex = CANdevicePtr;
+    sockAddr.can_ifindex = CANdriverState;
     ret = bind(interface->fd, (struct sockaddr*)&sockAddr, sizeof(sockAddr));
     if(ret < 0){
         log_printf(LOG_ERR, CAN_BINDING_FAILED, interface->ifName);
@@ -534,7 +534,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
             buffer->object = object;
             buffer->pFunct = pFunct;
 #ifdef CO_DRIVER_MULTI_INTERFACE
-            buffer->CANdevicePtr = NULL;
+            buffer->CANdriverState = NULL;
             buffer->timestamp.tv_nsec = 0;
             buffer->timestamp.tv_sec = 0;
 #endif
@@ -567,7 +567,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
 bool_t CO_CANrxBuffer_getInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        void                  **CANdevicePtrRx,
+        void                  **CANdriverStateRx,
         struct timespec        *timestamp)
 {
     if (CANmodule != NULL){
@@ -581,14 +581,14 @@ bool_t CO_CANrxBuffer_getInterface(
         buffer = &CANmodule->rxArray[index];
 
         /* return values */
-        if (CANdevicePtrRx != NULL) {
-            *CANdevicePtrRx = buffer->CANdevicePtr;
+        if (CANdriverStateRx != NULL) {
+            *CANdriverStateRx = buffer->CANdriverState;
         }
         if (timestamp != NULL) {
             *timestamp = buffer->timestamp;
         }
 
-        if (buffer->CANdevicePtr >= 0) {
+        if (buffer->CANdriverState >= 0) {
             return true;
         }
         else {
@@ -620,7 +620,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
        CO_CANsetIdentToIndex(CANmodule->txIdentToIndex, index, ident, buffer->ident);
 #endif
 
-        buffer->CANdevicePtr = NULL;
+        buffer->CANdriverState = NULL;
 
         /* CAN identifier and rtr */
         buffer->ident = ident & CAN_SFF_MASK;
@@ -641,7 +641,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
 CO_ReturnError_t CO_CANtxBuffer_setInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        void                   *CANdevicePtrTx)
+        void                   *CANdriverStateTx)
 {
     if (CANmodule != NULL) {
         uint32_t index;
@@ -650,7 +650,7 @@ CO_ReturnError_t CO_CANtxBuffer_setInterface(
         if ((index == CO_INVALID_COB_ID) || (index > CANmodule->txSize)) {
             return CO_ERROR_PARAMETERS;
         }
-        CANmodule->txArray[index].CANdevicePtr = CANdevicePtrTx;
+        CANmodule->txArray[index].CANdriverState = CANdriverStateTx;
 
         return CO_ERROR_NO;
     }
@@ -751,8 +751,8 @@ CO_ReturnError_t CO_CANCheckSend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer)
     for (i = 0; i < CANmodule->CANinterfaceCount; i++) {
         CO_CANinterface_t *interface = &CANmodule->CANinterfaces[i];
 
-        if ((buffer->CANdevicePtr == NULL) ||
-            buffer->CANdevicePtr == interface->CANdevicePtr) {
+        if ((buffer->CANdriverState == NULL) ||
+            buffer->CANdriverState == interface->CANdriverState) {
 
             CO_ReturnError_t tmp;
 
@@ -898,7 +898,7 @@ int32_t CO_CANrxWait(CO_CANmodule_t *CANmodule, int fdTimer, CO_CANrxMsg_t *buff
 {
     int32_t retval;
     int32_t ret;
-    void *CANdevicePtr __attribute__((unused));
+    void *CANdriverState __attribute__((unused));
     CO_ReturnError_t err;
     CO_CANinterface_t *interface = NULL;
     struct epoll_event ev[1];
@@ -958,7 +958,7 @@ int32_t CO_CANrxWait(CO_CANmodule_t *CANmodule, int fdTimer, CO_CANrxMsg_t *buff
 
                     if (ev[0].data.fd == interface->fd) {
                         /* get interface handle */
-                        CANdevicePtr = interface->CANdevicePtr;
+                        CANdriverState = interface->CANdriverState;
                         /* get message */
                         err = CO_CANread(CANmodule, interface, &msg, &timestamp);
                         if (err != CO_ERROR_NO) {
@@ -997,7 +997,7 @@ int32_t CO_CANrxWait(CO_CANmodule_t *CANmodule, int fdTimer, CO_CANrxMsg_t *buff
 #ifdef CO_DRIVER_MULTI_INTERFACE
                 /* Store message info */
                 CANmodule->rxArray[msgIndex].timestamp = timestamp;
-                CANmodule->rxArray[msgIndex].CANdevicePtr = CANdevicePtr;
+                CANmodule->rxArray[msgIndex].CANdriverState = CANdriverState;
 #endif
             }
             retval = msgIndex;

--- a/stack/neuberger-socketCAN/CO_driver.h
+++ b/stack/neuberger-socketCAN/CO_driver.h
@@ -62,7 +62,7 @@ extern "C" {
  * adds functions to broadcast/selective transmit messages on the
  * given interfaces as well as combining all received message into
  * one queue.
- * 
+ *
  * This is not intended to realize interface redundancy!!!
  */
 //#define CO_DRIVER_MULTI_INTERFACE
@@ -93,7 +93,7 @@ extern "C" {
  * socketCAN interface object
  */
 typedef struct {
-    int32_t             CANbaseAddress;   /**< CAN Interface identifier */
+    void               *CANdevicePtr;   /**< CAN Interface identifier */
     char                ifName[IFNAMSIZ]; /**< CAN Interface name */
     int                 fd;               /**< socketCAN file descriptor */
 #ifdef CO_DRIVER_ERROR_REPORTING
@@ -131,9 +131,9 @@ typedef struct{
 /**
  * Request CAN configuration (stopped) mode and *wait* until it is set.
  *
- * @param CANbaseAddress CAN module base address.
+ * @param CANdevicePtr CAN module base address.
  */
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 
 
 /**
@@ -152,7 +152,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANbaseAddress unused
+ * @param CANdevicePtr unused
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -169,7 +169,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANbaseAddress CAN module base address.
+ * @param CANdevicePtr CAN module base address.
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -182,7 +182,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 #endif
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -197,13 +197,13 @@ CO_ReturnError_t CO_CANmodule_init(
  * Function must be called after CO_CANmodule_init.
  *
  * @param CANmodule This object will be initialized.
- * @param CANbaseAddress CAN module base address.
+ * @param CANdevicePtr CAN module base address.
  * @return #CO_ReturnError_t: CO_ERROR_NO, CO_ERROR_ILLEGAL_ARGUMENT,
  * CO_ERROR_SYSCALL or CO_ERROR_INVALID_STATE.
  */
 CO_ReturnError_t CO_CANmodule_addInterface(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress);
+        void                   *CANdevicePtr);
 
 #endif
 
@@ -266,7 +266,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
  *
  * @param CANmodule This object.
  * @param ident 11-bit standard CAN Identifier.
- * @param [out] CANbaseAddressRx message was received on this interface
+ * @param [out] CANdevicePtrRx message was received on this interface
  * @param [out] timestamp message was received at this time (system clock)
  *
  * @retval false message has never been received, therefore no base address
@@ -276,7 +276,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
 bool_t CO_CANrxBuffer_getInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        int32_t                *CANbaseAddressRx,
+        void                  **CANdevicePtrRx,
         struct timespec        *timestamp);
 
 #endif
@@ -314,19 +314,19 @@ CO_CANtx_t *CO_CANtxBufferInit(
  * It is in the responsibility of the user to ensure that the correct interface
  * is used. Some messages need to be transmitted on all interfaces.
  *
- * If given interface is unknown or "-1" is used, a message is transmitted on
+ * If given interface is unknown or NULL is used, a message is transmitted on
  * all available interfaces.
  *
  * @param CANmodule This object.
  * @param ident 11-bit standard CAN Identifier.
- * @param CANbaseAddressTx use this interface. -1 = not specified
+ * @param CANdevicePtrTx use this interface. NULL = not specified
  *
  * @return #CO_ReturnError_t: CO_ERROR_NO or CO_ERROR_ILLEGAL_ARGUMENT.
  */
 CO_ReturnError_t CO_CANtxBuffer_setInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        int32_t                 CANbaseAddressTx);
+        void                   *CANdevicePtrTx);
 
 #endif
 

--- a/stack/neuberger-socketCAN/CO_driver.h
+++ b/stack/neuberger-socketCAN/CO_driver.h
@@ -93,7 +93,7 @@ extern "C" {
  * socketCAN interface object
  */
 typedef struct {
-    void               *CANdevicePtr;   /**< CAN Interface identifier */
+    void               *CANdriverState;   /**< CAN Interface identifier */
     char                ifName[IFNAMSIZ]; /**< CAN Interface name */
     int                 fd;               /**< socketCAN file descriptor */
 #ifdef CO_DRIVER_ERROR_REPORTING
@@ -131,9 +131,9 @@ typedef struct{
 /**
  * Request CAN configuration (stopped) mode and *wait* until it is set.
  *
- * @param CANdevicePtr CAN module base address.
+ * @param CANdriverState CAN module base address.
  */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 
 
 /**
@@ -152,7 +152,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANdevicePtr unused
+ * @param CANdriverState unused
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -169,7 +169,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
  * be in Configuration Mode before.
  *
  * @param CANmodule This object will be initialized.
- * @param CANdevicePtr CAN module base address.
+ * @param CANdriverState CAN module base address.
  * @param rxArray Array for handling received CAN messages
  * @param rxSize Size of the above array. Must be equal to number of receiving CAN objects.
  * @param txArray Array for handling transmitting CAN messages
@@ -182,7 +182,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 #endif
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -197,13 +197,13 @@ CO_ReturnError_t CO_CANmodule_init(
  * Function must be called after CO_CANmodule_init.
  *
  * @param CANmodule This object will be initialized.
- * @param CANdevicePtr CAN module base address.
+ * @param CANdriverState CAN module base address.
  * @return #CO_ReturnError_t: CO_ERROR_NO, CO_ERROR_ILLEGAL_ARGUMENT,
  * CO_ERROR_SYSCALL or CO_ERROR_INVALID_STATE.
  */
 CO_ReturnError_t CO_CANmodule_addInterface(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr);
+        void                   *CANdriverState);
 
 #endif
 
@@ -266,7 +266,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
  *
  * @param CANmodule This object.
  * @param ident 11-bit standard CAN Identifier.
- * @param [out] CANdevicePtrRx message was received on this interface
+ * @param [out] CANdriverStateRx message was received on this interface
  * @param [out] timestamp message was received at this time (system clock)
  *
  * @retval false message has never been received, therefore no base address
@@ -276,7 +276,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
 bool_t CO_CANrxBuffer_getInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        void                  **CANdevicePtrRx,
+        void                  **CANdriverStateRx,
         struct timespec        *timestamp);
 
 #endif
@@ -319,14 +319,14 @@ CO_CANtx_t *CO_CANtxBufferInit(
  *
  * @param CANmodule This object.
  * @param ident 11-bit standard CAN Identifier.
- * @param CANdevicePtrTx use this interface. NULL = not specified
+ * @param CANdriverStateTx use this interface. NULL = not specified
  *
  * @return #CO_ReturnError_t: CO_ERROR_NO or CO_ERROR_ILLEGAL_ARGUMENT.
  */
 CO_ReturnError_t CO_CANtxBuffer_setInterface(
         CO_CANmodule_t         *CANmodule,
         uint32_t                ident,
-        void                   *CANdevicePtrTx);
+        void                   *CANdriverStateTx);
 
 #endif
 

--- a/stack/neuberger-socketCAN/CO_driver_base.h
+++ b/stack/neuberger-socketCAN/CO_driver_base.h
@@ -281,7 +281,7 @@ typedef struct{
 
 #ifdef CO_DRIVER_MULTI_INTERFACE
     /** info about last received message */
-    void               *CANdevicePtr; /**< CAN Interface identifier */
+    void               *CANdriverState; /**< CAN Interface identifier */
     struct timespec     timestamp;      /**< time of reception */
 #endif
 }CO_CANrx_t;
@@ -301,7 +301,7 @@ typedef struct{
     volatile bool_t     syncFlag;
 
     /** info about transmit message */
-    void               *CANdevicePtr; /**< CAN Interface identifier to use */
+    void               *CANdriverState; /**< CAN Interface identifier to use */
 } CO_CANtx_t;
 
 /**

--- a/stack/neuberger-socketCAN/CO_driver_base.h
+++ b/stack/neuberger-socketCAN/CO_driver_base.h
@@ -281,7 +281,7 @@ typedef struct{
 
 #ifdef CO_DRIVER_MULTI_INTERFACE
     /** info about last received message */
-    int32_t             CANbaseAddress; /**< CAN Interface identifier */
+    void               *CANdevicePtr; /**< CAN Interface identifier */
     struct timespec     timestamp;      /**< time of reception */
 #endif
 }CO_CANrx_t;
@@ -301,7 +301,7 @@ typedef struct{
     volatile bool_t     syncFlag;
 
     /** info about transmit message */
-    int32_t             CANbaseAddress; /**< CAN Interface identifier to use */
+    void               *CANdevicePtr; /**< CAN Interface identifier to use */
 } CO_CANtx_t;
 
 /**

--- a/stack/socketCAN/CO_driver.c
+++ b/stack/socketCAN/CO_driver.c
@@ -99,7 +99,7 @@ static CO_ReturnError_t setFilters(CO_CANmodule_t *CANmodule){
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(void *CANdevicePtr){
+void CO_CANsetConfigurationMode(void *CANdriverState){
 }
 
 
@@ -116,7 +116,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -127,13 +127,13 @@ CO_ReturnError_t CO_CANmodule_init(
     uint16_t i;
 
     /* verify arguments */
-    if(CANmodule==NULL || CANdevicePtr==NULL || rxArray==NULL || txArray==NULL){
+    if(CANmodule==NULL || CANdriverState==NULL || rxArray==NULL || txArray==NULL){
         ret = CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
     /* Configure object variables */
     if(ret == CO_ERROR_NO){
-        CANmodule->CANdevicePtr = CANdevicePtr;
+        CANmodule->CANdriverState = CANdriverState;
         CANmodule->rxArray = rxArray;
         CANmodule->rxSize = rxSize;
         CANmodule->txArray = txArray;
@@ -173,7 +173,7 @@ CO_ReturnError_t CO_CANmodule_init(
         if(CANmodule->fd < 0){
             ret = CO_ERROR_ILLEGAL_ARGUMENT;
         }else{
-            const int * const ifindex_ptr = CANdevicePtr;
+            const int * const ifindex_ptr = CANdriverState;
             sockAddr.can_family = AF_CAN;
             sockAddr.can_ifindex = *ifindex_ptr;
             if(bind(CANmodule->fd, (struct sockaddr*)&sockAddr, sizeof(sockAddr)) != 0){
@@ -336,7 +336,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
     uint32_t err;
 
-    canGetErrorCounters(CANmodule->CANdevicePtr, &rxErrors, &txErrors);
+    canGetErrorCounters(CANmodule->CANdriverState, &rxErrors, &txErrors);
     if(txErrors > 0xFFFF) txErrors = 0xFFFF;
     if(rxErrors > 0xFF) rxErrors = 0xFF;
 

--- a/stack/socketCAN/CO_driver.c
+++ b/stack/socketCAN/CO_driver.c
@@ -99,7 +99,7 @@ static CO_ReturnError_t setFilters(CO_CANmodule_t *CANmodule){
 
 
 /******************************************************************************/
-void CO_CANsetConfigurationMode(int32_t CANbaseAddress){
+void CO_CANsetConfigurationMode(void *CANdevicePtr){
 }
 
 
@@ -116,7 +116,7 @@ void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule){
 /******************************************************************************/
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],
@@ -127,13 +127,13 @@ CO_ReturnError_t CO_CANmodule_init(
     uint16_t i;
 
     /* verify arguments */
-    if(CANmodule==NULL || CANbaseAddress==0 || rxArray==NULL || txArray==NULL){
+    if(CANmodule==NULL || CANdevicePtr==NULL || rxArray==NULL || txArray==NULL){
         ret = CO_ERROR_ILLEGAL_ARGUMENT;
     }
 
     /* Configure object variables */
     if(ret == CO_ERROR_NO){
-        CANmodule->CANbaseAddress = CANbaseAddress;
+        CANmodule->CANdevicePtr = CANdevicePtr;
         CANmodule->rxArray = rxArray;
         CANmodule->rxSize = rxSize;
         CANmodule->txArray = txArray;
@@ -173,8 +173,9 @@ CO_ReturnError_t CO_CANmodule_init(
         if(CANmodule->fd < 0){
             ret = CO_ERROR_ILLEGAL_ARGUMENT;
         }else{
+            const int * const ifindex_ptr = CANdevicePtr;
             sockAddr.can_family = AF_CAN;
-            sockAddr.can_ifindex = CANbaseAddress;
+            sockAddr.can_ifindex = *ifindex_ptr;
             if(bind(CANmodule->fd, (struct sockaddr*)&sockAddr, sizeof(sockAddr)) != 0){
                 ret = CO_ERROR_ILLEGAL_ARGUMENT;
             }
@@ -335,7 +336,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule){
     CO_EM_t* em = (CO_EM_t*)CANmodule->em;
     uint32_t err;
 
-    canGetErrorCounters(CANmodule->CANbaseAddress, &rxErrors, &txErrors);
+    canGetErrorCounters(CANmodule->CANdevicePtr, &rxErrors, &txErrors);
     if(txErrors > 0xFFFF) txErrors = 0xFFFF;
     if(rxErrors > 0xFF) rxErrors = 0xFF;
 

--- a/stack/socketCAN/CO_driver.h
+++ b/stack/socketCAN/CO_driver.h
@@ -143,7 +143,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    void               *CANdevicePtr;
+    void               *CANdriverState;
 #ifdef CO_LOG_CAN_MESSAGES
     CO_CANtx_t          txRecord;
 #endif
@@ -180,14 +180,14 @@ void CO_errExit(char* msg);
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdevicePtr);
+void CO_CANsetConfigurationMode(void *CANdriverState);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        void                   *CANdevicePtr,
+        void                   *CANdriverState,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],

--- a/stack/socketCAN/CO_driver.h
+++ b/stack/socketCAN/CO_driver.h
@@ -143,7 +143,7 @@ typedef struct{
 
 /* CAN module object. */
 typedef struct{
-    int32_t             CANbaseAddress;
+    void               *CANdevicePtr;
 #ifdef CO_LOG_CAN_MESSAGES
     CO_CANtx_t          txRecord;
 #endif
@@ -180,14 +180,14 @@ void CO_errExit(char* msg);
 
 
 /* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(int32_t fdSocket);
+void CO_CANsetConfigurationMode(void *CANdevicePtr);
 void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
 
 
 /* Initialize CAN module object. */
 CO_ReturnError_t CO_CANmodule_init(
         CO_CANmodule_t         *CANmodule,
-        int32_t                 CANbaseAddress,
+        void                   *CANdevicePtr,
         CO_CANrx_t              rxArray[],
         uint16_t                rxSize,
         CO_CANtx_t              txArray[],


### PR DESCRIPTION
Previously, the address of the CAN device (`CANbaseAddress`)
was specified as a signed or unsigned integer of variable size.
This made the ABI specific for each driver and is not generic
enough for some use cases.

Replaced all usages by a void pointer. Renamed `CANbaseAddress`
to `CANdevicePtr`.
Refactored the code where it needed to be (some comparisons to -1).