### PR TITLE
Single project-wide header for driver functions

### DIFF
--- a/CO_types.h
+++ b/CO_types.h
@@ -1,0 +1,106 @@
+/**
+ * CANopenNode types.
+ *
+ * Defines common types for CANopenNode.
+ *
+ * @file        CO_types.h
+ * @ingroup     CO_CANopen
+ * @author      Olivier Desenfans
+ * @copyright   2004 - 2019 Janez Paternoster
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * CANopenNode is free and open source software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Following clarification and special exception to the GNU General Public
+ * License is included to the distribution terms of CANopenNode:
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library. Thus, the terms and
+ * conditions of the GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give
+ * you permission to link this library with independent modules to
+ * produce an executable, regardless of the license terms of these
+ * independent modules, and to copy and distribute the resulting
+ * executable under terms of your choice, provided that you also meet,
+ * for each linked independent module, the terms and conditions of the
+ * license of that module. An independent module is a module which is
+ * not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the
+ * library, but you are not obliged to do so. If you do not wish
+ * to do so, delete this exception statement from your version.
+ */
+
+#ifndef CO_TYPES_H
+#define CO_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * Return values of some CANopen functions.
+ *
+ * A function should return 0 on success and a negative value on error.
+ */
+typedef enum {
+    /** Operation completed successfully */
+    CO_ERROR_NO = 0,
+    /** Error in function arguments */
+    CO_ERROR_ILLEGAL_ARGUMENT = -1,
+    /** Memory allocation failed */
+    CO_ERROR_OUT_OF_MEMORY = -2,
+    /** Function timeout */
+    CO_ERROR_TIMEOUT = -3,
+    /** Illegal baudrate passed to function CO_CANmodule_init() */
+    CO_ERROR_ILLEGAL_BAUDRATE = -4,
+    /** Previous message was not processed yet */
+    CO_ERROR_RX_OVERFLOW = -5,
+    /** previous PDO was not processed yet */
+    CO_ERROR_RX_PDO_OVERFLOW = -6,
+    /** Wrong receive message length */
+    CO_ERROR_RX_MSG_LENGTH = -7,
+    /** Wrong receive PDO length */
+    CO_ERROR_RX_PDO_LENGTH = -8,
+    /** Previous message is still waiting, buffer full */
+    CO_ERROR_TX_OVERFLOW = -9,
+    /** Synchronous TPDO is outside window */
+    CO_ERROR_TX_PDO_WINDOW = -10,
+    /** Transmit buffer was not confugured properly */
+    CO_ERROR_TX_UNCONFIGURED = -11,
+    /** Error in function function parameters */
+    CO_ERROR_PARAMETERS = -12,
+    /** Stored data are corrupt */
+    CO_ERROR_DATA_CORRUPT = -13,
+    /** CRC does not match */
+    CO_ERROR_CRC = -14,
+    /** Sending rejected because driver is busy. Try again */
+    CO_ERROR_TX_BUSY = -15,
+    /** Command can't be processed in current state */
+    CO_ERROR_WRONG_NMT_STATE = -16,
+    /** Syscall failed */
+    CO_ERROR_SYSCALL = -17,
+    /** Driver not ready */
+    CO_ERROR_INVALID_STATE = -18,
+} CO_ReturnError_t;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/** @} */
+#endif /* CO_TYPES_H */

--- a/stack/LPC1768/CO_driver_target.h
+++ b/stack/LPC1768/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for LPC1768 microcontroller using Mbed SDK.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @ingroup     CO_driver
  * @author      Benoit Rapidel
  * @copyright   2016 Benoit Rapidel
@@ -44,8 +44,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 /* For documentation see file drvTemplate/CO_driver.h */
@@ -56,49 +56,32 @@
 #include <stdbool.h>        /* for 'true', 'false' */
 
 
+/* Endianness */
+#define CO_LITTLE_ENDIAN
+
 /* CAN module base address */
 #define MBED_CAN 1
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()
-    #define CO_UNLOCK_CAN_SEND()
+#define CO_LOCK_CAN_SEND()
+#define CO_UNLOCK_CAN_SEND()
 
-    #define CO_LOCK_EMCY()
-    #define CO_UNLOCK_EMCY()
+#define CO_LOCK_EMCY()
+#define CO_UNLOCK_EMCY()
 
-    #define CO_LOCK_OD()
-    #define CO_UNLOCK_OD()
+#define CO_LOCK_OD()
+#define CO_UNLOCK_OD()
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN receive message structure as aligned in CAN module. */
@@ -145,69 +128,8 @@ typedef struct{
 }CO_CANmodule_t;
 
 
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
 /* Receives and transmits CAN messages. */
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/LPC177x_8x/CO_driver_target.h
+++ b/stack/LPC177x_8x/CO_driver_target.h
@@ -3,7 +3,7 @@
  *
  * This file is a template for other microcontrollers.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @author      Amit H
  * @copyright   2004 - 2014 Janez Paternoster
@@ -46,11 +46,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
-
-
-/* For documentation see file drvTemplate/CO_driver.h */
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 #include "FreeRTOS.h"
@@ -60,65 +57,48 @@
 #include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
 
 
+/* Endianness */
+#define CO_LITTLE_ENDIAN
+
 /* CAN module base address */
-    #define ADDR_CAN1               0
-    #define ADDR_CAN2               1
+#define ADDR_CAN1               0
+#define ADDR_CAN2               1
 
 
-    #define CAN_NODE_ID_0_PORT      1
-    #define CAN_NODE_ID_0_PIN       23
-    #define CAN_NODE_ID_1_PORT      1
-    #define CAN_NODE_ID_1_PIN       24
-    #define CAN_NODE_ID_2_PORT      1
-    #define CAN_NODE_ID_2_PIN       25
-    #define CAN_NODE_ID_3_PORT      1
-    #define CAN_NODE_ID_3_PIN       26
-    #define CAN_NODE_ID_4_PORT      1
-    #define CAN_NODE_ID_4_PIN       28
+#define CAN_NODE_ID_0_PORT      1
+#define CAN_NODE_ID_0_PIN       23
+#define CAN_NODE_ID_1_PORT      1
+#define CAN_NODE_ID_1_PIN       24
+#define CAN_NODE_ID_2_PORT      1
+#define CAN_NODE_ID_2_PIN       25
+#define CAN_NODE_ID_3_PORT      1
+#define CAN_NODE_ID_3_PIN       26
+#define CAN_NODE_ID_4_PORT      1
+#define CAN_NODE_ID_4_PIN       28
 
