### PR TITLE
guard CO_trace to be optionnal

### DIFF
--- a/stack/CO_trace.c
+++ b/stack/CO_trace.c
@@ -44,6 +44,9 @@
 
 
 #include "CO_trace.h"
+
+#if CO_NO_TRACE > 0
+
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -520,3 +523,5 @@ void CO_trace_process(CO_trace_t *trace, uint32_t timestamp) {
         trace->lastTimeStamp = timestamp;
     }
 }
+
+#endif /* CO_NO_TRACE */

--- a/stack/CO_trace.h
+++ b/stack/CO_trace.h
@@ -51,8 +51,9 @@
 extern "C" {
 #endif
 
-#include "CO_driver.h"
-#include "CO_SDO.h"
+#include "CANopen.h"
+    
+#if CO_NO_TRACE > 0
 
 
 /**
@@ -182,6 +183,8 @@ void CO_trace_init(
  * @return 0 on success, -1 on error.
  */
 void CO_trace_process(CO_trace_t *trace, uint32_t timestamp);
+
+#endif /* CO_NO_TRACE */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix compile error by guarding CO_trace with `#if CO_NO_TRACE > 0` as suggested by @wilkinsw #118 