### PR TITLE
change SYNC module to be optional

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -85,7 +85,7 @@
 /* Verify features from CO_OD *************************************************/
     /* generate error, if features are not correctly configured for this project */
     #if        CO_NO_NMT_MASTER                           >  1     \
-            || CO_NO_SYNC                                 != 1     \
+            || CO_NO_SYNC                                 >  1     \
             || CO_NO_EMERGENCY                            != 1     \
             || CO_NO_SDO_SERVER                           == 0     \
             || CO_NO_TIME                                 >  1     \
@@ -143,7 +143,9 @@
     static CO_EM_t              COO_EM;
     static CO_EMpr_t            COO_EMpr;
     static CO_NMT_t             COO_NMT;
+#if CO_NO_SYNC == 1
     static CO_SYNC_t            COO_SYNC;
+#endif
     static CO_TIME_t            COO_TIME;
     static CO_RPDO_t            COO_RPDO[CO_NO_RPDO];
     static CO_TPDO_t            COO_TPDO[CO_NO_TPDO];
@@ -238,6 +240,7 @@ CO_ReturnError_t CO_new(void)
 #ifdef CO_USE_GLOBALS
     CO = &COO;
 
+    CO_memset((uint8_t*)CO, 0, sizeof(CO_t));
     CO->CANmodule[0]                    = &COO_CANmodule;
     CO_CANmodule_rxArray0               = &COO_CANmodule_rxArray0[0];
     CO_CANmodule_txArray0               = &COO_CANmodule_txArray0[0];
@@ -247,7 +250,9 @@ CO_ReturnError_t CO_new(void)
     CO->em                              = &COO_EM;
     CO->emPr                            = &COO_EMpr;
     CO->NMT                             = &COO_NMT;
+  #if CO_NO_SYNC == 1
     CO->SYNC                            = &COO_SYNC;
+  #endif
     CO->TIME                            = &COO_TIME;
     for(i=0; i<CO_NO_RPDO; i++)
         CO->RPDO[i]                     = &COO_RPDO[i];
@@ -287,7 +292,9 @@ CO_ReturnError_t CO_new(void)
         CO->em                              = (CO_EM_t *)           calloc(1, sizeof(CO_EM_t));
         CO->emPr                            = (CO_EMpr_t *)         calloc(1, sizeof(CO_EMpr_t));
         CO->NMT                             = (CO_NMT_t *)          calloc(1, sizeof(CO_NMT_t));
+      #if CO_NO_SYNC == 1
         CO->SYNC                            = (CO_SYNC_t *)         calloc(1, sizeof(CO_SYNC_t));