-    #define CAN_RUN_LED_PORT        1
-    #define CAN_RUN_LED_PIN         20
+#define CAN_RUN_LED_PORT        1
+#define CAN_RUN_LED_PIN         20
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      taskENTER_CRITICAL()
-    #define CO_UNLOCK_CAN_SEND()    taskEXIT_CRITICAL()
+#define CO_LOCK_CAN_SEND()      taskENTER_CRITICAL()
+#define CO_UNLOCK_CAN_SEND()    taskEXIT_CRITICAL()
 
-    #define CO_LOCK_EMCY()          taskENTER_CRITICAL()
-    #define CO_UNLOCK_EMCY()        taskEXIT_CRITICAL()
+#define CO_LOCK_EMCY()          taskENTER_CRITICAL()
+#define CO_UNLOCK_EMCY()        taskEXIT_CRITICAL()
 
-    #define CO_LOCK_OD()            taskENTER_CRITICAL()
-    #define CO_UNLOCK_OD()          taskEXIT_CRITICAL()
+#define CO_LOCK_OD()            taskENTER_CRITICAL()
+#define CO_UNLOCK_OD()          taskEXIT_CRITICAL()
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN receive message structure as aligned in CAN module. */
@@ -167,70 +147,8 @@ typedef struct{
     void               *em;
 }CO_CANmodule_t;
 
-
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
 /* CAN interrupt receives and transmits CAN messages. */
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/MCF5282/CO_driver_target.h
+++ b/stack/MCF5282/CO_driver_target.h
@@ -1,9 +1,10 @@
 /*
- * CAN module object for Microchip PIC32MX microcontroller.
+ * CAN module object for Freescale MCF5282 ColdFire V2 microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
- * @copyright   2004 - 2015 Janez Paternoster
+ * @author      Laurent Grosbois
+ * @copyright   2004 - 2014 Janez Paternoster
  *
  * This file is part of CANopenNode, an opensource CANopen Stack.
  * Project home page is <https://github.com/CANopenNode/CANopenNode>.
@@ -43,53 +44,46 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
-/* For documentation see file drvTemplate/CO_driver.h */
-
-
-#include <p32xxxx.h>        /* processor header file */
+#include "mcf5282.h"        /* processor header file */
 #include <stddef.h>         /* for 'NULL' */
 #include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
-#include <stdbool.h>        /* for 'true', 'false' */
 
+
+/* Endianness */
+#define CO_LITTLE_ENDIAN
 
 /* CAN module base address */
-    #define ADDR_CAN1               0
-    #define ADDR_CAN2               (_CAN2_BASE_ADDRESS - _CAN1_BASE_ADDRESS)
-
-
-/* Translate a kernel virtual address in KSEG0 or KSEG1 to a real
- * physical address and back. */
-    typedef unsigned long CO_paddr_t; /* a physical address */
-    typedef unsigned long CO_vaddr_t; /* a virtual address */
-    #define CO_KVA_TO_PA(v) 	((CO_paddr_t)(v) & 0x1fffffff)
-    #define CO_PA_TO_KVA0(pa)	((void *) ((pa) | 0x80000000))
-    #define CO_PA_TO_KVA1(pa)	((void *) ((pa) | 0xa0000000))
+#define ADDR_CAN1               0
+#define ADDR_CAN2               (_CAN2_BASE_ADDRESS - _CAN1_BASE_ADDRESS)
 
 
 /* Critical sections */
-    extern unsigned int CO_interruptStatus;
-    #define CO_LOCK_CAN_SEND()      CO_interruptStatus = __builtin_disable_interrupts()
-    #define CO_UNLOCK_CAN_SEND()    if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
+#define CO_LOCK_CAN_SEND()      asm{ move.w        #0x2700,sr};
+#define CO_UNLOCK_CAN_SEND()    asm{ move.w        #0x2000,sr};
 
-    #define CO_LOCK_EMCY()          CO_interruptStatus = __builtin_disable_interrupts()
-    #define CO_UNLOCK_EMCY()        if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
+#define CO_LOCK_EMCY()          asm{ move.w        #0x2700,sr};
+#define CO_UNLOCK_EMCY()        asm{ move.w        #0x2000,sr};
 
-    #define CO_LOCK_OD()            CO_interruptStatus = __builtin_disable_interrupts()
-    #define CO_UNLOCK_OD()          if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
+#define CO_LOCK_OD()            asm{ move.w        #0x2700,sr};
+#define CO_UNLOCK_OD()          asm{ move.w        #0x2000,sr};
+
+
+/* MACRO : get information from Rx buffer */
+#define MCF_CANMB_MSG(x)      (*(CO_CANrxMsg_t *)(&__IPSBAR[0x1C0080 + ((x)*0x10)]))
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN bit rates
@@ -311,35 +305,15 @@ typedef struct{
 }CO_CANbitRateData_t;
 
 
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
-
-
 /* CAN receive message structure as aligned in CAN module. */
 typedef struct{
-    unsigned    ident    :11;   /* Standard Identifier */
-    unsigned    FILHIT   :5;    /* Filter hit, see PIC32MX documentation */
-    unsigned    CMSGTS   :16;   /* CAN message timestamp, see PIC32MX documentation */
-    unsigned    DLC      :4;    /* Data length code (bits 0...3) */
-    unsigned             :5;
-    unsigned    RTR      :1;    /* Remote Transmission Request bit */
-    unsigned             :22;
+    unsigned    timestamp   :8; /* 8 bits timestamp, see MCF5282 documentation */
+    unsigned    code        :4; /* Message Buffer code. see MCF52825 documentation */
+    unsigned    DLC         :4; /* Data length code */
+    unsigned    sid         :11;/* Standard Identifier - 11bits */
+    unsigned    RTR         :1; /* Remote Transmission Request bit */
+    unsigned                :4;
+    unsigned    timestamp16 :16;/* See MCF5282 documentation */
     uint8_t     data[8];        /* 8 data bytes */
 }CO_CANrxMsg_t;
 
