### PR TITLE
Sync: fix cast to integer of different size

### DIFF
--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -197,7 +197,7 @@ extern "C" {
 /** Memory barrier */
 #define CANrxMemoryBarrier()
 /** Check if new message has arrived */
-#define IS_CANrxNew(rxNew) ((int)rxNew)
+#define IS_CANrxNew(rxNew) ((uintptr_t)rxNew)
 /** Set new message flag */
 #define SET_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)1L;}
 /** Clear new message flag */

--- a/stack/neuberger-socketCAN/CO_driver_base.h
+++ b/stack/neuberger-socketCAN/CO_driver_base.h
@@ -204,7 +204,7 @@ static inline void CO_UNLOCK_OD()   { (void)pthread_mutex_unlock(&CO_OD_mutex); 
 /** Memory barrier */
 #define CANrxMemoryBarrier() {__sync_synchronize();}
 /** Check if new message has arrived */
-#define IS_CANrxNew(rxNew) ((int)rxNew)
+#define IS_CANrxNew(rxNew) ((uintptr_t)rxNew)
 /** Set new message flag */
 #define SET_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)1L;}
 /** Clear new message flag */

--- a/stack/socketCAN/CO_driver.h
+++ b/stack/socketCAN/CO_driver.h
@@ -79,7 +79,7 @@
 #endif
 
 /* Syncronisation functions */
-#define IS_CANrxNew(rxNew) ((int)rxNew)
+#define IS_CANrxNew(rxNew) ((uintptr_t)rxNew)
 #define SET_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)1L;}
 #define CLEAR_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)0L;}
 


### PR DESCRIPTION
Cast the pointer to `uintptr_t` instead of `int` in the implementations
of `IS_CANrxNew`.