### PR TITLE
All Warnings fixed

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -307,42 +307,42 @@ CO_ReturnError_t CO_new(void)
 #else
     if(CO == NULL){    /* Use malloc only once */
         CO = &COO;
-        CO->CANmodule[0]                    = (CO_CANmodule_t *)    calloc(1, sizeof(CO_CANmodule_t));
-        CO_CANmodule_rxArray0               = (CO_CANrx_t *)        calloc(CO_RXCAN_NO_MSGS, sizeof(CO_CANrx_t));
-        CO_CANmodule_txArray0               = (CO_CANtx_t *)        calloc(CO_TXCAN_NO_MSGS, sizeof(CO_CANtx_t));
+        CO->CANmodule[0]                    = (CO_CANmodule_t *)    COcalloc(1, sizeof(CO_CANmodule_t));
+        CO_CANmodule_rxArray0               = (CO_CANrx_t *)        COcalloc(CO_RXCAN_NO_MSGS, sizeof(CO_CANrx_t));
+        CO_CANmodule_txArray0               = (CO_CANtx_t *)        COcalloc(CO_TXCAN_NO_MSGS, sizeof(CO_CANtx_t));
         for(i=0; i<CO_NO_SDO_SERVER; i++){
-            CO->SDO[i]                      = (CO_SDO_t *)          calloc(1, sizeof(CO_SDO_t));
+            CO->SDO[i]                      = (CO_SDO_t *)          COcalloc(1, sizeof(CO_SDO_t));
         }
-        CO_SDO_ODExtensions                 = (CO_OD_extension_t*)  calloc(CO_OD_NoOfElements, sizeof(CO_OD_extension_t));
-        CO->em                              = (CO_EM_t *)           calloc(1, sizeof(CO_EM_t));
-        CO->emPr                            = (CO_EMpr_t *)         calloc(1, sizeof(CO_EMpr_t));
-        CO->NMT                             = (CO_NMT_t *)          calloc(1, sizeof(CO_NMT_t));
-        CO->SYNC                            = (CO_SYNC_t *)         calloc(1, sizeof(CO_SYNC_t));
-        CO->TIME                            = (CO_TIME_t *)         calloc(1, sizeof(CO_TIME_t));
+        CO_SDO_ODExtensions                 = (CO_OD_extension_t*)  COcalloc(CO_OD_NoOfElements, sizeof(CO_OD_extension_t));
+        CO->em                              = (CO_EM_t *)           COcalloc(1, sizeof(CO_EM_t));
+        CO->emPr                            = (CO_EMpr_t *)         COcalloc(1, sizeof(CO_EMpr_t));
+        CO->NMT                             = (CO_NMT_t *)          COcalloc(1, sizeof(CO_NMT_t));
+        CO->SYNC                            = (CO_SYNC_t *)         COcalloc(1, sizeof(CO_SYNC_t));
+        CO->TIME                            = (CO_TIME_t *)         COcalloc(1, sizeof(CO_TIME_t));
         for(i=0; i<CO_NO_RPDO; i++){
-            CO->RPDO[i]                     = (CO_RPDO_t *)         calloc(1, sizeof(CO_RPDO_t));
+            CO->RPDO[i]                     = (CO_RPDO_t *)         COcalloc(1, sizeof(CO_RPDO_t));
         }
         for(i=0; i<CO_NO_TPDO; i++){
-            CO->TPDO[i]                     = (CO_TPDO_t *)         calloc(1, sizeof(CO_TPDO_t));
+            CO->TPDO[i]                     = (CO_TPDO_t *)         COcalloc(1, sizeof(CO_TPDO_t));
         }
-        CO->HBcons                          = (CO_HBconsumer_t *)   calloc(1, sizeof(CO_HBconsumer_t));
-        CO_HBcons_monitoredNodes            = (CO_HBconsNode_t *)   calloc(CO_NO_HB_CONS, sizeof(CO_HBconsNode_t));
+        CO->HBcons                          = (CO_HBconsumer_t *)   COcalloc(1, sizeof(CO_HBconsumer_t));
+        CO_HBcons_monitoredNodes            = (CO_HBconsNode_t *)   COcalloc(CO_NO_HB_CONS, sizeof(CO_HBconsNode_t));
       #if CO_NO_LSS_SERVER == 1
-        CO->LSSslave                        = (CO_LSSslave_t *)     calloc(1, sizeof(CO_LSSslave_t));
+        CO->LSSslave                        = (CO_LSSslave_t *)     COcalloc(1, sizeof(CO_LSSslave_t));
       #endif
       #if CO_NO_LSS_CLIENT == 1
-        CO->LSSmaster                       = (CO_LSSmaster_t *)    calloc(1, sizeof(CO_LSSmaster_t));
+        CO->LSSmaster                       = (CO_LSSmaster_t *)    COcalloc(1, sizeof(CO_LSSmaster_t));
       #endif
       #if CO_NO_SDO_CLIENT != 0
         for(i=0; i<CO_NO_SDO_CLIENT; i++){
-            CO->SDOclient[i]                = (CO_SDOclient_t *)    calloc(1, sizeof(CO_SDOclient_t));
+            CO->SDOclient[i]                = (CO_SDOclient_t *)    COcalloc(1, sizeof(CO_SDOclient_t));
         }
       #endif
       #if CO_NO_TRACE > 0
         for(i=0; i<CO_NO_TRACE; i++) {
-            CO->trace[i]                    = (CO_trace_t *)        calloc(1, sizeof(CO_trace_t));
-            CO_traceTimeBuffers[i]          = (uint32_t *)          calloc(OD_traceConfig[i].size, sizeof(uint32_t));
-            CO_traceValueBuffers[i]         = (int32_t *)           calloc(OD_traceConfig[i].size, sizeof(int32_t));
+            CO->trace[i]                    = (CO_trace_t *)        COcalloc(1, sizeof(CO_trace_t));
+            CO_traceTimeBuffers[i]          = (uint32_t *)          COcalloc(OD_traceConfig[i].size, sizeof(uint32_t));
+            CO_traceValueBuffers[i]         = (int32_t *)           COcalloc(OD_traceConfig[i].size, sizeof(int32_t));
             if(CO_traceTimeBuffers[i] != NULL && CO_traceValueBuffers[i] != NULL) {
                 CO_traceBufferSize[i] = OD_traceConfig[i].size;
             } else {
@@ -753,41 +753,42 @@ void CO_delete(void *CANdriverState){
 #ifndef CO_USE_GLOBALS
   #if CO_NO_TRACE > 0
       for(i=0; i<CO_NO_TRACE; i++) {
-          free(CO->trace[i]);
-          free(CO_traceTimeBuffers[i]);
-          free(CO_traceValueBuffers[i]);
+          COfree(CO->trace[i]);
+          COfree(CO_traceTimeBuffers[i]);
+          COfree(CO_traceValueBuffers[i]);
       }
   #endif
   #if CO_NO_SDO_CLIENT != 0
       for(i=0; i<CO_NO_SDO_CLIENT; i++) {
-          free(CO->SDOclient[i]);
+          COfree(CO->SDOclient[i]);
       }
   #endif
   #if CO_NO_LSS_SERVER == 1
-    free(CO->LSSslave);
+    COfree(CO->LSSslave);
   #endif
   #if CO_NO_LSS_CLIENT == 1
-    free(CO->LSSmaster);
+    COfree(CO->LSSmaster);
   #endif
-    free(CO_HBcons_monitoredNodes);
-    free(CO->HBcons);
+    COfree(CO_HBcons_monitoredNodes);
+    COfree(CO->HBcons);
     for(i=0; i<CO_NO_RPDO; i++){
-        free(CO->RPDO[i]);
+        COfree(CO->RPDO[i]);
     }
     for(i=0; i<CO_NO_TPDO; i++){
-        free(CO->TPDO[i]);
+        COfree(CO->TPDO[i]);
     }
-    free(CO->SYNC);
-    free(CO->NMT);
-    free(CO->emPr);
-    free(CO->em);
-    free(CO_SDO_ODExtensions);
+    COfree(CO->SYNC);
+    COfree(CO->NMT);
+    COfree(CO->emPr);
+    COfree(CO->em);
+    COfree(CO_SDO_ODExtensions);
     for(i=0; i<CO_NO_SDO_SERVER; i++){
-        free(CO->SDO[i]);
+        COfree(CO->SDO[i]);
     }
-    free(CO_CANmodule_txArray0);
-    free(CO_CANmodule_rxArray0);
-    free(CO->CANmodule[0]);
+    COfree(CO_CANmodule_txArray0);
+    COfree(CO_CANmodule_rxArray0);
+    COfree(CO->CANmodule[0]);
+	COfree(CO->TIME);
     CO = NULL;
 #endif
 }

--- a/CANopen.c
+++ b/CANopen.c
@@ -205,6 +205,9 @@ CO_ReturnError_t CO_init(
         NMTM_txBuff->data[0] = command;
         NMTM_txBuff->data[1] = nodeID;
 
+        /* Protect access to NMT operatingState and resetCommand */
+        CO_LOCK_NMT();
+
         /* Apply NMT command also to this node, if set so. */
         if(nodeID == 0 || nodeID == CO_this->NMT->nodeId){
             switch(command){

--- a/CANopen.h
+++ b/CANopen.h
@@ -165,7 +165,7 @@ typedef struct{
  * object. Follow the code in CANopen.c file. If macro CO_NO_NMT_MASTER is 1,
  * function CO_sendNMTcommand can be used to send NMT master message.
  *
- * @param CO CANopen object.
+ * @param CO_this CANopen object.
  * @param command NMT command.
  * @param nodeID Node ID.
  *
@@ -173,7 +173,7 @@ typedef struct{
  * @return other: same as CO_CANsend().
  */
 #if CO_NO_NMT_MASTER == 1
-    CO_ReturnError_t CO_sendNMTcommand(CO_t *CO, uint8_t command, uint8_t nodeID);
+    CO_ReturnError_t CO_sendNMTcommand(CO_t *CO_this, uint8_t command, uint8_t nodeID);
 #endif
 
 
@@ -265,7 +265,7 @@ void CO_delete(void *CANdriverState);
  * Function must be called cyclically. It processes all "asynchronous" CANopen
  * objects.
  *
- * @param CO This object
+ * @param CO_this This object
  * @param timeDifference_ms Time difference from previous function call in [milliseconds].
  * @param timerNext_ms Return value - info to OS - maximum delay after function
  *        should be called next time in [milliseconds]. Value can be used for OS
@@ -277,7 +277,7 @@ void CO_delete(void *CANdriverState);
  * @return #CO_NMT_reset_cmd_t from CO_NMT_process().
  */
 CO_NMT_reset_cmd_t CO_process(
-        CO_t                   *CO,
+        CO_t                   *CO_this,
         uint16_t                timeDifference_ms,
         uint16_t               *timerNext_ms);
 
@@ -288,13 +288,13 @@ CO_NMT_reset_cmd_t CO_process(
  * Function must be called cyclically from real time thread with constant
  * interval (1ms typically). It processes SYNC and receive PDO CANopen objects.
  *
- * @param CO This object.
+ * @param CO_this This object.
  * @param timeDifference_us Time difference from previous function call in [microseconds].
  *
  * @return True, if CANopen SYNC message was just received or transmitted.
  */
 bool_t CO_process_SYNC_RPDO(
-        CO_t                   *CO,
+        CO_t                   *CO_this,
         uint32_t                timeDifference_us);
 
 
@@ -304,12 +304,12 @@ bool_t CO_process_SYNC_RPDO(
  * Function must be called cyclically from real time thread with constant.
  * interval (1ms typically). It processes transmit PDO CANopen objects.
  *
- * @param CO This object.
+ * @param CO_this This object.
  * @param syncWas True, if CANopen SYNC message was just received or transmitted.
  * @param timeDifference_us Time difference from previous function call in [microseconds].
  */
 void CO_process_TPDO(
-        CO_t                   *CO,
+        CO_t                   *CO_this,
         bool_t                  syncWas,
         uint32_t                timeDifference_us);
 

--- a/stack/CO_Emergency.c
+++ b/stack/CO_Emergency.c
@@ -329,12 +329,12 @@ void CO_EM_process(
 
             /* write to 'pre-defined error field' (object dictionary, index 0x1003) */
             if(emPr->preDefErr){
-                uint8_t i;
+                uint8_t j;
 
                 if(emPr->preDefErrNoOfErrors < emPr->preDefErrSize)
                     emPr->preDefErrNoOfErrors++;
-                for(i=emPr->preDefErrNoOfErrors-1; i>0; i--)
-                    emPr->preDefErr[i] = emPr->preDefErr[i-1];
+                for(j=emPr->preDefErrNoOfErrors-1; j>0; j--)
+                    emPr->preDefErr[j] = emPr->preDefErr[j-1];
                 emPr->preDefErr[0] = preDEF;
             }
 

--- a/stack/CO_LSSmaster.c
+++ b/stack/CO_LSSmaster.c
@@ -823,6 +823,7 @@ static CO_LSSmaster_return_t CO_LSSmaster_FsScanInitiate(
         case CO_LSSmaster_FS_MATCH:
             /* No scanning requested */
             return CO_LSSmaster_SCAN_FINISHED;
+        case CO_LSSmaster_FS_SKIP:
         default:
             return CO_LSSmaster_SCAN_FAILED;
     }
@@ -852,6 +853,7 @@ static CO_LSSmaster_return_t CO_LSSmaster_FsScanWait(
         case CO_LSSmaster_FS_MATCH:
             /* No scanning requested */
             return CO_LSSmaster_SCAN_FINISHED;
+        case CO_LSSmaster_FS_SKIP:
         default:
             return CO_LSSmaster_SCAN_FAILED;
     }
@@ -909,6 +911,7 @@ static CO_LSSmaster_return_t CO_LSSmaster_FsVerifyInitiate(
             /* ID given by user */
             LSSmaster->fsIdNumber = idNumberCheck;
             break;
+        case CO_LSSmaster_FS_SKIP:
         default:
             return CO_LSSmaster_SCAN_FAILED;
     }
@@ -1107,6 +1110,8 @@ CO_LSSmaster_return_t CO_LSSmaster_IdentifyFastscan(
                     LSSmaster->fsState = CO_LSSmaster_FS_STATE_SCAN;
                 }
             }
+            break;
+        default:
             break;
     }
 

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -86,6 +86,8 @@ static void CO_NMT_receive(void *object, const CO_CANrxMsg_t *msg){
             case CO_NMT_RESET_COMMUNICATION:
                 NMT->resetCommand = CO_RESET_COMM;
                 break;
+            default:
+                break;
         }
 
         if(NMT->pFunctNMT!=NULL && currentOperatingState!=NMT->operatingState){
@@ -188,6 +190,7 @@ void CO_NMT_blinkingProcess50ms(CO_NMT_t *NMT){
         case    4:  NMT->LEDdoubleFlash = -104; break;
         case -100:  NMT->LEDdoubleFlash =  100; break;
         case  104:  NMT->LEDdoubleFlash =  -20; break;
+        default: break;
     }
 
     switch(++NMT->LEDtripleFlash){
@@ -196,6 +199,7 @@ void CO_NMT_blinkingProcess50ms(CO_NMT_t *NMT){
         case  104:  NMT->LEDtripleFlash = -114; break;
         case -110:  NMT->LEDtripleFlash =  110; break;
         case  114:  NMT->LEDtripleFlash =  -20; break;
+        default: break;
     }
 
     switch(++NMT->LEDquadrupleFlash){
@@ -206,6 +210,7 @@ void CO_NMT_blinkingProcess50ms(CO_NMT_t *NMT){
         case  114:  NMT->LEDquadrupleFlash = -124; break;
         case -120:  NMT->LEDquadrupleFlash =  120; break;
         case  124:  NMT->LEDquadrupleFlash =  -20; break;
+        default: break;
     }
 }
 #endif /* CO_USE_LEDS */
@@ -272,6 +277,7 @@ CO_NMT_reset_cmd_t CO_NMT_process(
         case CO_NMT_STOPPED:          NMT->LEDgreenRun = NMT->LEDsingleFlash;   break;
         case CO_NMT_PRE_OPERATIONAL:  NMT->LEDgreenRun = NMT->LEDblinking;      break;
         case CO_NMT_OPERATIONAL:      NMT->LEDgreenRun = 1;                     break;
+        default: break;
     }
 
 

--- a/stack/CO_PDO.c
+++ b/stack/CO_PDO.c
@@ -443,14 +443,16 @@ static CO_SDO_abortCode_t CO_ODF_RPDOcom(CO_ODF_arg_t *ODF_arg){
     /* Reading Object Dictionary variable */
     if(ODF_arg->reading){
         if(ODF_arg->subIndex == 1){
-            uint32_t *value = (uint32_t*) ODF_arg->data;
+            uint32_t value = CO_getUint32(ODF_arg->data);
 
             /* if default COB ID is used, write default value here */
-            if(((*value)&0xFFFF) == RPDO->defaultCOB_ID && RPDO->defaultCOB_ID)
-                *value += RPDO->nodeId;
+            if(((value)&0xFFFF) == RPDO->defaultCOB_ID && RPDO->defaultCOB_ID)
+                value += RPDO->nodeId;
 
             /* If PDO is not valid, set bit 31 */
-            if(!RPDO->valid) *value |= 0x80000000L;
+            if(!RPDO->valid) value |= 0x80000000L;
+
+            CO_setUint32(ODF_arg->data, value);
         }
         return CO_SDO_AB_NONE;
     }
@@ -462,24 +464,25 @@ static CO_SDO_abortCode_t CO_ODF_RPDOcom(CO_ODF_arg_t *ODF_arg){
         return CO_SDO_AB_DATA_DEV_STATE;   /* Data cannot be transferred or stored to the application because of the present device state. */
 
     if(ODF_arg->subIndex == 1){   /* COB_ID */
-        uint32_t *value = (uint32_t*) ODF_arg->data;
+        uint32_t value = CO_getUint32(ODF_arg->data);
 
         /* bits 11...29 must be zero */
-        if(*value & 0x3FFF8000L)
+        if(value & 0x3FFF8000L)
             return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
 
         /* if default COB-ID is being written, write defaultCOB_ID without nodeId */
-        if(((*value)&0xFFFF) == (RPDO->defaultCOB_ID + RPDO->nodeId)){
-            *value &= 0xC0000000L;
-            *value += RPDO->defaultCOB_ID;
+        if(((value)&0xFFFF) == (RPDO->defaultCOB_ID + RPDO->nodeId)){
+            value &= 0xC0000000L;
+            value += RPDO->defaultCOB_ID;
+            CO_setUint32(ODF_arg->data, value);
         }
 
         /* if PDO is valid, bits 0..29 can not be changed */
-        if(RPDO->valid && ((*value ^ RPDO->RPDOCommPar->COB_IDUsedByRPDO) & 0x3FFFFFFFL))
+        if(RPDO->valid && ((value ^ RPDO->RPDOCommPar->COB_IDUsedByRPDO) & 0x3FFFFFFFL))
             return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
 
         /* configure RPDO */
-        CO_RPDOconfigCom(RPDO, *value);
+        CO_RPDOconfigCom(RPDO, value);
     }
     else if(ODF_arg->subIndex == 2){   /* Transmission_type */
         uint8_t *value = (uint8_t*) ODF_arg->data;
@@ -516,14 +519,16 @@ static CO_SDO_abortCode_t CO_ODF_TPDOcom(CO_ODF_arg_t *ODF_arg){
     /* Reading Object Dictionary variable */
     if(ODF_arg->reading){
         if(ODF_arg->subIndex == 1){   /* COB_ID */
-            uint32_t *value = (uint32_t*) ODF_arg->data;
+            uint32_t value = CO_getUint32(ODF_arg->data);
 
             /* if default COB ID is used, write default value here */
-            if(((*value)&0xFFFF) == TPDO->defaultCOB_ID && TPDO->defaultCOB_ID)
-                *value += TPDO->nodeId;
+            if(((value)&0xFFFF) == TPDO->defaultCOB_ID && TPDO->defaultCOB_ID)
+                value += TPDO->nodeId;
 
             /* If PDO is not valid, set bit 31 */
-            if(!TPDO->valid) *value |= 0x80000000L;
+            if(!TPDO->valid) value |= 0x80000000L;
+
+            CO_setUint32(ODF_arg->data, value);
         }
         return CO_SDO_AB_NONE;
     }
@@ -535,24 +540,26 @@ static CO_SDO_abortCode_t CO_ODF_TPDOcom(CO_ODF_arg_t *ODF_arg){
         return CO_SDO_AB_DATA_DEV_STATE;   /* Data cannot be transferred or stored to the application because of the present device state. */
 
     if(ODF_arg->subIndex == 1){   /* COB_ID */
-        uint32_t *value = (uint32_t*) ODF_arg->data;
+        uint32_t value = CO_getUint32(ODF_arg->data);
 
         /* bits 11...29 must be zero */
-        if(*value & 0x3FFF8000L)
+        if(value & 0x3FFF8000L)
             return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
 
         /* if default COB-ID is being written, write defaultCOB_ID without nodeId */
-        if(((*value)&0xFFFF) == (TPDO->defaultCOB_ID + TPDO->nodeId)){
-            *value &= 0xC0000000L;
-            *value += TPDO->defaultCOB_ID;
+        if(((value)&0xFFFF) == (TPDO->defaultCOB_ID + TPDO->nodeId)){
+            value &= 0xC0000000L;
+            value += TPDO->defaultCOB_ID;
+
+            CO_setUint32(ODF_arg->data, value);
         }
 
         /* if PDO is valid, bits 0..29 can not be changed */
-        if(TPDO->valid && ((*value ^ TPDO->TPDOCommPar->COB_IDUsedByTPDO) & 0x3FFFFFFFL))
+        if(TPDO->valid && ((value ^ TPDO->TPDOCommPar->COB_IDUsedByTPDO) & 0x3FFFFFFFL))
             return CO_SDO_AB_INVALID_VALUE;  /* Invalid value for parameter (download only). */
 
         /* configure TPDO */
-        CO_TPDOconfigCom(TPDO, *value, TPDO->CANtxBuff->syncFlag);
+        CO_TPDOconfigCom(TPDO, value, TPDO->CANtxBuff->syncFlag);
         TPDO->syncCounter = 255;
     }
     else if(ODF_arg->subIndex == 2){   /* Transmission_type */
@@ -572,9 +579,9 @@ static CO_SDO_abortCode_t CO_ODF_TPDOcom(CO_ODF_arg_t *ODF_arg){
         TPDO->inhibitTimer = 0;
     }
     else if(ODF_arg->subIndex == 5){   /* Event_Timer */
-        uint16_t *value = (uint16_t*) ODF_arg->data;
+        uint16_t value = CO_getUint16(ODF_arg->data);
 
-        TPDO->eventTimer = ((uint32_t) *value) * 1000;
+        TPDO->eventTimer = ((uint32_t) value) * 1000;
     }
     else if(ODF_arg->subIndex == 6){   /* SYNC start value */
         uint8_t *value = (uint8_t*) ODF_arg->data;
@@ -634,7 +641,7 @@ static CO_SDO_abortCode_t CO_ODF_RPDOmap(CO_ODF_arg_t *ODF_arg){
 
     /* mappedObject */
     else{
-        uint32_t *value = (uint32_t*) ODF_arg->data;
+        uint32_t value = CO_getUint32(ODF_arg->data);
         uint8_t* pData;
         uint8_t length = 0;
         uint8_t dummy = 0;
@@ -646,7 +653,7 @@ static CO_SDO_abortCode_t CO_ODF_RPDOmap(CO_ODF_arg_t *ODF_arg){
         /* verify if mapping is correct */
         return CO_PDOfindMap(
                 RPDO->SDO,
-               *value,
+                value,
                 0,
                &pData,
                &length,
@@ -700,7 +707,7 @@ static CO_SDO_abortCode_t CO_ODF_TPDOmap(CO_ODF_arg_t *ODF_arg){
 
     /* mappedObject */
     else{
-        uint32_t *value = (uint32_t*) ODF_arg->data;
+        uint32_t value = CO_getUint32(ODF_arg->data);
         uint8_t* pData;
         uint8_t length = 0;
         uint8_t dummy = 0;
@@ -712,7 +719,7 @@ static CO_SDO_abortCode_t CO_ODF_TPDOmap(CO_ODF_arg_t *ODF_arg){
         /* verify if mapping is correct */
         return CO_PDOfindMap(
                 TPDO->SDO,
-               *value,
+                value,
                 1,
                &pData,
                &length,
@@ -916,7 +923,9 @@ void CO_RPDO_process(CO_RPDO_t *RPDO, bool_t syncWas){
     }
     else if(!RPDO->synchronous || syncWas)
     {
+#ifdef RPDO_CALLS_EXTENSION
         bool_t update = false;
+#endif
         uint8_t bufNo = 0;
 
         /* Determine, which of the two rx buffers, contains relevant message. */

--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -1192,8 +1192,8 @@ int8_t CO_SDO_process(
 
                 /* indicate data size, if known */
                 if(SDO->ODF_arg.dataLengthTotal != 0U){
-                    uint32_t len = SDO->ODF_arg.dataLengthTotal;
-                    CO_memcpySwap4(&SDO->CANtxBuff->data[4], &len);
+                    uint32_t dlentot = SDO->ODF_arg.dataLengthTotal;
+                    CO_memcpySwap4(&SDO->CANtxBuff->data[4], &dlentot);
                     SDO->CANtxBuff->data[0] = 0x41U;
                 }
                 else{
@@ -1305,8 +1305,8 @@ int8_t CO_SDO_process(
 
             /* indicate data size, if known */
             if(SDO->ODF_arg.dataLengthTotal != 0U){
-                uint32_t len = SDO->ODF_arg.dataLengthTotal;
-                CO_memcpySwap4(&SDO->CANtxBuff->data[4], &len);
+                uint32_t dlentot = SDO->ODF_arg.dataLengthTotal;
+                CO_memcpySwap4(&SDO->CANtxBuff->data[4], &dlentot);
                 SDO->CANtxBuff->data[0] = 0xC6U;
             }
             else{
@@ -1468,6 +1468,12 @@ int8_t CO_SDO_process(
             }
 
             SDO->state = CO_SDO_ST_IDLE;
+            break;
+        }
+        
+        case CO_SDO_ST_IDLE:
+        {
+            /* Nothing to do it seems */
             break;
         }
 

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -70,6 +70,9 @@
     #define CO_LOCK_OD()
     #define CO_UNLOCK_OD()
 
+    #define CO_LOCK_NMT()
+    #define CO_UNLOCK_NMT()
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/LPC1768/CO_driver.h
+++ b/stack/LPC1768/CO_driver.h
@@ -72,6 +72,17 @@
 
     #define CO_LOCK_NMT()
     #define CO_UNLOCK_NMT()
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */    
 
 
 /* Data types */

--- a/stack/LPC177x_8x/CO_driver.h
+++ b/stack/LPC177x_8x/CO_driver.h
@@ -90,6 +90,9 @@
     #define CO_LOCK_OD()            taskENTER_CRITICAL()
     #define CO_UNLOCK_OD()          taskEXIT_CRITICAL()
 
+    #define CO_LOCK_NMT()           taskENTER_CRITICAL()
+    #define CO_UNLOCK_NMT()         taskEXIT_CRITICAL()
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/LPC177x_8x/CO_driver.h
+++ b/stack/LPC177x_8x/CO_driver.h
@@ -93,6 +93,18 @@
     #define CO_LOCK_NMT()           taskENTER_CRITICAL()
     #define CO_UNLOCK_NMT()         taskEXIT_CRITICAL()
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */    
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/MCF5282/CO_driver.h
+++ b/stack/MCF5282/CO_driver.h
@@ -74,6 +74,18 @@
     #define CO_LOCK_NMT()           asm{ move.w        #0x2700,sr};
     #define CO_UNLOCK_NMT()         asm{ move.w        #0x2000,sr};
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 
 /* MACRO : get information from Rx buffer */

--- a/stack/MCF5282/CO_driver.h
+++ b/stack/MCF5282/CO_driver.h
@@ -71,6 +71,10 @@
     #define CO_LOCK_OD()            asm{ move.w        #0x2700,sr};
     #define CO_UNLOCK_OD()          asm{ move.w        #0x2000,sr};
 
+    #define CO_LOCK_NMT()           asm{ move.w        #0x2700,sr};
+    #define CO_UNLOCK_NMT()         asm{ move.w        #0x2000,sr};
+
+
 
 /* MACRO : get information from Rx buffer */
 #define MCF_CANMB_MSG(x)      (*(CO_CANrxMsg_t *)(&__IPSBAR[0x1C0080 + ((x)*0x10)]))

--- a/stack/PIC24_dsPIC33/CO_driver.h
+++ b/stack/PIC24_dsPIC33/CO_driver.h
@@ -140,6 +140,18 @@
     #define CO_LOCK_NMT()           asm volatile ("disi #0x3FFF")
     #define CO_UNLOCK_NMT()         asm volatile ("disi #0x0000")
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/PIC24_dsPIC33/CO_driver.h
+++ b/stack/PIC24_dsPIC33/CO_driver.h
@@ -137,6 +137,9 @@
     #define CO_DISABLE_INTERRUPTS()  asm volatile ("disi #0x3FFF")
     #define CO_ENABLE_INTERRUPTS()   asm volatile ("disi #0x0000")
 
+    #define CO_LOCK_NMT()           asm volatile ("disi #0x3FFF")
+    #define CO_UNLOCK_NMT()         asm volatile ("disi #0x0000")
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/PIC32/CO_driver.h
+++ b/stack/PIC32/CO_driver.h
@@ -84,6 +84,18 @@
     #define CO_LOCK_NMT()           CO_interruptStatus = __builtin_disable_interrupts()
     #define CO_UNLOCK_NMT()         if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/PIC32/CO_driver.h
+++ b/stack/PIC32/CO_driver.h
@@ -81,6 +81,9 @@
     #define CO_LOCK_OD()            CO_interruptStatus = __builtin_disable_interrupts()
     #define CO_UNLOCK_OD()          if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
 
+    #define CO_LOCK_NMT()           CO_interruptStatus = __builtin_disable_interrupts()
+    #define CO_UNLOCK_NMT()         if(CO_interruptStatus & 0x00000001) {__builtin_enable_interrupts();}
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/SAM3X/CO_driver.h
+++ b/stack/SAM3X/CO_driver.h
@@ -84,6 +84,18 @@
     #define CO_LOCK_NMT()           //taskENTER_CRITICAL()
     #define CO_UNLOCK_NMT()         //taskEXIT_CRITICAL()
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/SAM3X/CO_driver.h
+++ b/stack/SAM3X/CO_driver.h
@@ -81,6 +81,9 @@
     #define CO_LOCK_OD()            //taskENTER_CRITICAL()
     #define CO_UNLOCK_OD()          //taskEXIT_CRITICAL()
 
+    #define CO_LOCK_NMT()           //taskENTER_CRITICAL()
+    #define CO_UNLOCK_NMT()         //taskEXIT_CRITICAL()
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/STM32/CO_driver.h
+++ b/stack/STM32/CO_driver.h
@@ -122,6 +122,19 @@
 /* Timeout for initialization */
 
 #define INAK_TIMEOUT        ((uint32_t)0x0000FFFF)
+
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 /* Data types */
     typedef float                   float32_t;
     typedef long double             float64_t;

--- a/stack/STM32/CO_driver.h
+++ b/stack/STM32/CO_driver.h
@@ -75,6 +75,9 @@
     #define CO_LOCK_OD()            __set_PRIMASK(1);
     #define CO_UNLOCK_OD()          __set_PRIMASK(0);
 
+    #define CO_LOCK_NMT()           __set_PRIMASK(1);
+    #define CO_UNLOCK_NMT()         __set_PRIMASK(0);
+
 
 #define CLOCK_CAN                   RCC_APB1Periph_CAN1
 

--- a/stack/STM32F3/CO_driver.h
+++ b/stack/STM32F3/CO_driver.h
@@ -80,6 +80,9 @@
 #define CO_LOCK_OD()                __set_PRIMASK(1);
 #define CO_UNLOCK_OD()              __set_PRIMASK(0);
 
+#define CO_LOCK_NMT()               __set_PRIMASK(1);
+#define CO_UNLOCK_NMT()             __set_PRIMASK(0);
+
 #define CLOCK_CAN                   RCC_APB1Periph_CAN1
 
 #define CAN_REMAP_1                 /* Select CAN1 remap 1 */

--- a/stack/STM32F3/CO_driver.h
+++ b/stack/STM32F3/CO_driver.h
@@ -115,6 +115,20 @@
 /* Timeout for initialization */
 
 #define INAK_TIMEOUT        ((uint32_t)0x0000FFFF)
+
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
+
 /* Data types */
     typedef float                   float32_t;
     typedef long double             float64_t;

--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -178,6 +178,10 @@ extern "C" {
 
     #define CO_LOCK_OD()        /**< Lock critical section when accessing Object Dictionary */
     #define CO_UNLOCK_OD()      /**< Unock critical section when accessing Object Dictionary */
+
+    #define CO_LOCK_NMT()       /**< Lock critical section when accessing NMT Object asyncronous */
+    #define CO_UNLOCK_NMT()     /**< Lock critical section when accessing NMT Object asyncronous */
+
 /** @} */
 
 /**

--- a/stack/drvTemplate/CO_driver.h
+++ b/stack/drvTemplate/CO_driver.h
@@ -209,6 +209,18 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
+/**
  * @defgroup CO_dataTypes Data types
  * @{
  *

--- a/stack/dsPIC30F/CO_driver.h
+++ b/stack/dsPIC30F/CO_driver.h
@@ -71,6 +71,9 @@
     #define CO_LOCK_OD()            asm volatile ("disi #0x3FFF")
     #define CO_UNLOCK_OD()          asm volatile ("disi #0x0000")
 
+    #define CO_LOCK_NMT()           asm volatile ("disi #0x3FFF")
+    #define CO_UNLOCK_NMT()         asm volatile ("disi #0x0000")
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/dsPIC30F/CO_driver.h
+++ b/stack/dsPIC30F/CO_driver.h
@@ -74,6 +74,18 @@
     #define CO_LOCK_NMT()           asm volatile ("disi #0x3FFF")
     #define CO_UNLOCK_NMT()         asm volatile ("disi #0x0000")
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/eCos/CO_driver.h
+++ b/stack/eCos/CO_driver.h
@@ -103,6 +103,9 @@
     #define CO_LOCK_OD()            cyg_scheduler_lock()
     #define CO_UNLOCK_OD()          cyg_scheduler_unlock()
 
+    #define CO_LOCK_NMT()           cyg_scheduler_lock()
+    #define CO_UNLOCK_NMT()         cyg_scheduler_unlock()
+
 
 
 /* Data types */

--- a/stack/eCos/CO_driver.h
+++ b/stack/eCos/CO_driver.h
@@ -106,6 +106,17 @@
     #define CO_LOCK_NMT()           cyg_scheduler_lock()
     #define CO_UNLOCK_NMT()         cyg_scheduler_unlock()
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
 
 
 /* Data types */

--- a/stack/neuberger-socketCAN/CO_driver.c
+++ b/stack/neuberger-socketCAN/CO_driver.c
@@ -281,7 +281,7 @@ CO_ReturnError_t CO_CANmodule_init(
     /* initialize socketCAN filters
      * CAN module filters will be configured with CO_CANrxBufferInit()
      * functions, called by separate CANopen init functions */
-    CANmodule->rxFilter = calloc(CANmodule->rxSize, sizeof(struct can_filter));
+    CANmodule->rxFilter = COcalloc(CANmodule->rxSize, sizeof(struct can_filter));
     if(CANmodule->rxFilter == NULL){
         log_printf(LOG_DEBUG, DBG_ERRNO, "malloc()");
         return CO_ERROR_OUT_OF_MEMORY;
@@ -461,7 +461,7 @@ void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
         interface->fd = -1;
     }
     if (CANmodule->CANinterfaces != NULL) {
-        free(CANmodule->CANinterfaces);
+        COfree(CANmodule->CANinterfaces);
     }
     CANmodule->CANinterfaceCount = 0;
 
@@ -481,7 +481,7 @@ void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
     CANmodule->fdEpoll = -1;
 
     if (CANmodule->rxFilter != NULL) {
-        free(CANmodule->rxFilter);
+        COfree(CANmodule->rxFilter);
     }
     CANmodule->rxFilter = NULL;
 }

--- a/stack/neuberger-socketCAN/CO_driver.h
+++ b/stack/neuberger-socketCAN/CO_driver.h
@@ -102,6 +102,18 @@ typedef struct {
 } CO_CANinterface_t;
 
 /**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
+/**
  * CAN module object. It may be different in different microcontrollers.
  */
 typedef struct{

--- a/stack/neuberger-socketCAN/CO_notify_pipe.c
+++ b/stack/neuberger-socketCAN/CO_notify_pipe.c
@@ -21,7 +21,7 @@ CO_NotifyPipe_t *CO_NotifyPipeCreate(void)
     if (ret < 0) {
         return NULL;
     }
-    p = calloc(1, sizeof(CO_NotifyPipe_t));
+    p = COcalloc(1, sizeof(CO_NotifyPipe_t));
     if (p == NULL) {
         return NULL;
     }
@@ -38,7 +38,7 @@ void CO_NotifyPipeFree(CO_NotifyPipe_t *p)
     }
     close(p->m_sendFd);
     close(p->m_receiveFd);
-    free(p);
+    COfree(p);
 }
 
 

--- a/stack/socketCAN/CO_OD_storage.c
+++ b/stack/socketCAN/CO_OD_storage.c
@@ -111,7 +111,7 @@ int CO_OD_storage_saveSecure(
     uint16_t CRC = 0;
 
     /* Generate new string with extension '.old' and rename current file to it. */
-    filename_old = malloc(strlen(filename)+10);
+    filename_old = COmalloc(strlen(filename)+10);
     if(filename_old != NULL) {
         strcpy(filename_old, filename);
         strcat(filename_old, ".old");
@@ -148,7 +148,7 @@ int CO_OD_storage_saveSecure(
         uint32_t cnt = 0;
         uint16_t CRC2 = 0;
 
-        buf = malloc(odSize + 4);
+        buf = COmalloc(odSize + 4);
         if(buf != NULL) {
             fp = fopen(filename, "r");
             if(fp != NULL) {
@@ -158,7 +158,7 @@ int CO_OD_storage_saveSecure(
                 cnt += fread(buf, 1, 4, fp);
                 fclose(fp);
             }
-            free(buf);
+            COfree(buf);
         }
         /* If size or CRC differs, report error */
         if(buf == NULL || fp == NULL || cnt != (odSize + 2) || CRC != CRC2) {
@@ -172,7 +172,7 @@ int CO_OD_storage_saveSecure(
         rename(filename_old, filename);
     }
 
-    free(filename_old);
+    COfree(filename_old);
 
     return ret;
 }
@@ -190,7 +190,7 @@ int CO_OD_storage_restoreSecure(char *filename) {
 
         fclose(fp);
 
-        filename_old = malloc(strlen(filename)+10);
+        filename_old = COmalloc(strlen(filename)+10);
         if(filename_old != NULL) {
             strcpy(filename_old, filename);
             strcat(filename_old, ".old");
@@ -199,7 +199,7 @@ int CO_OD_storage_restoreSecure(char *filename) {
             if(rename(filename, filename_old) != 0) {
                 ret = RETURN_ERROR;
             }
-            free(filename_old);
+            COfree(filename_old);
         }
         else {
             ret = RETURN_ERROR;
@@ -245,7 +245,7 @@ CO_ReturnError_t CO_OD_storage_init(
         odStor->tmr1msPrev = 0;
         odStor->lastSavedMs = 0;
 
-        buf = malloc(odStor->odSize);
+        buf = COmalloc(odStor->odSize);
         if(buf == NULL) {
             ret = CO_ERROR_OUT_OF_MEMORY;
         }
@@ -284,7 +284,7 @@ CO_ReturnError_t CO_OD_storage_init(
         }
     }
 
-    free(buf);
+    COfree(buf);
 
     return ret;
 }
@@ -313,7 +313,7 @@ CO_ReturnError_t CO_OD_storage_autoSave(
 
         /* allocate buffer and open file if necessary */
         if(ret == CO_ERROR_NO) {
-            buf = malloc(odStor->odSize);
+            buf = COmalloc(odStor->odSize);
             if(odStor->fp == NULL) {
                 odStor->fp = fopen(odStor->filename, "r+");
             }
@@ -364,7 +364,7 @@ CO_ReturnError_t CO_OD_storage_autoSave(
             odStor->lastSavedMs = 0;
         }
 
-        free(buf);
+        COfree(buf);
     }
 
     odStor->tmr1msPrev = timer1ms;

--- a/stack/socketCAN/CO_driver.c
+++ b/stack/socketCAN/CO_driver.c
@@ -49,7 +49,7 @@ static CO_ReturnError_t setFilters(CO_CANmodule_t *CANmodule){
 
         nFiltersIn = CANmodule->rxSize;
         nFiltersOut = 0;
-        filtersOut = (struct can_filter *) calloc(nFiltersIn, sizeof(struct can_filter));
+        filtersOut = (struct can_filter *) COcalloc(nFiltersIn, sizeof(struct can_filter));
 
         if(filtersOut == NULL){
             ret = CO_ERROR_OUT_OF_MEMORY;
@@ -81,7 +81,7 @@ static CO_ReturnError_t setFilters(CO_CANmodule_t *CANmodule){
                 ret = CO_ERROR_ILLEGAL_ARGUMENT;
             }
 
-            free(filtersOut);
+            COfree(filtersOut);
         }
     }else{
         /* Use one socketCAN filter, match any CAN address, including extended and rtr. */
@@ -183,7 +183,7 @@ CO_ReturnError_t CO_CANmodule_init(
 
         /* allocate memory for filter array */
         if(ret == CO_ERROR_NO){
-            CANmodule->filter = (struct can_filter *) calloc(rxSize, sizeof(struct can_filter));
+            CANmodule->filter = (struct can_filter *) COcalloc(rxSize, sizeof(struct can_filter));
             if(CANmodule->filter == NULL){
                 ret = CO_ERROR_OUT_OF_MEMORY;
             }
@@ -216,7 +216,7 @@ CO_ReturnError_t CO_CANmodule_init(
 /******************************************************************************/
 void CO_CANmodule_disable(CO_CANmodule_t *CANmodule){
     close(CANmodule->fd);
-    free(CANmodule->filter);
+    COfree(CANmodule->filter);
     CANmodule->filter = NULL;
 }
 

--- a/stack/socketCAN/CO_driver.h
+++ b/stack/socketCAN/CO_driver.h
@@ -90,6 +90,18 @@
 #define SET_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)1L;}
 #define CLEAR_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)0L;}
 
+/**
+ * @name Memory/heap management functions mapping
+ * Here the user may select heap management functions according to needs.
+ * @{
+ */
+#define COmalloc(size) malloc(size) 
+/** Calloc */
+#define COcalloc(items, size) calloc(items, size) 
+/** Free */
+#define COfree(loc) free(loc)
+/** @} */
+
 
 /* Data types */
     /* int8_t to uint64_t are defined in stdint.h */

--- a/stack/socketCAN/CO_driver.h
+++ b/stack/socketCAN/CO_driver.h
@@ -63,6 +63,10 @@
     #define CO_UNLOCK_OD()
 
     #define CANrxMemoryBarrier()
+
+    #define CO_LOCK_NMT()
+    #define CO_UNLOCK_NMT()
+
 #else
     #define CO_LOCK_CAN_SEND()      /* not needed */
     #define CO_UNLOCK_CAN_SEND()
@@ -74,6 +78,9 @@
     extern pthread_mutex_t CO_OD_mtx;
     #define CO_LOCK_OD()            {if(pthread_mutex_lock(&CO_OD_mtx) != 0) CO_errExit("Mutex lock CO_OD_mtx failed");}
     #define CO_UNLOCK_OD()          {if(pthread_mutex_unlock(&CO_OD_mtx) != 0) CO_errExit("Mutex unlock CO_OD_mtx failed");}
+
+    #define CO_LOCK_NMT()           {if(pthread_mutex_lock(&CO_OD_mtx) != 0) CO_errExit("Mutex lock CO_OD_mtx failed");}
+    #define CO_UNLOCK_NMT()         {if(pthread_mutex_unlock(&CO_OD_mtx) != 0) CO_errExit("Mutex unlock CO_OD_mtx failed");}
 
     #define CANrxMemoryBarrier()    {__sync_synchronize();}
 #endif


### PR DESCRIPTION
Now all warnings that came up in previous versions are fixed in a clean way directly in the code.
Inlcudes:
Shadowing
Missing default cases
Missing cases in switch statements
unused variables
Pointer problems
Function declarations' visibility