### PR TITLE
add fifo queue for SDO received messages to fix possible drops

### DIFF
--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -160,6 +160,19 @@ void CO_memcpySwap8(void* dest, const void* src){
 }
 #endif
 
+static void CO_SDO_receive_done(CO_SDO_t *SDO){
+#if CO_SDO_RX_DATA_SIZE > 1
+    uint8_t rcv = SDO->CANrxRcv;
+    uint8_t newRcv = rcv;
+
+    if (++newRcv >= CO_SDO_RX_DATA_SIZE)
+        newRcv = 0;
+    SDO->CANrxRcv = newRcv;
+    SET_CANrxNew(SDO->CANrxNew[rcv]);
+#else
+    SET_CANrxNew(SDO->CANrxNew[0]);
+#endif
+}
 
 /*
  * Read received message from CAN module.
@@ -171,35 +184,33 @@ void CO_memcpySwap8(void* dest, const void* src){
 static void CO_SDO_receive(void *object, const CO_CANrxMsg_t *msg);
 static void CO_SDO_receive(void *object, const CO_CANrxMsg_t *msg){
     CO_SDO_t *SDO;
+    uint8_t rcv, *CANrxData;
 
     SDO = (CO_SDO_t*)object;   /* this is the correct pointer type of the first argument */
+    rcv = SDO->CANrxRcv;
+    CANrxData = SDO->CANrxData[rcv];
 