+      #endif
         CO->TIME                            = (CO_TIME_t *)         calloc(1, sizeof(CO_TIME_t));
         for(i=0; i<CO_NO_RPDO; i++){
             CO->RPDO[i]                     = (CO_RPDO_t *)         calloc(1, sizeof(CO_RPDO_t));
@@ -551,6 +558,7 @@ CO_ReturnError_t CO_CANopenInit(
 
 #endif
 
+#if CO_NO_SYNC == 1
     err = CO_SYNC_init(
             CO->SYNC,
             CO->em,
@@ -565,6 +573,7 @@ CO_ReturnError_t CO_CANopenInit(
             CO_TXCAN_SYNC);
 
     if(err){return err;}
+#endif
 
     err = CO_TIME_init(
             CO->TIME,
@@ -579,7 +588,7 @@ CO_ReturnError_t CO_CANopenInit(
             CO_TXCAN_TIME);
 
     if(err){return err;}
-    
+
     for(i=0; i<CO_NO_RPDO; i++){
         CO_CANmodule_t *CANdevRx = CO->CANmodule[0];
         uint16_t CANdevRxIdx = CO_RXCAN_RPDO + i;
@@ -603,12 +612,12 @@ CO_ReturnError_t CO_CANopenInit(
         if(err){return err;}
     }
 
-
     for(i=0; i<CO_NO_TPDO; i++){
         err = CO_TPDO_init(
                 CO->TPDO[i],
                 CO->em,
                 CO->SDO[0],
+                CO->SYNC,
                &CO->NMT->operatingState,
                 nodeId,
                 ((i<4) ? (CO_CAN_ID_TPDO_1+i*0x100) : 0),
@@ -835,11 +844,11 @@ CO_NMT_reset_cmd_t CO_process(
 
 
 /******************************************************************************/
-bool_t CO_process_SYNC_RPDO(
+#if CO_NO_SYNC == 1
+bool_t CO_process_SYNC(
         CO_t                   *CO,
         uint32_t                timeDifference_us)
 {
-    int16_t i;
     bool_t syncWas = false;
 
     switch(CO_SYNC_process(CO->SYNC, timeDifference_us, OD_synchronousWindowLength)){
@@ -851,11 +860,20 @@ bool_t CO_process_SYNC_RPDO(
             break;
     }
 
+    return syncWas;
+}
+#endif
+
+/******************************************************************************/
+void CO_process_RPDO(
+        CO_t                   *CO,
+        bool_t                  syncWas)
+{
+    int16_t i;
+
     for(i=0; i<CO_NO_RPDO; i++){
         CO_RPDO_process(CO->RPDO[i], syncWas);
     }
-
-    return syncWas;
 }
 
 
@@ -869,7 +887,9 @@ void CO_process_TPDO(
 
     /* Verify PDO Change Of State and process PDOs */
     for(i=0; i<CO_NO_TPDO; i++){
-        if(!CO->TPDO[i]->sendRequest) CO->TPDO[i]->sendRequest = CO_TPDOisCOS(CO->TPDO[i]);
-        CO_TPDO_process(CO->TPDO[i], CO->SYNC, syncWas, timeDifference_us);
+        if(!CO->TPDO[i]->sendRequest)
+            CO->TPDO[i]->sendRequest = CO_TPDOisCOS(CO->TPDO[i]);
+
+        CO_TPDO_process(CO->TPDO[i], syncWas, timeDifference_us);
     }
 }

--- a/CANopen.c
+++ b/CANopen.c
@@ -756,7 +756,9 @@ void CO_delete(void *CANdriverState){
     for(i=0; i<CO_NO_TPDO; i++){
         free(CO->TPDO[i]);
     }
+  #if CO_NO_SYNC == 1
     free(CO->SYNC);
+  #endif
     free(CO->NMT);
     free(CO->emPr);
     free(CO->em);

--- a/CANopen.h
+++ b/CANopen.h
@@ -282,21 +282,35 @@ CO_NMT_reset_cmd_t CO_process(
         uint16_t               *timerNext_ms);
 
 
+#if CO_NO_SYNC == 1
 /**
- * Process CANopen SYNC and RPDO objects.
+ * Process CANopen SYNC objects.
  *
  * Function must be called cyclically from real time thread with constant
- * interval (1ms typically). It processes SYNC and receive PDO CANopen objects.
+ * interval (1ms typically). It processes SYNC CANopen objects.
  *
  * @param CO This object.
  * @param timeDifference_us Time difference from previous function call in [microseconds].
  *
  * @return True, if CANopen SYNC message was just received or transmitted.
  */
-bool_t CO_process_SYNC_RPDO(
+bool_t CO_process_SYNC(
         CO_t                   *CO,
         uint32_t                timeDifference_us);
+#endif
 
+/**
+ * Process CANopen RPDO objects.
+ *
+ * Function must be called cyclically from real time thread with constant.
+ * interval (1ms typically). It processes receive PDO CANopen objects.
+ *
+ * @param CO This object.
+ * @param syncWas True, if CANopen SYNC message was just received or transmitted.
+ */
+void CO_process_RPDO(
+        CO_t                   *CO,
+        bool_t                  syncWas);
 
 /**
  * Process CANopen TPDO objects.

--- a/example/main.c
+++ b/example/main.c
@@ -150,8 +150,11 @@ static void tmrTask_thread(void){
         if(CO->CANmodule[0]->CANnormal) {
             bool_t syncWas;
 
-            /* Process Sync and read inputs */
-            syncWas = CO_process_SYNC_RPDO(CO, TMR_TASK_INTERVAL);
+            /* Process Sync */
+            syncWas = CO_process_SYNC(CO, TMR_TASK_INTERVAL);
+
+            /* Read inputs */
+            CO_process_RPDO(CO, syncWas);
 
             /* Further I/O or nonblocking application code may go here. */
 

--- a/stack/CO_PDO.c
+++ b/stack/CO_PDO.c
@@ -50,7 +50,6 @@
 #include "CO_NMT_Heartbeat.h"
 #include "CO_SYNC.h"
 #include "CO_PDO.h"
-#include <string.h>
 
 /*
  * Read received message from CAN module.
@@ -70,7 +69,7 @@ static void CO_PDO_receive(void *object, const CO_CANrxMsg_t *msg){
         (*RPDO->operatingState == CO_NMT_OPERATIONAL) &&
         (msg->DLC >= RPDO->dataLength))
     {
-        if(RPDO->synchronous && RPDO->SYNC->CANrxToggle) {
+        if(RPDO->SYNC && RPDO->synchronous && RPDO->SYNC->CANrxToggle) {
             /* copy data into second buffer and set 'new message' flag */
             RPDO->CANrxData[1][0] = msg->data[0];
             RPDO->CANrxData[1][1] = msg->data[1];
@@ -742,7 +741,7 @@ CO_ReturnError_t CO_RPDO_init(
         uint16_t                CANdevRxIdx)
 {
     /* verify arguments */
-    if(RPDO==NULL || em==NULL || SDO==NULL || SYNC==NULL || operatingState==NULL ||
+    if(RPDO==NULL || em==NULL || SDO==NULL || operatingState==NULL ||
         RPDOCommPar==NULL || RPDOMapPar==NULL || CANdevRx==NULL){
         return CO_ERROR_ILLEGAL_ARGUMENT;
     }
@@ -780,6 +779,7 @@ CO_ReturnError_t CO_TPDO_init(
         CO_TPDO_t              *TPDO,
         CO_EM_t                *em,
         CO_SDO_t               *SDO,
+        CO_SYNC_t              *SYNC,
         uint8_t                *operatingState,
         uint8_t                 nodeId,
         uint16_t                defaultCOB_ID,
@@ -800,6 +800,7 @@ CO_ReturnError_t CO_TPDO_init(
     /* Configure object variables */
     TPDO->em = em;
     TPDO->SDO = SDO;
+    TPDO->SYNC = SYNC;
     TPDO->TPDOCommPar = TPDOCommPar;
     TPDO->TPDOMapPar = TPDOMapPar;
     TPDO->operatingState = operatingState;
@@ -920,7 +921,7 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas){
         uint8_t bufNo = 0;
 
         /* Determine, which of the two rx buffers, contains relevant message. */
-        if(RPDO->synchronous && !RPDO->SYNC->CANrxToggle) {
+        if(RPDO->SYNC && RPDO->synchronous && !RPDO->SYNC->CANrxToggle) {
             bufNo = 1;
         }
 
@@ -977,7 +978,6 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas){
 /******************************************************************************/
 void CO_TPDO_process(
         CO_TPDO_t              *TPDO,
-        CO_SYNC_t              *SYNC,
         bool_t                  syncWas,
         uint32_t                timeDifference_us)
 {
@@ -995,7 +995,7 @@ void CO_TPDO_process(
         }
 
         /* Synchronous PDOs */
-        else if(SYNC && syncWas){
+        else if(TPDO->SYNC && syncWas){
             /* send synchronous acyclic PDO */
             if(TPDO->TPDOCommPar->transmissionType == 0){
                 if(TPDO->sendRequest) CO_TPDOsend(TPDO);
@@ -1004,14 +1004,14 @@ void CO_TPDO_process(
             else{
                 /* is the start of synchronous TPDO transmission */
                 if(TPDO->syncCounter == 255){
-                    if(SYNC->counterOverflowValue && TPDO->TPDOCommPar->SYNCStartValue)
+                    if(TPDO->SYNC->counterOverflowValue && TPDO->TPDOCommPar->SYNCStartValue)
                         TPDO->syncCounter = 254;   /* SYNCStartValue is in use */
                     else
                         TPDO->syncCounter = TPDO->TPDOCommPar->transmissionType;
                 }
                 /* if the SYNCStartValue is in use, start first TPDO after SYNC with matched SYNCStartValue. */
                 if(TPDO->syncCounter == 254){
-                    if(SYNC->counter == TPDO->TPDOCommPar->SYNCStartValue){
+                    if(TPDO->SYNC->counter == TPDO->TPDOCommPar->SYNCStartValue){
                         TPDO->syncCounter = TPDO->TPDOCommPar->transmissionType;
                         CO_TPDOsend(TPDO);
                     }

--- a/stack/CO_PDO.h
+++ b/stack/CO_PDO.h
@@ -215,6 +215,7 @@ typedef struct{
 typedef struct{
     CO_EM_t            *em;             /**< From CO_TPDO_init() */
     CO_SDO_t           *SDO;            /**< From CO_TPDO_init() */
+    CO_SYNC_t          *SYNC;           /**< From CO_TPDO_init() */
     const CO_TPDOCommPar_t *TPDOCommPar;/**< From CO_TPDO_init() */
     const CO_TPDOMapPar_t  *TPDOMapPar; /**< From CO_TPDO_init() */
     uint8_t            *operatingState; /**< From CO_TPDO_init() */
@@ -324,6 +325,7 @@ CO_ReturnError_t CO_TPDO_init(
         CO_TPDO_t              *TPDO,
         CO_EM_t                *em,
         CO_SDO_t               *SDO,
+        CO_SYNC_t              *SYNC,
         uint8_t                *operatingState,
         uint8_t                 nodeId,
         uint16_t                defaultCOB_ID,
@@ -394,7 +396,6 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas);
  */
 void CO_TPDO_process(
         CO_TPDO_t              *TPDO,
-        CO_SYNC_t              *SYNC,
         bool_t                  syncWas,
         uint32_t                timeDifference_us);
 

--- a/stack/PIC32/main_PIC32.c
+++ b/stack/PIC32/main_PIC32.c
@@ -300,8 +300,11 @@ void __ISR(_TIMER_2_VECTOR, IPL3SOFT) CO_TimerInterruptHandler(void){
         bool_t syncWas;
         int i;
 
-        /* Process Sync and read inputs */
-        syncWas = CO_process_SYNC_RPDO(CO, 1000);
+        /* Process Sync */
+        syncWas = CO_process_SYNC(CO, 1000);
+
+        /* Read inputs */
+        CO_process_RPDO(CO, syncWas);
 
         /* Further I/O or nonblocking application code may go here. */
 #if CO_NO_TRACE > 0

--- a/stack/neuberger-socketCAN/CO_Linux_threads.c
+++ b/stack/neuberger-socketCAN/CO_Linux_threads.c
@@ -168,8 +168,11 @@ void CANrx_threadTmr_process(void)
       if(CO->CANmodule[0]->CANnormal == true) {
 
         for (i = 0; i <= missed; i++) {
-          /* Process Sync and read inputs */
-          syncWas = CO_process_SYNC_RPDO(CO, threadRT.us_interval);
+          /* Process Sync */
+          syncWas = CO_process_SYNC(CO, threadRT.us_interval);
+
+          /* Read inputs */
+          CO_process_RPDO(CO, syncWas);
 
           /* Write outputs */
           CO_process_TPDO(CO, syncWas, threadRT.us_interval);

--- a/stack/socketCAN/CO_Linux_tasks.c
+++ b/stack/socketCAN/CO_Linux_tasks.c
@@ -283,8 +283,11 @@ bool_t CANrx_taskTmr_process(int fd) {
         if(CO->CANmodule[0]->CANnormal) {
             bool_t syncWas;
 
-            /* Process Sync and read inputs */
-            syncWas = CO_process_SYNC_RPDO(CO, taskRT.intervalus);
+            /* Process Sync */
+            syncWas = CO_process_SYNC(CO, taskRT.intervalus);
+
+            /* Read inputs */
+            CO_process_RPDO(CO, syncWas);
 
             /* Further I/O or nonblocking application code may go here. */
 


### PR DESCRIPTION
This change will allow CO_NO_SYNC to be zero if the project does not wish to use the sync message.

If CO_NO_SYNC is zero the stack does not need to assign a mailbox to it, which is important if you are using hardware filtering and only have a limited number of mailboxes to work with.  This also means you do not have to define EDS entries 1005-1007.

Changes:
- feature verification no longer asserts on `CO_NO_SYNC == 0`
- `CO_SYNC_t COO_SYNC` is no longer allocated if `CO_NO_SYNC == 0`
- `CO_SYNC_init` will not be called if `CO_NO_SYNC == 0`
- split `CO_process_SYNC_RPDO` into two separate functions.
  - `bool_t CO_process_SYNC`  (returns syncWas)
  - `void CO_process_RPDO` (takes syncWas)
- SYNC is now passed to TPDO on init rather than at every process call.
- Both TPDO and RPDO will now check if SYNC is NULL before dereferencing.