@@ -355,8 +329,8 @@ typedef struct{
 
 /* Transmit message object. */
 typedef struct{
-    uint32_t            CMSGSID;     /* Equal to register in transmit message buffer. Includes standard Identifier */
-    uint32_t            CMSGEID;     /* Equal to register in transmit message buffer. Includes data length code and RTR */
+    uint8_t             DLC;
+    uint16_t            ident;
     uint8_t             data[8];
     volatile bool_t     bufferFull;
     volatile bool_t     syncFlag;
@@ -366,8 +340,8 @@ typedef struct{
 /* CAN module object. */
 typedef struct{
     void               *CANdriverState;
-    CO_CANrxMsg_t       CANmsgBuff[33]; /* PIC32 specific: CAN message buffer for CAN module. 32 buffers for receive, 1 buffer for transmit */
-    uint8_t             CANmsgBuffSize; /* PIC32 specific: Size of the above buffer == 33. Take care initial value! */
+    CO_CANrxMsg_t      *CANmsgBuff;
+    uint8_t             CANmsgBuffSize;
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -382,80 +356,8 @@ typedef struct{
 }CO_CANmodule_t;
 
 
-/* Endianes */
-#define CO_LITTLE_ENDIAN
+/* CAN interrupt receives and transmits CAN messages. */
+void CO_CANinterrupt(CO_CANmodule_t *CANmodule, uint16_t ICODE);
 
 
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object.
- *
- * PIC32MX CAN FIFO configuration: Two FIFOs are used. First FIFO is 32 messages
- * long and is used for reception. Second is used for transmission and is 1
- * message long. Format of message in fifo is described by CO_CANrxMsg_t for
- * both: receiving and transmitting messages. However transmitting messages does
- * not use all structure members.
- */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
-/* CAN interrupt receives and transmits CAN messages.
- *
- * Function must be called directly from _C1Interrupt or _C2Interrupt with
- * high priority.
- */
-void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
-
-
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/PIC24_dsPIC33/CO_driver_target.h
+++ b/stack/PIC24_dsPIC33/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for Microchip dsPIC33 or PIC24 microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @author      Peter Rozsahegyi (EDS)
  * @author      Jens Nielsen (CAN receive)
@@ -45,11 +45,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
-
-
-/* For documentation see file drvTemplate/CO_driver.h */
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 #if defined(__dsPIC33F__) || defined(__PIC24H__)
@@ -61,91 +58,93 @@
 #include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
 #include <stdbool.h>        /* for 'true' and 'false' */
 
+/* Endianness */
+#define CO_LITTLE_ENDIAN
 
 /* CAN message buffer sizes for CAN module 1 and 2. Valid values
  * are 0, 4, 6, 8, 12, 16. Default is one TX and seven RX messages (FIFO). */
-    #ifndef CO_CAN1msgBuffSize
-        #define CO_CAN1msgBuffSize   8
-    #endif
-    #ifndef CO_CAN2msgBuffSize
-        #define CO_CAN2msgBuffSize   0  //CAN module 2 not used by default
-    #endif
+#ifndef CO_CAN1msgBuffSize
+    #define CO_CAN1msgBuffSize   8
+#endif /* CO_CAN1msgBuffSize */
+#ifndef CO_CAN2msgBuffSize
+    #define CO_CAN2msgBuffSize   0  //CAN module 2 not used by default
+#endif /* CO_CAN2msgBuffSize */
 
 
 /* Default DMA addresses for CAN modules. */
-    #ifndef CO_CAN1_DMA0
-        #define CO_CAN1_DMA0 ADDR_DMA0
-    #endif
-    #ifndef CO_CAN1_DMA1
-        #define CO_CAN1_DMA1 ADDR_DMA1
-    #endif
-    #ifndef CO_CAN2_DMA0
-        #define CO_CAN2_DMA0 ADDR_DMA2
-    #endif
-    #ifndef CO_CAN2_DMA1
-        #define CO_CAN2_DMA1 ADDR_DMA3
-    #endif
+#ifndef CO_CAN1_DMA0
+    #define CO_CAN1_DMA0 ADDR_DMA0
+#endif /* CO_CAN1_DMA0 */
+#ifndef CO_CAN1_DMA1
+    #define CO_CAN1_DMA1 ADDR_DMA1
+#endif /* CO_CAN1_DMA1 */
+#ifndef CO_CAN2_DMA0
+    #define CO_CAN2_DMA0 ADDR_DMA2
+#endif /* CO_CAN2_DMA0 */
+#ifndef CO_CAN2_DMA1
+    #define CO_CAN2_DMA1 ADDR_DMA3
+#endif /* CO_CAN2_DMA1 */
 
 
 /* Define DMA attribute on supported platforms */
-    #if defined(__dsPIC33F__) || defined(__PIC24H__) || defined(__DMA_BASE)
-        #define __dma  __attribute__((space(dma)))
-    #else
-        #define __dma
-        #if defined(__C30_VERSION__) && !defined(__XC16_VERSION__)
-            #define __builtin_dmaoffset(V)  (uint16_t)V
-        #endif
+#if defined(__dsPIC33F__) || defined(__PIC24H__) || defined(__DMA_BASE)
+    #define __dma  __attribute__((space(dma)))
+#else
+    #define __dma
+    #if defined(__C30_VERSION__) && !defined(__XC16_VERSION__)
+        #define __builtin_dmaoffset(V)  (uint16_t)V
     #endif
+#endif
 
 /* Define EDS attribute on supported platforms */
-    #if defined(__HAS_EDS__)
-        #define __eds __attribute__((eds))
-        #if defined(__C30_VERSION__) && !defined(__XC16_VERSION__)
-            #define __builtin_dmapage(V)  (uint16_t)0
-        #endif
-    #else
-        #define __eds
-        #define __eds__
+#if defined(__HAS_EDS__)
+    #define __eds __attribute__((eds))
+    #if defined(__C30_VERSION__) && !defined(__XC16_VERSION__)
+        #define __builtin_dmapage(V)  (uint16_t)0
     #endif
+#else
+    #define __eds
+    #define __eds__
+#endif
 
 
 /* CAN module base addresses */
-    #define ADDR_CAN1               ((uint16_t)&C1CTRL1)
-    #define ADDR_CAN2               ((uint16_t)&C2CTRL1)
+#define ADDR_CAN1               ((uint16_t)&C1CTRL1)
+#define ADDR_CAN2               ((uint16_t)&C2CTRL1)
 
 /* DMA addresses */
-    #define ADDR_DMA0               ((uint16_t)&DMA0CON)
-    #define ADDR_DMA1               ((uint16_t)&DMA1CON)
-    #define ADDR_DMA2               ((uint16_t)&DMA2CON)
-    #define ADDR_DMA3               ((uint16_t)&DMA3CON)
-    #define ADDR_DMA4               ((uint16_t)&DMA4CON)
-    #define ADDR_DMA5               ((uint16_t)&DMA5CON)
-    #define ADDR_DMA6               ((uint16_t)&DMA6CON)
-    #define ADDR_DMA7               ((uint16_t)&DMA7CON)
+#define ADDR_DMA0               ((uint16_t)&DMA0CON)
+#define ADDR_DMA1               ((uint16_t)&DMA1CON)
+#define ADDR_DMA2               ((uint16_t)&DMA2CON)
+#define ADDR_DMA3               ((uint16_t)&DMA3CON)
+#define ADDR_DMA4               ((uint16_t)&DMA4CON)
+#define ADDR_DMA5               ((uint16_t)&DMA5CON)
+#define ADDR_DMA6               ((uint16_t)&DMA6CON)
+#define ADDR_DMA7               ((uint16_t)&DMA7CON)
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_CAN_SEND()    asm volatile ("disi #0x0000")
+#define CO_LOCK_CAN_SEND()      asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_CAN_SEND()    asm volatile ("disi #0x0000")
 
-    #define CO_LOCK_EMCY()          asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_EMCY()        asm volatile ("disi #0x0000")
+#define CO_LOCK_EMCY()          asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_EMCY()        asm volatile ("disi #0x0000")
 
-    #define CO_LOCK_OD()            asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_OD()          asm volatile ("disi #0x0000")
+#define CO_LOCK_OD()            asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_OD()          asm volatile ("disi #0x0000")
 
-    #define CO_DISABLE_INTERRUPTS()  asm volatile ("disi #0x3FFF")
-    #define CO_ENABLE_INTERRUPTS()   asm volatile ("disi #0x0000")
+#define CO_DISABLE_INTERRUPTS()  asm volatile ("disi #0x3FFF")
+#define CO_ENABLE_INTERRUPTS()   asm volatile ("disi #0x0000")
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN bit rates
@@ -364,8 +363,8 @@
         {1, 2,   TQ_x_17}    /*Not working*/
     #else
         #error define_CO_FCY CO_FCY not supported
-    #endif
-#endif
+    #endif /* CO_FCY == <value> */
+#endif /* CO_FCY */
 
 
 /* Structure contains timing coefficients for CAN module.
@@ -384,26 +383,6 @@ typedef struct{
     uint8_t   phSeg1;   /* (1...8) Phase Segment 1 time */
     uint8_t   phSeg2;   /* (1...8) Phase Segment 2 time */
 }CO_CANbitRateData_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
 
 
 /* CAN receive message structure as aligned in CAN module.
@@ -461,67 +440,6 @@ typedef struct{
 }CO_CANmodule_t;
 
 
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
 /* CAN interrupt receives and transmits CAN messages.
  *
  * Function must be called directly from _C1Interrupt or _C2Interrupt with
@@ -530,4 +448,4 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/PIC32/CO_driver_target.h
+++ b/stack/PIC32/CO_driver_target.h
@@ -1,10 +1,9 @@
 /*
- * CAN module object for Freescale MCF5282 ColdFire V2 microcontroller.
+ * CAN module object for Microchip PIC32MX microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
- * @author      Laurent Grosbois
- * @copyright   2004 - 2014 Janez Paternoster
+ * @copyright   2004 - 2015 Janez Paternoster
  *
  * This file is part of CANopenNode, an opensource CANopen Stack.
  * Project home page is <https://github.com/CANopenNode/CANopenNode>.
@@ -44,46 +43,52 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
-/* For documentation see file drvTemplate/CO_driver.h */
-
-
-#include "mcf5282.h"        /* processor header file */
+#include <p32xxxx.h>        /* processor header file */
 #include <stddef.h>         /* for 'NULL' */
 #include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
+#include <stdbool.h>        /* for 'true', 'false' */
 
+/* Endianness */
+#define CO_LITTLE_ENDIAN
 
 /* CAN module base address */
-    #define ADDR_CAN1               0
-    #define ADDR_CAN2               (_CAN2_BASE_ADDRESS - _CAN1_BASE_ADDRESS)
+#define ADDR_CAN1               0
+#define ADDR_CAN2               (_CAN2_BASE_ADDRESS - _CAN1_BASE_ADDRESS)
+
+
+/* Translate a kernel virtual address in KSEG0 or KSEG1 to a real
+* physical address and back. */
+typedef unsigned long CO_paddr_t; /* a physical address */
+typedef unsigned long CO_vaddr_t; /* a virtual address */
+#define CO_KVA_TO_PA(v) 	((CO_paddr_t)(v) & 0x1fffffff)
+#define CO_PA_TO_KVA0(pa)	((void *) ((pa) | 0x80000000))
+#define CO_PA_TO_KVA1(pa)	((void *) ((pa) | 0xa0000000))
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      asm{ move.w        #0x2700,sr};
-    #define CO_UNLOCK_CAN_SEND()    asm{ move.w        #0x2000,sr};
+extern unsigned int CO_interruptStatus;
+#define CO_LOCK_CAN_SEND()      CO_interruptStatus = __builtin_disable_interrupts()
+#define CO_UNLOCK_CAN_SEND()    if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
 
-    #define CO_LOCK_EMCY()          asm{ move.w        #0x2700,sr};
-    #define CO_UNLOCK_EMCY()        asm{ move.w        #0x2000,sr};
+#define CO_LOCK_EMCY()          CO_interruptStatus = __builtin_disable_interrupts()
+#define CO_UNLOCK_EMCY()        if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
 
-    #define CO_LOCK_OD()            asm{ move.w        #0x2700,sr};
-    #define CO_UNLOCK_OD()          asm{ move.w        #0x2000,sr};
-
-
-/* MACRO : get information from Rx buffer */
-#define MCF_CANMB_MSG(x)      (*(CO_CANrxMsg_t *)(&__IPSBAR[0x1C0080 + ((x)*0x10)]))
+#define CO_LOCK_OD()            CO_interruptStatus = __builtin_disable_interrupts()
+#define CO_UNLOCK_OD()          if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN bit rates
@@ -305,35 +310,15 @@ typedef struct{
 }CO_CANbitRateData_t;
 
 
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
-
-
 /* CAN receive message structure as aligned in CAN module. */
 typedef struct{
-    unsigned    timestamp   :8; /* 8 bits timestamp, see MCF5282 documentation */
-    unsigned    code        :4; /* Message Buffer code. see MCF52825 documentation */
-    unsigned    DLC         :4; /* Data length code */
-    unsigned    sid         :11;/* Standard Identifier - 11bits */
-    unsigned    RTR         :1; /* Remote Transmission Request bit */
-    unsigned                :4;
-    unsigned    timestamp16 :16;/* See MCF5282 documentation */
+    unsigned    ident    :11;   /* Standard Identifier */
+    unsigned    FILHIT   :5;    /* Filter hit, see PIC32MX documentation */
+    unsigned    CMSGTS   :16;   /* CAN message timestamp, see PIC32MX documentation */
+    unsigned    DLC      :4;    /* Data length code (bits 0...3) */
+    unsigned             :5;
+    unsigned    RTR      :1;    /* Remote Transmission Request bit */
+    unsigned             :22;
     uint8_t     data[8];        /* 8 data bytes */
 }CO_CANrxMsg_t;
 
@@ -349,8 +334,8 @@ typedef struct{
 
 /* Transmit message object. */
 typedef struct{
-    uint8_t             DLC;
-    uint16_t            ident;
+    uint32_t            CMSGSID;     /* Equal to register in transmit message buffer. Includes standard Identifier */
+    uint32_t            CMSGEID;     /* Equal to register in transmit message buffer. Includes data length code and RTR */
     uint8_t             data[8];
     volatile bool_t     bufferFull;
     volatile bool_t     syncFlag;
@@ -360,8 +345,8 @@ typedef struct{
 /* CAN module object. */
 typedef struct{
     void               *CANdriverState;
-    CO_CANrxMsg_t      *CANmsgBuff;
-    uint8_t             CANmsgBuffSize;
+    CO_CANrxMsg_t       CANmsgBuff[33]; /* PIC32 specific: CAN message buffer for CAN module. 32 buffers for receive, 1 buffer for transmit */
+    uint8_t             CANmsgBuffSize; /* PIC32 specific: Size of the above buffer == 33. Take care initial value! */
     CO_CANrx_t         *rxArray;
     uint16_t            rxSize;
     CO_CANtx_t         *txArray;
@@ -376,74 +361,12 @@ typedef struct{
 }CO_CANmodule_t;
 
 
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object.
+/* CAN interrupt receives and transmits CAN messages.
  *
- * MCF5282 FlexCAN configuration: 16 buffers are available.
- * Buffers [0..13] are used for reception
- * Buffers [14..15] are used for reception
+ * Function must be called directly from _C1Interrupt or _C2Interrupt with
+ * high priority.
  */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);    /* Valid values are (in kbps): 125, 1000. If value is illegal, bitrate defaults to 125. */
+void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
 
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
-/* CAN interrupt receives and transmits CAN messages. */
-void CO_CANinterrupt(CO_CANmodule_t *CANmodule, uint16_t ICODE);
-
-
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/SAM3X/CO_driver_target.h
+++ b/stack/SAM3X/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for the Atmel SAM3X microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @author      Olof Larsson
  * @copyright   2014 Janez Paternoster
@@ -44,11 +44,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
-
-
-/* For documentation see file drvTemplate/CO_driver.h */
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 #include <stddef.h>         /* for 'NULL' */
@@ -59,57 +56,40 @@
 #include <can.h>
 
 
+/** Endianness */
+#define CO_LITTLE_ENDIAN
+
 
 /* CAN module base address */
-    #define ADDR_CAN1               CAN0
-    #define ADDR_CAN2               CAN1
-    /*
-    Remember to set:
-     #define CONF_BOARD_CAN0
-     #define CONF_BOARD_CAN1
-    in conf_board.h
-    */
+#define ADDR_CAN1               CAN0
+#define ADDR_CAN2               CAN1
+/*
+Remember to set:
+ #define CONF_BOARD_CAN0
+ #define CONF_BOARD_CAN1
+in conf_board.h
+*/
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      //taskENTER_CRITICAL()
-    #define CO_UNLOCK_CAN_SEND()    //taskEXIT_CRITICAL()
+#define CO_LOCK_CAN_SEND()      //taskENTER_CRITICAL()
+#define CO_UNLOCK_CAN_SEND()    //taskEXIT_CRITICAL()
 
-    #define CO_LOCK_EMCY()          //taskENTER_CRITICAL()
-    #define CO_UNLOCK_EMCY()        //taskEXIT_CRITICAL()
+#define CO_LOCK_EMCY()          //taskENTER_CRITICAL()
+#define CO_UNLOCK_EMCY()        //taskEXIT_CRITICAL()
 
-    #define CO_LOCK_OD()            //taskENTER_CRITICAL()
-    #define CO_UNLOCK_OD()          //taskEXIT_CRITICAL()
+#define CO_LOCK_OD()            //taskENTER_CRITICAL()
+#define CO_UNLOCK_OD()          //taskEXIT_CRITICAL()
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN receive message structure as aligned in CAN module. */
@@ -159,67 +139,6 @@ typedef struct{
     can_mb_conf_t       rxMbConf[CANMB_NUMBER-1]; /* Reference to controller's mailboxes */
     can_mb_conf_t       txMbConf;
 }CO_CANmodule_t;
-
-
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
 
 
 /* CAN interrupt receives and transmits CAN messages. */

--- a/stack/STM32/CO_driver_target.h
+++ b/stack/STM32/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for ST STM32F103 microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @author      Ondrej Netik
  * @author      Vijayendra
@@ -46,34 +46,31 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
-
-
-/* For documentation see file drvTemplate/CO_driver.h */
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 /* Includes ------------------------------------------------------------------*/
-#include "common.h"
-#include "stm32f10x_conf.h"
+// #include "common.h"
+// #include "stm32f10x_conf.h"
 
 /* Exported define -----------------------------------------------------------*/
 #define PACKED_STRUCT               __attribute__((packed))
 #define ALIGN_STRUCT_DWORD          __attribute__((aligned(4)))
 
 /* Peripheral addresses */
-    #define ADDR_CAN1               CAN1
-    #define TMIDxR_TXRQ  ((uint32_t)0x00000001) /* Transmit mailbox request */
+#define ADDR_CAN1 CAN1
+#define TMIDxR_TXRQ ((uint32_t)0x00000001) /* Transmit mailbox request */
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      __set_PRIMASK(1);
-    #define CO_UNLOCK_CAN_SEND()    __set_PRIMASK(0);
+#define CO_LOCK_CAN_SEND()      __set_PRIMASK(1);
+#define CO_UNLOCK_CAN_SEND()    __set_PRIMASK(0);
 
-    #define CO_LOCK_EMCY()          __set_PRIMASK(1);
-    #define CO_UNLOCK_EMCY()        __set_PRIMASK(0);
+#define CO_LOCK_EMCY()          __set_PRIMASK(1);
+#define CO_UNLOCK_EMCY()        __set_PRIMASK(0);
 
-    #define CO_LOCK_OD()            __set_PRIMASK(1);
-    #define CO_UNLOCK_OD()          __set_PRIMASK(0);
+#define CO_LOCK_OD()            __set_PRIMASK(1);
+#define CO_UNLOCK_OD()          __set_PRIMASK(0);
 
 
 #define CLOCK_CAN                   RCC_APB1Periph_CAN1
@@ -120,30 +117,11 @@
 
 #define INAK_TIMEOUT        ((uint32_t)0x0000FFFF)
 /* Data types */
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 /* CAN receive message structure as aligned in CAN module.
  * prevzato z stm32f10_can.h - velikostne polozky a poradi odpovidaji. */
@@ -212,65 +190,10 @@ void CanLedsOff(eCoLeds led);
 void CanLedsSet(eCoLeds led);
 
 
-/* Request CAN configuration or normal mode */
-//void CO_CANsetConfigurationMode(CAN_TypeDef *CANdriverState);
-//void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-//uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        int8_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        int8_t                  rtr,
-        uint8_t                 noOfBytes,
-        int8_t                  syncFlag);
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
 /* CAN interrupts receives and transmits CAN messages. */
 void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule);
 void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule);
 void CO_CANinterrupt_Status(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/STM32F3/CO_driver_target.h
+++ b/stack/STM32F3/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for ST STM32F334 microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @author      Ondrej Netik
  * @author      Vijayendra
@@ -113,30 +113,12 @@
 
 #define INAK_TIMEOUT        ((uint32_t)0x0000FFFF)
 /* Data types */
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
 
 /* CAN receive message structure as aligned in CAN module.
  * prevzato z stm32f10_can.h - velikostne polozky a poradi odpovidaji. */
@@ -189,62 +171,9 @@ typedef struct{
     void               *em;
 }CO_CANmodule_t;
 
-/* Exported variables -----------------------------------------------------------*/
-
-/* Exported functions -----------------------------------------------------------*/
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        int8_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        int8_t                  rtr,
-        uint8_t                 noOfBytes,
-        int8_t                  syncFlag);
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
 
 /* CAN interrupts receives and transmits CAN messages. */
 void CO_CANinterrupt_Rx(CO_CANmodule_t *CANmodule);
 void CO_CANinterrupt_Tx(CO_CANmodule_t *CANmodule);
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/dsPIC30F/CO_driver_target.h
+++ b/stack/dsPIC30F/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for Microchip dsPIC30F microcontroller.
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Janez Paternoster
  * @copyright   2004 - 2013 Janez Paternoster
  *
@@ -43,11 +43,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
-
-
-/* For documentation see file drvTemplate/CO_driver.h */
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 #include <p30Fxxxx.h>       /* processor header file */
@@ -55,31 +52,34 @@
 #include <stdint.h>         /* for 'int8_t' to 'uint64_t' */
 #include <stdbool.h>        /* for true and false */
 
+/* Endianness */
+#define CO_LITTLE_ENDIAN
+
 
 /* CAN module base address */
-    #define ADDR_CAN1               0x300
-    #define ADDR_CAN2               0x3C0
+#define ADDR_CAN1               0x300
+#define ADDR_CAN2               0x3C0
 
 
 /* Critical sections */
-    #define CO_LOCK_CAN_SEND()      asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_CAN_SEND()    asm volatile ("disi #0x0000")
+#define CO_LOCK_CAN_SEND()      asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_CAN_SEND()    asm volatile ("disi #0x0000")
 
-    #define CO_LOCK_EMCY()          asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_EMCY()        asm volatile ("disi #0x0000")
+#define CO_LOCK_EMCY()          asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_EMCY()        asm volatile ("disi #0x0000")
 
-    #define CO_LOCK_OD()            asm volatile ("disi #0x3FFF")
-    #define CO_UNLOCK_OD()          asm volatile ("disi #0x0000")
+#define CO_LOCK_OD()            asm volatile ("disi #0x3FFF")
+#define CO_UNLOCK_OD()          asm volatile ("disi #0x0000")
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef unsigned char           bool_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef unsigned char           bool_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN bit rates
@@ -331,26 +331,6 @@ typedef struct{
 }CO_CANbitRateData_t;
 
 
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
-
-
 /* CAN receive message structure as aligned in CAN module. */
 typedef struct{
     uint16_t    ident;          /* Standard Identifier as aligned in CAN module. 16 bits:
@@ -400,67 +380,6 @@ typedef struct{
 }CO_CANmodule_t;
 
 
-/* Endianes */
-#define CO_LITTLE_ENDIAN
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
 /* CAN interrupt receives and transmits CAN messages.
  *
  * Function must be called directly from _C1Interrupt or _C2Interrupt with
@@ -469,4 +388,4 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
 void CO_CANinterrupt(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/eCos/CO_driver_target.h
+++ b/stack/eCos/CO_driver_target.h
@@ -1,7 +1,7 @@
 /*
  * CAN module object for eCos RTOS CAN layer
  *
- * @file        CO_driver.h
+ * @file        CO_driver_target.h
  * @author      Uwe Kindler
  * @copyright   2013 Uwe Kindler
  *
@@ -43,8 +43,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 /* For documentation see file drvTemplate/CO_driver.h */
@@ -58,6 +58,10 @@
 #include <cyg/io/io.h>
 #include <cyg/kernel/kapi.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
 
 //===========================================================================
 //                              CONFIGURATION
@@ -86,60 +90,40 @@
 /* CAN module base address */
 // we don't really care about the addresses here because the eCos port
 // uses I/O handles for accessing its CAN devices
-    #define ADDR_CAN1               0
-    #define ADDR_CAN2               1
+#define ADDR_CAN1               0
+#define ADDR_CAN2               1
 
 
 /* Critical sections */
 // shared data is accessed only from thread level code (not from ISR or DSR)
 // so we simply do a scheduler lock here to prevent access from different
 // threads
-    #define CO_LOCK_CAN_SEND()      cyg_scheduler_lock()
-    #define CO_UNLOCK_CAN_SEND()    cyg_scheduler_unlock()
+#define CO_LOCK_CAN_SEND()      cyg_scheduler_lock()
+#define CO_UNLOCK_CAN_SEND()    cyg_scheduler_unlock()
 
-    #define CO_LOCK_EMCY()          cyg_scheduler_lock()
-    #define CO_UNLOCK_EMCY()        cyg_scheduler_unlock()
+#define CO_LOCK_EMCY()          cyg_scheduler_lock()
+#define CO_UNLOCK_EMCY()        cyg_scheduler_unlock()
 
-    #define CO_LOCK_OD()            cyg_scheduler_lock()
-    #define CO_UNLOCK_OD()          cyg_scheduler_unlock()
+#define CO_LOCK_OD()            cyg_scheduler_lock()
+#define CO_UNLOCK_OD()          cyg_scheduler_unlock()
 
 
 
 /* Data types */
-    typedef unsigned char           bool_t;
-    typedef cyg_uint8               uint8_t;
-    typedef cyg_uint16              uint16_t;
-    typedef cyg_uint32              uint32_t;
-    typedef cyg_uint64              uint64_t;
-    typedef cyg_int8                int8_t;
-    typedef cyg_int16               int16_t;
-    typedef cyg_int32               int32_t;
-    typedef cyg_int64               int64_t;
-    typedef float                   float32_t;
-    typedef long double             float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+typedef unsigned char           bool_t;
+typedef cyg_uint8               uint8_t;
+typedef cyg_uint16              uint16_t;
+typedef cyg_uint32              uint32_t;
+typedef cyg_uint64              uint64_t;
+typedef cyg_int8                int8_t;
+typedef cyg_int16               int16_t;
+typedef cyg_int32               int32_t;
+typedef cyg_int64               int64_t;
+typedef float                   float32_t;
+typedef long double             float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN receive message structure as aligned in CAN module. */
@@ -190,68 +174,6 @@ typedef struct{
 }CO_CANmodule_t;
 
 #ifdef __cplusplus
-extern "C"
-{
-#endif
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-int16_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t             *rxArray,
-        uint16_t                rxSize,
-        CO_CANtx_t             *txArray,
-        uint16_t                txSize,
-        uint16_t                CANbitRate);
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-int16_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        uint8_t                 rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint8_t                 rtr,
-        uint8_t                 noOfBytes,
-        uint8_t                 syncFlag);
-
-
-/* Send CAN message. */
-int16_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
-
-
-#ifdef __cplusplus
 } //extern "C"
-#endif
-#endif
+#endif /* __cplusplus */
+#endif /* CO_DRIVER_TARGET_H */

--- a/stack/neuberger-socketCAN/CO_driver.c
+++ b/stack/neuberger-socketCAN/CO_driver.c
@@ -498,9 +498,9 @@ uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg)
 /******************************************************************************/
 CO_ReturnError_t CO_CANrxBufferInit(
         CO_CANmodule_t         *CANmodule,
-        uint32_t                index,
-        uint32_t                ident,
-        uint32_t                mask,
+        uint16_t                index,
+        uint16_t                ident,
+        uint16_t                mask,
         bool_t                  rtr,
         void                   *object,
         void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message))
@@ -508,7 +508,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
     CO_ReturnError_t ret = CO_ERROR_NO;
 
     if((CANmodule!=NULL) && (index < CANmodule->rxSize)){
-        uint32_t i;
+        uint16_t i;
         CO_CANrx_t *buffer;
 
         /* check if COB ID is already used */
@@ -604,8 +604,8 @@ bool_t CO_CANrxBuffer_getInterface(
 /******************************************************************************/
 CO_CANtx_t *CO_CANtxBufferInit(
         CO_CANmodule_t         *CANmodule,
-        uint32_t                index,
-        uint32_t                ident,
+        uint16_t                index,
+        uint16_t                ident,
         bool_t                  rtr,
         uint8_t                 noOfBytes,
         bool_t                  syncFlag)

--- a/stack/socketCAN/CO_driver_target.h
+++ b/stack/socketCAN/CO_driver_target.h
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef CO_DRIVER_H
-#define CO_DRIVER_H
+#ifndef CO_DRIVER_TARGET_H
+#define CO_DRIVER_TARGET_H
 
 
 /* For documentation see file drvTemplate/CO_driver.h */
@@ -44,6 +44,16 @@
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #include <linux/can/error.h>
+
+
+/* Endianness */
+#ifdef BYTE_ORDER
+#if BYTE_ORDER == LITTLE_ENDIAN
+    #define CO_LITTLE_ENDIAN
+#else
+    #define CO_BIG_ENDIAN
+#endif /* BYTE_ORDER == LITTLE_ENDIAN */
+#endif /* BYTE_ORDER */
 
 
 /* general configuration */
@@ -76,7 +86,7 @@
     #define CO_UNLOCK_OD()          {if(pthread_mutex_unlock(&CO_OD_mtx) != 0) CO_errExit("Mutex unlock CO_OD_mtx failed");}
 
     #define CANrxMemoryBarrier()    {__sync_synchronize();}
-#endif
+#endif /* CO_SINGLE_THREAD */
 
 /* Syncronisation functions */
 #define IS_CANrxNew(rxNew) ((uintptr_t)rxNew)
@@ -85,33 +95,13 @@
 
 
 /* Data types */
-    /* int8_t to uint64_t are defined in stdint.h */
-    typedef _Bool                   bool_t;
-    typedef float                   float32_t;
-    typedef double                  float64_t;
-    typedef char                    char_t;
-    typedef unsigned char           oChar_t;
-    typedef unsigned char           domain_t;
-
-
-/* Return values */
-typedef enum{
-    CO_ERROR_NO                 = 0,
-    CO_ERROR_ILLEGAL_ARGUMENT   = -1,
-    CO_ERROR_OUT_OF_MEMORY      = -2,
-    CO_ERROR_TIMEOUT            = -3,
-    CO_ERROR_ILLEGAL_BAUDRATE   = -4,
-    CO_ERROR_RX_OVERFLOW        = -5,
-    CO_ERROR_RX_PDO_OVERFLOW    = -6,
-    CO_ERROR_RX_MSG_LENGTH      = -7,
-    CO_ERROR_RX_PDO_LENGTH      = -8,
-    CO_ERROR_TX_OVERFLOW        = -9,
-    CO_ERROR_TX_PDO_WINDOW      = -10,
-    CO_ERROR_TX_UNCONFIGURED    = -11,
-    CO_ERROR_PARAMETERS         = -12,
-    CO_ERROR_DATA_CORRUPT       = -13,
-    CO_ERROR_CRC                = -14
-}CO_ReturnError_t;
+/* int8_t to uint64_t are defined in stdint.h */
+typedef _Bool                   bool_t;
+typedef float                   float32_t;
+typedef double                  float64_t;
+typedef char                    char_t;
+typedef unsigned char           oChar_t;
+typedef unsigned char           domain_t;
 
 
 /* CAN receive message structure as aligned in CAN module. */
@@ -164,76 +154,8 @@ typedef struct{
     void               *em;
 }CO_CANmodule_t;
 
-
-/* Endianes */
-#ifdef BYTE_ORDER
-#if BYTE_ORDER == LITTLE_ENDIAN
-    #define CO_LITTLE_ENDIAN
-#else
-    #define CO_BIG_ENDIAN
-#endif
-#endif
-
-
 /* Helper function, must be defined externally. */
 void CO_errExit(char* msg);
-
-
-/* Request CAN configuration or normal mode */
-void CO_CANsetConfigurationMode(void *CANdriverState);
-void CO_CANsetNormalMode(CO_CANmodule_t *CANmodule);
-
-
-/* Initialize CAN module object. */
-CO_ReturnError_t CO_CANmodule_init(
-        CO_CANmodule_t         *CANmodule,
-        void                   *CANdriverState,
-        CO_CANrx_t              rxArray[],
-        uint16_t                rxSize,
-        CO_CANtx_t              txArray[],
-        uint16_t                txSize,
-        uint16_t                CANbitRate); /* not used */
-
-
-/* Switch off CANmodule. */
-void CO_CANmodule_disable(CO_CANmodule_t *CANmodule);
-
-
-/* Read CAN identifier */
-uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);
-
-
-/* Configure CAN message receive buffer. */
-CO_ReturnError_t CO_CANrxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        uint16_t                mask,
-        bool_t                  rtr,
-        void                   *object,
-        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message));
-
-
-/* Configure CAN message transmit buffer. */
-CO_CANtx_t *CO_CANtxBufferInit(
-        CO_CANmodule_t         *CANmodule,
-        uint16_t                index,
-        uint16_t                ident,
-        bool_t                  rtr,
-        uint8_t                 noOfBytes,
-        bool_t                  syncFlag);
-
-
-/* Send CAN message. */
-CO_ReturnError_t CO_CANsend(CO_CANmodule_t *CANmodule, CO_CANtx_t *buffer);
-
-
-/* Clear all synchronous TPDOs from CAN module transmit buffers. */
-void CO_CANclearPendingSyncPDOs(CO_CANmodule_t *CANmodule);
-
-
-/* Verify all errors of CAN module. */
-void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
 
 
 /* Functions receives CAN messages. It is blocking.
@@ -243,4 +165,4 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule);
 void CO_CANrxWait(CO_CANmodule_t *CANmodule);
 
 
-#endif
+#endif /* CO_DRIVER_TARGET_H */


### PR DESCRIPTION
Created a single header file (`CO_driver.h`) to declare the functions
of the drivers API. This forces drivers to use a common API.

Previously, each driver declared these functions in its specific
`CO_driver.h` file. This causes two issues:
1. while these functions are used in target-independent code,
   the declarations could be target specific, leading to API/ABI
   compatibility issues.
2. the declarations were duplicated for each driver.

The `CO_driver.h` files for each driver were renamed to
`CO_driver_target.h`. This file is included from `CO_driver.h`.

Added a new header for types: `CO_types.h`. This file currently
holds the definition of `CO_ReturnError_t` that was previously
duplicated for all drivers. Added a few enum values to support
the `neuberger-socketCAN` code.