### PR TITLE
fix NMTstartup handling if device is NOT the NMT Master

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -824,7 +824,11 @@ CO_NMT_reset_cmd_t CO_process(
             CO->NMT,
             timeDifference_ms,
             OD_producerHeartbeatTime,
+#if (CO_NO_NMT_MASTER == 1) && defined(OD_NMTStartup)
             OD_NMTStartup,
+#else
+			0U,
+#endif
             OD_errorRegister,
             OD_errorBehavior,
             timerNext_ms);

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -220,9 +220,10 @@ CO_NMT_reset_cmd_t CO_NMT_process(
         if(NMT->operatingState == CO_NMT_INITIALIZING){
             if(HBtime > NMT->firstHBTime) NMT->HBproducerTimer = HBtime - NMT->firstHBTime;
             else                          NMT->HBproducerTimer = 0;
-
-            if((NMTstartup & 0x05) == 0) NMT->operatingState = CO_NMT_OPERATIONAL;
-            else                         NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
+            
+            /* NMT slave self starting */
+            if (NMTstartup == 0x00000008U) NMT->operatingState = CO_NMT_OPERATIONAL;
+            else                           NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
         }
     }
 

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -221,7 +221,7 @@ CO_NMT_reset_cmd_t CO_NMT_process(
             if(HBtime > NMT->firstHBTime) NMT->HBproducerTimer = HBtime - NMT->firstHBTime;
             else                          NMT->HBproducerTimer = 0;
 
-            if((NMTstartup & 0x04) == 0) NMT->operatingState = CO_NMT_OPERATIONAL;
+            if((NMTstartup & 0x05) == 0) NMT->operatingState = CO_NMT_OPERATIONAL;
             else                         NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
         }
     }


### PR DESCRIPTION
OD_NMTStartup (0x1F80 OD) can be optional

issue #149