-    /* WARNING: When doing a SDO block upload and immediately after that
-     * starting another SDO request, this request is dropped. Especially if
-     * processing function has slow response.
-     * See: https://github.com/CANopenNode/CANopenNode/issues/39 */
-
-    /* verify message length and message overflow (previous message was not processed yet) */
-    if((msg->DLC == 8U) && (!IS_CANrxNew(SDO->CANrxNew))){
+    /* verify message length and message queue overflow (if previous messages were not processed yet) */
+    if((msg->DLC == 8U) && (!IS_CANrxNew(SDO->CANrxNew[rcv]))){
         if(SDO->state != CO_SDO_ST_DOWNLOAD_BL_SUBBLOCK) {
             /* copy data and set 'new message' flag */
-            SDO->CANrxData[0] = msg->data[0];
-            SDO->CANrxData[1] = msg->data[1];
-            SDO->CANrxData[2] = msg->data[2];
-            SDO->CANrxData[3] = msg->data[3];
-            SDO->CANrxData[4] = msg->data[4];
-            SDO->CANrxData[5] = msg->data[5];
-            SDO->CANrxData[6] = msg->data[6];
-            SDO->CANrxData[7] = msg->data[7];
+            CANrxData[0] = msg->data[0];
+            CANrxData[1] = msg->data[1];
+            CANrxData[2] = msg->data[2];
+            CANrxData[3] = msg->data[3];
+            CANrxData[4] = msg->data[4];
+            CANrxData[5] = msg->data[5];
+            CANrxData[6] = msg->data[6];
+            CANrxData[7] = msg->data[7];
 
-            SET_CANrxNew(SDO->CANrxNew);
+            CO_SDO_receive_done(SDO);
         }
         else {
             /* block download, copy data directly */
             uint8_t seqno;
 
-            SDO->CANrxData[0] = msg->data[0];
-            seqno = SDO->CANrxData[0] & 0x7fU;
+            CANrxData[0] = msg->data[0];
+            seqno = CANrxData[0] & 0x7fU;
             SDO->timeoutTimer = 0;
             /* clear timeout in sub-block transfer indication if set before */
             if (SDO->timeoutSubblockDownolad)
@@ -218,29 +229,29 @@ static void CO_SDO_receive(void *object, const CO_CANrxMsg_t *msg){
                     if(SDO->bufferOffset >= CO_SDO_BUFFER_SIZE) {
                         /* buffer full, break reception */
                         SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP;
-                        SET_CANrxNew(SDO->CANrxNew);
+                        CO_SDO_receive_done(SDO);
                         break;
                     }
                 }
 
                 /* break reception if last segment, block ends or block sequence is too large */
-                if(((SDO->CANrxData[0] & 0x80U) == 0x80U) || (SDO->sequence >= SDO->blksize)) {
+                if(((CANrxData[0] & 0x80U) == 0x80U) || (SDO->sequence >= SDO->blksize)) {
                     SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP;
-                    SET_CANrxNew(SDO->CANrxNew);
+                    CO_SDO_receive_done(SDO);
                 }
             }
-            else if((seqno == SDO->sequence) || (SDO->sequence == 0U)){
+            else if((seqno == SDO->sequence) || (SDO->sequence == 0U)) {
                 /* Ignore message, if it is duplicate or if sequence didn't started yet. */
             }
             else {
                 /* seqno is wrong, send response without resetting sequence */
                 SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP_2;
-                SET_CANrxNew(SDO->CANrxNew);
+                CO_SDO_receive_done(SDO);
             }
         }
 
         /* Optional signal to RTOS, which can resume task, which handles SDO server. */
-        if(IS_CANrxNew(SDO->CANrxNew) && SDO->pFunctSignal != NULL) {
+        if((IS_CANrxNew(SDO->CANrxNew[rcv])) && (SDO->pFunctSignal != NULL)) {
             SDO->pFunctSignal();
         }
     }
@@ -319,7 +330,14 @@ CO_ReturnError_t CO_SDO_init(
     /* Configure object variables */
     SDO->nodeId = nodeId;
     SDO->state = CO_SDO_ST_IDLE;
-    CLEAR_CANrxNew(SDO->CANrxNew);
+
+    uint8_t i;
+    for(i=0U; i<CO_SDO_RX_DATA_SIZE; i++){
+        CLEAR_CANrxNew(SDO->CANrxNew[i]);
+    }
+    SDO->CANrxRcv = 0;
+    SDO->CANrxProc = 0;
+
     SDO->pFunctSignal = NULL;
 
 
@@ -751,6 +769,25 @@ uint32_t CO_SDO_writeOD(CO_SDO_t *SDO, uint16_t length){
     return 0;
 }
 
+/******************************************************************************/
+static void CO_SDO_process_done(CO_SDO_t *SDO, uint16_t *timerNext_ms) {
+#if CO_SDO_RX_DATA_SIZE > 1
+    uint8_t proc = SDO->CANrxProc;
+    uint8_t newProc = proc;
+
+    if (++newProc >= CO_SDO_RX_DATA_SIZE)
+        newProc = 0;
+
+    SDO->CANrxProc = newProc;
+    CLEAR_CANrxNew(SDO->CANrxNew[proc]);
+
+    if ((timerNext_ms != NULL) && (IS_CANrxNew(SDO->CANrxNew[newProc])))
+        timerNext_ms = 0; /* Set timerNext_ms to 0 to inform OS to call CO_SDO_process function again without delay. */
+#else
+    (void)(timerNext_ms);
+    CLEAR_CANrxNew(SDO->CANrxNew[0]);
+#endif
+}
 
 /******************************************************************************/
 static void CO_SDO_abort(CO_SDO_t *SDO, uint32_t code){
@@ -760,10 +797,9 @@ static void CO_SDO_abort(CO_SDO_t *SDO, uint32_t code){
     SDO->CANtxBuff->data[3] = SDO->ODF_arg.subIndex;
     CO_memcpySwap4(&SDO->CANtxBuff->data[4], &code);
     SDO->state = CO_SDO_ST_IDLE;
-    CLEAR_CANrxNew(SDO->CANrxNew);
+    CO_SDO_process_done(SDO, NULL);
     CO_CANsend(SDO->CANdevTx, SDO->CANtxBuff);
 }
-
 
 /******************************************************************************/
 int8_t CO_SDO_process(
@@ -775,23 +811,28 @@ int8_t CO_SDO_process(
 {
     CO_SDO_state_t state = CO_SDO_ST_IDLE;
     bool_t sendResponse = false;
+    uint8_t proc, *CANrxData;
+    bool_t isNew;
+
+    proc = SDO->CANrxProc;
+    isNew = IS_CANrxNew(SDO->CANrxNew[proc]);
 
     /* return if idle */
-    if((SDO->state == CO_SDO_ST_IDLE) && (!IS_CANrxNew(SDO->CANrxNew))){
+    if((SDO->state == CO_SDO_ST_IDLE) && (!isNew)){
         return 0;
     }
 
     /* SDO is allowed to work only in operational or pre-operational NMT state */
     if(!NMTisPreOrOperational){
         SDO->state = CO_SDO_ST_IDLE;
-        CLEAR_CANrxNew(SDO->CANrxNew);
+        CO_SDO_process_done(SDO, timerNext_ms);
         return 0;
     }
 
-    /* Is something new to process? */
-    if((!SDO->CANtxBuff->bufferFull) && ((IS_CANrxNew(SDO->CANrxNew)) || (SDO->state == CO_SDO_ST_UPLOAD_BL_SUBBLOCK))){
-        uint8_t CCS = SDO->CANrxData[0] >> 5;   /* Client command specifier */
+    CANrxData = SDO->CANrxData[proc];
 
+    /* Is something new to process? */
+    if((!SDO->CANtxBuff->bufferFull) && (isNew || (SDO->state == CO_SDO_ST_UPLOAD_BL_SUBBLOCK))){
         /* reset timeout */
         if(SDO->state != CO_SDO_ST_UPLOAD_BL_SUBBLOCK)
             SDO->timeoutTimer = 0;
@@ -801,11 +842,13 @@ int8_t CO_SDO_process(
         SDO->CANtxBuff->data[4] = SDO->CANtxBuff->data[5] = SDO->CANtxBuff->data[6] = SDO->CANtxBuff->data[7] = 0;
 
         /* Is abort from client? */
-        if((IS_CANrxNew(SDO->CANrxNew)) && (SDO->CANrxData[0] == CCS_ABORT)){
+        if(isNew && (CANrxData[0] == CCS_ABORT)){
             SDO->state = CO_SDO_ST_IDLE;
-            CLEAR_CANrxNew(SDO->CANrxNew);
+            CO_SDO_process_done(SDO, timerNext_ms);
             return -1;
         }
+
+        uint8_t CCS = CANrxData[0] >> 5;   /* Client command specifier */
 
         /* continue with previous SDO communication or start new */
         if(SDO->state != CO_SDO_ST_IDLE){
@@ -823,9 +866,9 @@ int8_t CO_SDO_process(
             }
 
             /* init ODF_arg */
-            index = SDO->CANrxData[2];
-            index = index << 8 | SDO->CANrxData[1];
-            abortCode = CO_SDO_initTransfer(SDO, index, SDO->CANrxData[3]);
+            index = CANrxData[2];
+            index = index << 8 | CANrxData[1];
+            abortCode = CO_SDO_initTransfer(SDO, index, CANrxData[3]);
             if(abortCode != 0U){
                 CO_SDO_abort(SDO, abortCode);
                 return -1;
@@ -856,7 +899,7 @@ int8_t CO_SDO_process(
                 }
 
                 /* if data size is large enough set state machine to block upload, otherwise set to normal transfer */
-                if((CCS == CCS_UPLOAD_BLOCK) && (SDO->ODF_arg.dataLength > SDO->CANrxData[5])){
+                if((CCS == CCS_UPLOAD_BLOCK) && (SDO->ODF_arg.dataLength > CANrxData[5])){
                     state = CO_SDO_ST_UPLOAD_BL_INITIATE;
                 }
                 else{
@@ -889,7 +932,7 @@ int8_t CO_SDO_process(
         return 0;
     }
 
-    /* state machine (buffer is freed (CLEAR_CANrxNew()) at the end) */
+    /* state machine (buffer is freed with process_done() at the end) */
     switch(state){
         uint32_t abortCode;
         uint16_t len, i;
@@ -898,25 +941,25 @@ int8_t CO_SDO_process(
         case CO_SDO_ST_DOWNLOAD_INITIATE:{
             /* default response */
             SDO->CANtxBuff->data[0] = 0x60;
-            SDO->CANtxBuff->data[1] = SDO->CANrxData[1];
-            SDO->CANtxBuff->data[2] = SDO->CANrxData[2];
-            SDO->CANtxBuff->data[3] = SDO->CANrxData[3];
+            SDO->CANtxBuff->data[1] = CANrxData[1];
+            SDO->CANtxBuff->data[2] = CANrxData[2];
+            SDO->CANtxBuff->data[3] = CANrxData[3];
 
             /* Expedited transfer */
-            if((SDO->CANrxData[0] & 0x02U) != 0U){
+            if((CANrxData[0] & 0x02U) != 0U){
                 /* is size indicated? Get message length */
-                if((SDO->CANrxData[0] & 0x01U) != 0U){
-                    len = 4U - ((SDO->CANrxData[0] >> 2U) & 0x03U);
+                if((CANrxData[0] & 0x01U) != 0U){
+                    len = 4U - ((CANrxData[0] >> 2U) & 0x03U);
                 }
                 else{
                     len = SDO->ODF_arg.dataLength;
                 }
 
                 /* copy data to SDO buffer */
-                SDO->ODF_arg.data[0] = SDO->CANrxData[4];
-                SDO->ODF_arg.data[1] = SDO->CANrxData[5];
-                SDO->ODF_arg.data[2] = SDO->CANrxData[6];
-                SDO->ODF_arg.data[3] = SDO->CANrxData[7];
+                SDO->ODF_arg.data[0] = CANrxData[4];
+                SDO->ODF_arg.data[1] = CANrxData[5];
+                SDO->ODF_arg.data[2] = CANrxData[6];
+                SDO->ODF_arg.data[3] = CANrxData[7];
 
                 /* write data to the Object dictionary */
                 abortCode = CO_SDO_writeOD(SDO, len);
@@ -933,9 +976,9 @@ int8_t CO_SDO_process(
             /* Segmented transfer */
             else{
                 /* verify length if size is indicated */
-                if((SDO->CANrxData[0]&0x01) != 0){
+                if((CANrxData[0]&0x01) != 0){
                     uint32_t lenRx;
-                    CO_memcpySwap4(&lenRx, &SDO->CANrxData[4]);
+                    CO_memcpySwap4(&lenRx, &CANrxData[4]);
                     SDO->ODF_arg.dataLengthTotal = lenRx;
 
                     /* verify length except for domain data type */
@@ -954,20 +997,20 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_DOWNLOAD_SEGMENTED:{
             /* verify client command specifier */
-            if((SDO->CANrxData[0]&0xE0) != 0x00U){
+            if((CANrxData[0]&0xE0) != 0x00U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
 
             /* verify toggle bit */
-            i = (SDO->CANrxData[0]&0x10U) ? 1U : 0U;
+            i = (CANrxData[0]&0x10U) ? 1U : 0U;
             if(i != SDO->sequence){
                 CO_SDO_abort(SDO, CO_SDO_AB_TOGGLE_BIT);/* toggle bit not alternated */
                 return -1;
             }
 
             /* get size of data in message */
-            len = 7U - ((SDO->CANrxData[0] >> 1U) & 0x07U);
+            len = 7U - ((CANrxData[0] >> 1U) & 0x07U);
 
             /* verify length. Domain data type enables length larger than SDO buffer size */
             if((SDO->bufferOffset + len) > SDO->ODF_arg.dataLength){
@@ -991,10 +1034,10 @@ int8_t CO_SDO_process(
 
             /* copy data to buffer */
             for(i=0U; i<len; i++)
-                SDO->ODF_arg.data[SDO->bufferOffset++] = SDO->CANrxData[i+1];
+                SDO->ODF_arg.data[SDO->bufferOffset++] = CANrxData[i+1];
 
             /* If no more segments to be downloaded, write data to the Object dictionary */
-            if((SDO->CANrxData[0] & 0x01U) != 0U){
+            if((CANrxData[0] & 0x01U) != 0U){
                 SDO->ODF_arg.lastSegment = true;
                 abortCode = CO_SDO_writeOD(SDO, SDO->bufferOffset);
                 if(abortCode != 0U){
@@ -1015,29 +1058,29 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_DOWNLOAD_BL_INITIATE:{
             /* verify client command specifier and subcommand */
-            if((SDO->CANrxData[0]&0xE1U) != 0xC0U){
+            if((CANrxData[0]&0xE1U) != 0xC0U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
 
             /* prepare response */
             SDO->CANtxBuff->data[0] = 0xA4;
-            SDO->CANtxBuff->data[1] = SDO->CANrxData[1];
-            SDO->CANtxBuff->data[2] = SDO->CANrxData[2];
-            SDO->CANtxBuff->data[3] = SDO->CANrxData[3];
+            SDO->CANtxBuff->data[1] = CANrxData[1];
+            SDO->CANtxBuff->data[2] = CANrxData[2];
+            SDO->CANtxBuff->data[3] = CANrxData[3];
 
             /* blksize */
             SDO->blksize = (CO_SDO_BUFFER_SIZE > (7*127)) ? 127 : (CO_SDO_BUFFER_SIZE / 7);
             SDO->CANtxBuff->data[4] = SDO->blksize;
 
             /* is CRC enabled */
-            SDO->crcEnabled = (SDO->CANrxData[0] & 0x04) ? true : false;
+            SDO->crcEnabled = (CANrxData[0] & 0x04) ? true : false;
             SDO->crc = 0;
 
             /* verify length if size is indicated */
-            if((SDO->CANrxData[0]&0x02) != 0U){
+            if((CANrxData[0]&0x02) != 0U){
                 uint32_t lenRx;
-                CO_memcpySwap4(&lenRx, &SDO->CANrxData[4]);
+                CO_memcpySwap4(&lenRx, &CANrxData[4]);
                 SDO->ODF_arg.dataLengthTotal = lenRx;
 
                 /* verify length except for domain data type */
@@ -1066,7 +1109,7 @@ int8_t CO_SDO_process(
         case CO_SDO_ST_DOWNLOAD_BL_SUB_RESP_2:{
             /* check if last segment received */
             lastSegmentInSubblock = (!SDO->timeoutSubblockDownolad &&
-                        ((SDO->CANrxData[0] & 0x80U) == 0x80U)) ? true : false;
+                        ((CANrxData[0] & 0x80U) == 0x80U)) ? true : false;
 
             /* prepare response */
             SDO->CANtxBuff->data[0] = 0xA2;
@@ -1120,13 +1163,13 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_DOWNLOAD_BL_END:{
             /* verify client command specifier and subcommand */
-            if((SDO->CANrxData[0]&0xE1U) != 0xC1U){
+            if((CANrxData[0]&0xE1U) != 0xC1U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
 
             /* number of bytes in the last segment of the last block that do not contain data. */
-            len = (SDO->CANrxData[0]>>2U) & 0x07U;
+            len = (CANrxData[0]>>2U) & 0x07U;
             SDO->bufferOffset -= len;
 
             /* calculate and verify CRC, if enabled */
@@ -1134,7 +1177,7 @@ int8_t CO_SDO_process(
                 uint16_t crc;
                 SDO->crc = crc16_ccitt(SDO->ODF_arg.data, SDO->bufferOffset, SDO->crc);
 
-                CO_memcpySwap2(&crc, &SDO->CANrxData[1]);
+                CO_memcpySwap2(&crc, &CANrxData[1]);
 
                 if(SDO->crc != crc){
                     CO_SDO_abort(SDO, CO_SDO_AB_CRC);   /* CRC error (block mode only). */
@@ -1159,9 +1202,9 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_UPLOAD_INITIATE:{
             /* default response */
-            SDO->CANtxBuff->data[1] = SDO->CANrxData[1];
-            SDO->CANtxBuff->data[2] = SDO->CANrxData[2];
-            SDO->CANtxBuff->data[3] = SDO->CANrxData[3];
+            SDO->CANtxBuff->data[1] = CANrxData[1];
+            SDO->CANtxBuff->data[2] = CANrxData[2];
+            SDO->CANtxBuff->data[3] = CANrxData[3];
 
             /* Expedited transfer */
             if(SDO->ODF_arg.dataLength <= 4U){
@@ -1198,13 +1241,13 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_UPLOAD_SEGMENTED:{
             /* verify client command specifier */
-            if((SDO->CANrxData[0]&0xE0U) != 0x60U){
+            if((CANrxData[0]&0xE0U) != 0x60U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
 
             /* verify toggle bit */
-            i = ((SDO->CANrxData[0]&0x10U) != 0) ? 1U : 0U;
+            i = ((CANrxData[0]&0x10U) != 0) ? 1U : 0U;
             if(i != SDO->sequence){
                 CO_SDO_abort(SDO, CO_SDO_AB_TOGGLE_BIT);/* toggle bit not alternated */
                 return -1;
@@ -1263,12 +1306,12 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_UPLOAD_BL_INITIATE:{
             /* default response */
-            SDO->CANtxBuff->data[1] = SDO->CANrxData[1];
-            SDO->CANtxBuff->data[2] = SDO->CANrxData[2];
-            SDO->CANtxBuff->data[3] = SDO->CANrxData[3];
+            SDO->CANtxBuff->data[1] = CANrxData[1];
+            SDO->CANtxBuff->data[2] = CANrxData[2];
+            SDO->CANtxBuff->data[3] = CANrxData[3];
 
             /* calculate CRC, if enabled */
-            if((SDO->CANrxData[0] & 0x04U) != 0U){
+            if((CANrxData[0] & 0x04U) != 0U){
                 SDO->crcEnabled = true;
                 SDO->crc = crc16_ccitt(SDO->ODF_arg.data, SDO->ODF_arg.dataLength, 0);
             }
@@ -1278,10 +1321,10 @@ int8_t CO_SDO_process(
             }
 
             /* Number of segments per block */
-            SDO->blksize = SDO->CANrxData[4];
+            SDO->blksize = CANrxData[4];
 
             /* verify client subcommand */
-            if((SDO->CANrxData[0]&0x03U) != 0x00U){
+            if((CANrxData[0]&0x03U) != 0x00U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
@@ -1311,7 +1354,7 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_UPLOAD_BL_INITIATE_2:{
             /* verify client command specifier and subcommand */
-            if((SDO->CANrxData[0]&0xE3U) != 0xA3U){
+            if((CANrxData[0]&0xE3U) != 0xA3U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
@@ -1319,7 +1362,8 @@ int8_t CO_SDO_process(
             SDO->bufferOffset = 0U;
             SDO->sequence = 0U;
             SDO->endOfTransfer = false;
-            CLEAR_CANrxNew(SDO->CANrxNew);
+            CO_SDO_process_done(SDO, timerNext_ms);
+            isNew = false;
             SDO->state = CO_SDO_ST_UPLOAD_BL_SUBBLOCK;
             /* continue in next case */
         }
@@ -1327,17 +1371,17 @@ int8_t CO_SDO_process(
 
         case CO_SDO_ST_UPLOAD_BL_SUBBLOCK:{
             /* is block confirmation received */
-            if(IS_CANrxNew(SDO->CANrxNew)){
+            if(isNew){
                 uint8_t ackseq;
                 uint16_t j;
 
                 /* verify client command specifier and subcommand */
-                if((SDO->CANrxData[0]&0xE3U) != 0xA2U){
+                if((CANrxData[0]&0xE3U) != 0xA2U){
                     CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                     return -1;
                 }
 
-                ackseq = SDO->CANrxData[1];   /* sequence number of the last segment, that was received correctly. */
+                ackseq = CANrxData[1];   /* sequence number of the last segment, that was received correctly. */
 
                 /* verify if response is too early */
                 if(ackseq > SDO->sequence){
@@ -1369,7 +1413,7 @@ int8_t CO_SDO_process(
                 SDO->ODF_arg.dataLength -= ackseq * 7U;
 
                 /* new block size */
-                SDO->blksize = SDO->CANrxData[2];
+                SDO->blksize = CANrxData[2];
 
                 /* If data type is domain, re-fill the data buffer if necessary and indicated so. */
                 if((SDO->ODF_arg.ODdataStorage == 0) && (SDO->ODF_arg.dataLength < (SDO->blksize*7U)) && (!SDO->ODF_arg.lastSegment)){
@@ -1405,8 +1449,9 @@ int8_t CO_SDO_process(
                 SDO->sequence = 0U;
                 SDO->endOfTransfer = false;
 
-                /* clear flag here */
-                CLEAR_CANrxNew(SDO->CANrxNew);
+                /* clear received flag here, no need to pass timerNext_ms */
+                CO_SDO_process_done(SDO, NULL);
+                isNew = false;
             }
 
             /* return, if all segments was already transfered or on end of transfer */
@@ -1447,13 +1492,13 @@ int8_t CO_SDO_process(
                 *timerNext_ms = 0;
             }
 
-            /* don't call CLEAR_CANrxNew, so return directly */
+            /* don't call process_done, so return directly */
             return 1;
         }
 
         case CO_SDO_ST_UPLOAD_BL_END:{
             /* verify client command specifier */
-            if((SDO->CANrxData[0]&0xE1U) != 0xA1U){
+            if((CANrxData[0]&0xE1U) != 0xA1U){
                 CO_SDO_abort(SDO, CO_SDO_AB_CMD);/* Client command specifier not valid or unknown. */
                 return -1;
             }
@@ -1475,7 +1520,7 @@ int8_t CO_SDO_process(
     }
 
     /* free buffer and send message */
-    CLEAR_CANrxNew(SDO->CANrxNew);
+    CO_SDO_process_done(SDO, timerNext_ms);
     if(sendResponse) {
         CO_CANsend(SDO->CANdevTx, SDO->CANtxBuff);
     }

--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -797,7 +797,9 @@ static void CO_SDO_abort(CO_SDO_t *SDO, uint32_t code){
     SDO->CANtxBuff->data[3] = SDO->ODF_arg.subIndex;
     CO_memcpySwap4(&SDO->CANtxBuff->data[4], &code);
     SDO->state = CO_SDO_ST_IDLE;
-    CO_SDO_process_done(SDO, NULL);
+    /* skip all received message in queue */
+    while (IS_CANrxNew(SDO->CANrxNew[SDO->CANrxProc]))
+        CO_SDO_process_done(SDO, NULL);
     CO_CANsend(SDO->CANdevTx, SDO->CANtxBuff);
 }
 

--- a/stack/CO_SDO.h
+++ b/stack/CO_SDO.h
@@ -338,6 +338,18 @@ typedef enum{
         #define CO_SDO_BUFFER_SIZE    32
     #endif
 
+/**
+ * Size of fifo queue for SDO received messages.
+ *
+ * If block transfers are used size of fifo queue should be more that 1 message
+ * to avoid possible drops in consecutive SDO block upload transfers.
+ * To increase performance, value can be set to 1 if block transfers are not used
+ *
+ * Min value is 1.
+ */
+    #ifndef CO_SDO_RX_DATA_SIZE
+        #define CO_SDO_RX_DATA_SIZE   2
+    #endif
 
 /**
  * Object Dictionary attributes. Bit masks for attribute in CO_OD_entry_t.
@@ -588,8 +600,8 @@ typedef struct{
  * SDO server object.
  */
 typedef struct{
-    /** 8 data bytes of the received message. */
-    uint8_t             CANrxData[8];
+    /** FIFO queue of the received message 8 data bytes each */
+    uint8_t             CANrxData[CO_SDO_RX_DATA_SIZE][8];
     /** SDO data buffer of size #CO_SDO_BUFFER_SIZE. */
     uint8_t             databuffer[CO_SDO_BUFFER_SIZE];
     /** Internal flag indicates, that this object has own OD */
@@ -628,8 +640,14 @@ typedef struct{
     bool_t              timeoutSubblockDownolad;
     /** Indication end of block transfer */
     bool_t              endOfTransfer;
-    /** Variable indicates, if new SDO message received from CAN bus */
-    volatile void      *CANrxNew;
+    /** Variables indicates, if new SDO message received from CAN bus */
+    volatile void      *CANrxNew[CO_SDO_RX_DATA_SIZE];
+    /** Index of CANrxData for new received SDO message */
+    uint8_t             CANrxRcv;
+    /** Index of CANrxData SDO message to processed */
+    uint8_t             CANrxProc;
+    /** Number of new SDO messages in CANrxData to process */
+    uint8_t             CANrxSize;
     /** From CO_SDO_initCallback() or NULL */
     void              (*pFunctSignal)(void);
     /** From CO_SDO_init() */

--- a/stack/drvTemplate/CO_driver_target.h
+++ b/stack/drvTemplate/CO_driver_target.h
@@ -170,16 +170,16 @@ extern "C" {
 /** @} */
 
 /**
- * @name Syncronisation functions
- * syncronisation for message buffer for communication between CAN receive and
+ * @name Synchronization functions
+ * synchronization for message buffer for communication between CAN receive and
  * message processing threads.
  *
- * If receive function runs inside IRQ, no further synchronsiation is needed.
- * Otherwise, some kind of synchronsiation has to be included. The following
+ * If receive function runs inside IRQ, no further synchronization is needed.
+ * Otherwise, some kind of synchronization has to be included. The following
  * example uses GCC builtin memory barrier __sync_synchronize(). A comprehensive
  * list can be found here: https://gist.github.com/leo-yuriev/ba186a6bf5cf3a27bae7
  * \code{.c}
-    #define CANrxMemoryBarrier() {__sync_synchronize();}
+    #define CANrxMemoryBarrier() __sync_synchronize()
  * \endcode
  * @{
  */


### PR DESCRIPTION
Previously when doing a SDO block upload and immediately after that starting another SDO request, this request was dropped. Especially if processing function has slow response.

fifo queue size is 2 by default. To increase performance a little, one can redifine CO_SDO_RX_DATA_SIZE to 1 in CO_driver_target.h, if block transfers are not used

issue #39