### PR TITLE
add NMT master self-start support

### DIFF
--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -333,6 +333,15 @@ CO_NMT_reset_cmd_t CO_NMT_process(
         }
     }
 
+#if CO_NO_NMT_MASTER == 1
+    if(NMTstartup & 0x00000004U){
+        /* if errors are cleared enter operational state. */
+        if(!OD_errorRegister && (NMT->operatingState == CO_NMT_PRE_OPERATIONAL)){
+            NMT->operatingState = CO_NMT_OPERATIONAL;
+        }
+    }
+#endif
+
     if(NMT->pFunctNMT!=NULL && currentOperatingState!=NMT->operatingState){
         NMT->pFunctNMT(NMT->operatingState);
     }

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -335,7 +335,7 @@ CO_NMT_reset_cmd_t CO_NMT_process(
 
     if(NMTstartup & 0x00000005U){
         /* if errors are cleared enter operational state. */
-        if(!OD_errorRegister && (NMT->operatingState == CO_NMT_PRE_OPERATIONAL)){
+        if(!errorRegister && (NMT->operatingState == CO_NMT_PRE_OPERATIONAL)){
             NMT->operatingState = CO_NMT_OPERATIONAL;
         }
     }

--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -333,14 +333,12 @@ CO_NMT_reset_cmd_t CO_NMT_process(
         }
     }
 
-#if CO_NO_NMT_MASTER == 1
-    if(NMTstartup & 0x00000004U){
+    if(NMTstartup & 0x00000005U){
         /* if errors are cleared enter operational state. */
         if(!OD_errorRegister && (NMT->operatingState == CO_NMT_PRE_OPERATIONAL)){
             NMT->operatingState = CO_NMT_OPERATIONAL;
         }
     }
-#endif
 
     if(NMT->pFunctNMT!=NULL && currentOperatingState!=NMT->operatingState){
         NMT->pFunctNMT(NMT->operatingState);


### PR DESCRIPTION
This adds support for bit 2 of 0x1F80 (NMT start-up) in accordance with CiA DSP 302 (v3.2.1) §5.1

If bit0 and bit2 of 0x1F80 are set then CO_NMT_process will check OD_errorRegister for active errors.  Once all error bits have been cleared by CO_errorReset the application will transition to NMT Operational.