### PR TITLE
Fix bool equality checks

### DIFF
--- a/stack/CO_LSSslave.c
+++ b/stack/CO_LSSslave.c
@@ -212,7 +212,7 @@ static void CO_LSSslave_serviceConfig(
                 /* Store "pending" to "persistent" */
                 result = LSSslave->pFunctLSScfgStore(LSSslave->functLSScfgStore,
                     LSSslave->pendingNodeID, LSSslave->pendingBitRate);
-                if (result != true) {
+                if (!result) {
                     errorCode = CO_LSS_CFG_STORE_FAILED;
                 }
             }
@@ -331,7 +331,7 @@ static void CO_LSSslave_serviceIdent(
             }
         }
     }
-    if (ack == true) {
+    if (ack) {
         LSSslave->TXbuff->data[0] = CO_LSS_IDENT_SLAVE;
         CO_memset(&LSSslave->TXbuff->data[1], 0, 7);
         CO_CANsend(LSSslave->CANdevTx, LSSslave->TXbuff);

--- a/stack/CO_PDO.c
+++ b/stack/CO_PDO.c
@@ -916,7 +916,10 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas){
     }
     else if(!RPDO->synchronous || syncWas)
     {
+#if defined(RPDO_CALLS_EXTENSION)
         bool_t update = false;
+#endif /* defined(RPDO_CALLS_EXTENSION) */
+
         uint8_t bufNo = 0;
 
         /* Determine, which of the two rx buffers, contains relevant message. */
@@ -939,10 +942,12 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas){
             for(; i>0; i--) {
                 **(ppODdataByte++) = *(pPDOdataByte++);
             }
+#if defined(RPDO_CALLS_EXTENSION)
             update = true;
+#endif /* defined(RPDO_CALLS_EXTENSION) */
         }
 #ifdef RPDO_CALLS_EXTENSION
-        if(update==true && RPDO->SDO->ODExtensions){
+        if(update && RPDO->SDO->ODExtensions){
             int16_t i;
             /* for each mapped OD, check mapping to see if an OD extension is available, and call it if it is */
             const uint32_t* pMap = &RPDO->RPDOMapPar->mappedObject1;

--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -514,7 +514,7 @@ uint16_t CO_OD_getAttribute(CO_SDO_t *SDO, uint16_t entryNo, uint8_t subIndex){
             attr |= CO_ODA_WRITEABLE;
         }
 
-        if(subIndex == 0U  && exception_1003 == false){
+        if(subIndex == 0U  && exception_1003){
             /* First subIndex is readonly */
             attr &= ~(CO_ODA_WRITEABLE | CO_ODA_RPDO_MAPABLE);
             attr |= CO_ODA_READABLE;
@@ -757,7 +757,7 @@ uint32_t CO_SDO_writeOD(CO_SDO_t *SDO, uint16_t length){
     }
 
     /* copy data from SDO buffer to OD if not domain */
-    if(ODdata != NULL && exception_1003 == false){
+    if((ODdata != NULL) && exception_1003){
         while(length--){
             *(ODdata++) = *(SDObuffer++);
         }

--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -514,7 +514,7 @@ uint16_t CO_OD_getAttribute(CO_SDO_t *SDO, uint16_t entryNo, uint8_t subIndex){
             attr |= CO_ODA_WRITEABLE;
         }
 
-        if(subIndex == 0U  && exception_1003){
+        if(subIndex == 0U  && !exception_1003){
             /* First subIndex is readonly */
             attr &= ~(CO_ODA_WRITEABLE | CO_ODA_RPDO_MAPABLE);
             attr |= CO_ODA_READABLE;
@@ -757,7 +757,7 @@ uint32_t CO_SDO_writeOD(CO_SDO_t *SDO, uint16_t length){
     }
 
     /* copy data from SDO buffer to OD if not domain */
-    if((ODdata != NULL) && exception_1003){
+    if((ODdata != NULL) && !exception_1003){
         while(length--){
             *(ODdata++) = *(SDObuffer++);
         }

--- a/stack/neuberger-socketCAN/CO_Linux_threads.c
+++ b/stack/neuberger-socketCAN/CO_Linux_threads.c
@@ -165,7 +165,7 @@ void CANrx_threadTmr_process(void)
       /* at least one timer interval occured */
       CO_LOCK_OD();
 
-      if(CO->CANmodule[0]->CANnormal == true) {
+      if(CO->CANmodule[0]->CANnormal) {
 
         for (i = 0; i <= missed; i++) {
           /* Process Sync and read inputs */

--- a/stack/neuberger-socketCAN/CO_driver.c
+++ b/stack/neuberger-socketCAN/CO_driver.c
@@ -332,7 +332,7 @@ CO_ReturnError_t CO_CANmodule_addInterface(
     can_err_mask_t err_mask;
 #endif
 
-    if (CANmodule->CANnormal != false) {
+    if (!CANmodule->CANnormal) {
         /* can't change config now! */
         return CO_ERROR_INVALID_STATE;
     }
@@ -570,32 +570,27 @@ bool_t CO_CANrxBuffer_getInterface(
         int32_t                *CANbaseAddressRx,
         struct timespec        *timestamp)
 {
-    if (CANmodule != NULL){
-        uint32_t index;
-        CO_CANrx_t *buffer;
-
-        index = CO_CANgetIndexFromIdent(CANmodule->rxIdentToIndex, ident);
-        if ((index == CO_INVALID_COB_ID) || (index > CANmodule->rxSize)) {
-            return false;
-        }
-        buffer = &CANmodule->rxArray[index];
-
-        /* return values */
-        if (CANbaseAddressRx != NULL) {
-            *CANbaseAddressRx = buffer->CANbaseAddress;
-        }
-        if (timestamp != NULL) {
-            *timestamp = buffer->timestamp;
-        }
-
-        if (buffer->CANbaseAddress >= 0) {
-            return true;
-        }
-        else {
-            return false;
-        }
+    if (CANmodule == NULL){
+        return false;
     }
-    return false;
+    uint32_t index;
+    CO_CANrx_t *buffer;
+
+    const uint32_t index = CO_CANgetIndexFromIdent(CANmodule->rxIdentToIndex, ident);
+    if ((index == CO_INVALID_COB_ID) || (index > CANmodule->rxSize)) {
+      return false;
+    }
+    buffer = &CANmodule->rxArray[index];
+
+    /* return values */
+    if (CANbaseAddressRx != NULL) {
+      *CANbaseAddressRx = buffer->CANbaseAddress;
+    }
+    if (timestamp != NULL) {
+      *timestamp = buffer->timestamp;
+    }
+
+    return buffer->CANbaseAddress >= 0;
 }
 
 #endif

--- a/stack/neuberger-socketCAN/CO_error.c
+++ b/stack/neuberger-socketCAN/CO_error.c
@@ -174,7 +174,7 @@ static CO_CANinterfaceState_t CO_CANerrorNoack(
 {
     CO_CANinterfaceState_t result = CO_INTERFACE_ACTIVE;
 
-    if (CANerrorhandler->listenOnly == true) {
+    if (CANerrorhandler->listenOnly) {
         return CO_INTERFACE_LISTEN_ONLY;
     }
 
@@ -240,7 +240,7 @@ void CO_CANerror_rxMsg(
     }
 
     /* someone is active, we can leave listen only immediately */
-    if (CANerrorhandler->listenOnly == true) {
+    if (CANerrorhandler->listenOnly) {
         CO_CANerrorClearListenOnly(CANerrorhandler);
     }
     CANerrorhandler->noackCounter = 0;
@@ -257,7 +257,7 @@ CO_CANinterfaceState_t CO_CANerror_txMsg(
         return CO_INTERFACE_BUS_OFF;
     }
 
-    if (CANerrorhandler->listenOnly == true) {
+    if (CANerrorhandler->listenOnly) {
         clock_gettime(CLOCK_MONOTONIC, &now);
         if (CANerrorhandler->timestamp.tv_sec + CO_CANerror_LISTEN_ONLY < now.tv_sec) {
             /* let's try that again. Maybe someone is waiting for LSS now. It
@@ -308,4 +308,3 @@ CO_CANinterfaceState_t CO_CANerror_rxMsgError(
 
     return CO_INTERFACE_ACTIVE;
 }
-


### PR DESCRIPTION
Removed comparisons of boolean values to `false` and `true`. Evaluating
them is enough.