### PR TITLE
Add CO_..._initCallbackPre() for RPDO and SYNC

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -24,6 +24,8 @@
  */
 
 
+#include <string.h>
+
 #include "301/CO_driver.h"
 #include "301/CO_SDOserver.h"
 #include "301/CO_Emergency.h"
@@ -54,35 +56,14 @@ static void CO_PDO_receive(void *object, void *msg){
         (DLC >= RPDO->dataLength))
     {
 #if (CO_CONFIG_PDO) & CO_CONFIG_PDO_SYNC_ENABLE
-        if(RPDO->SYNC && RPDO->synchronous && RPDO->SYNC->CANrxToggle) {
-            /* copy data into second buffer and set 'new message' flag */
-            RPDO->CANrxData[1][0] = data[0];
-            RPDO->CANrxData[1][1] = data[1];
-            RPDO->CANrxData[1][2] = data[2];
-            RPDO->CANrxData[1][3] = data[3];
-            RPDO->CANrxData[1][4] = data[4];
-            RPDO->CANrxData[1][5] = data[5];
-            RPDO->CANrxData[1][6] = data[6];
-            RPDO->CANrxData[1][7] = data[7];
-
-            CO_FLAG_SET(RPDO->CANrxNew[1]);
-        }
-        else {
+        const size_t index = RPDO->SYNC && RPDO->synchronous && RPDO->SYNC->CANrxToggle;
+#else
+        const size_t index = 0;
 #endif
-            /* copy data into default buffer and set 'new message' flag */
-            RPDO->CANrxData[0][0] = data[0];
-            RPDO->CANrxData[0][1] = data[1];
-            RPDO->CANrxData[0][2] = data[2];
-            RPDO->CANrxData[0][3] = data[3];
-            RPDO->CANrxData[0][4] = data[4];
-            RPDO->CANrxData[0][5] = data[5];
-            RPDO->CANrxData[0][6] = data[6];
-            RPDO->CANrxData[0][7] = data[7];
 
-            CO_FLAG_SET(RPDO->CANrxNew[0]);
-#if (CO_CONFIG_PDO) & CO_CONFIG_PDO_SYNC_ENABLE
-        }
-#endif
+        /* copy data into appropriate buffer and set 'new message' flag */
+        memcpy(RPDO->CANrxData[index], data, sizeof(RPDO->CANrxData[index]));
+        CO_FLAG_SET(RPDO->CANrxNew[index]);
     }
 }
 

--- a/301/CO_PDO.h
+++ b/301/CO_PDO.h
@@ -189,6 +189,12 @@ typedef struct{
     volatile void      *CANrxNew[1];
     uint8_t             CANrxData[1][8];
 #endif
+#if ((CO_CONFIG_PDO) & CO_CONFIG_FLAG_CALLBACK_PRE) || defined CO_DOXYGEN
+    /** From CO_RPDO_initCallbackPre() or NULL */
+    void              (*pFunctSignalPre)(void *object);
+    /** From CO_RPDO_initCallbackPre() or NULL */
+    void               *functSignalObjectPre;
+#endif
     CO_CANmodule_t     *CANdevRx;       /**< From CO_RPDO_init() */
     uint16_t            CANdevRxIdx;    /**< From CO_RPDO_init() */
 }CO_RPDO_t;
@@ -278,6 +284,25 @@ CO_ReturnError_t CO_RPDO_init(
         uint16_t                idx_RPDOMapPar,
         CO_CANmodule_t         *CANdevRx,
         uint16_t                CANdevRxIdx);
+
+
+#if ((CO_CONFIG_PDO) & CO_CONFIG_FLAG_CALLBACK_PRE) || defined CO_DOXYGEN
+/**
+ * Initialize RPDO callback function.
+ *
+ * Function initializes optional callback function, which should immediately
+ * start processing of CO_RPDO_process() function.
+ * Callback is called after RPDO message is received from the CAN bus.
+ *
+ * @param RPDO This object.
+ * @param object Pointer to object, which will be passed to pFunctSignalPre(). Can be NULL
+ * @param pFunctSignalPre Pointer to the callback function. Not called if NULL.
+ */
+void CO_RPDO_initCallbackPre(
+        CO_RPDO_t              *RPDO,
+        void                   *object,
+        void                  (*pFunctSignalPre)(void *object));
+#endif
 
 
 /**

--- a/301/CO_SYNC.h
+++ b/301/CO_SYNC.h
@@ -96,6 +96,12 @@ typedef struct{
     uint32_t            timer;
     /** Set to nonzero value, if SYNC with wrong data length is received from CAN */
     uint16_t            receiveError;
+#if ((CO_CONFIG_SYNC) & CO_CONFIG_FLAG_CALLBACK_PRE) || defined CO_DOXYGEN
+    /** From CO_SYNC_initCallbackPre() or NULL */
+    void              (*pFunctSignalPre)(void *object);
+    /** From CO_SYNC_initCallbackPre() or NULL */
+    void               *functSignalObjectPre;
+#endif
     CO_CANmodule_t     *CANdevRx;       /**< From CO_SYNC_init() */
     uint16_t            CANdevRxIdx;    /**< From CO_SYNC_init() */
     CO_CANmodule_t     *CANdevTx;       /**< From CO_SYNC_init() */
@@ -135,6 +141,25 @@ CO_ReturnError_t CO_SYNC_init(
         uint16_t                CANdevRxIdx,
         CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx);
+
+
+#if ((CO_CONFIG_SYNC) & CO_CONFIG_FLAG_CALLBACK_PRE) || defined CO_DOXYGEN
+/**
+ * Initialize SYNC callback function.
+ *
+ * Function initializes optional callback function, which should immediately
+ * start processing of CO_SYNC_process() function.
+ * Callback is called after SYNC message is received from the CAN bus.
+ *
+ * @param SYNC This object.
+ * @param object Pointer to object, which will be passed to pFunctSignalPre(). Can be NULL
+ * @param pFunctSignalPre Pointer to the callback function. Not called if NULL.
+ */
+void CO_SYNC_initCallbackPre(
+        CO_SYNC_t              *SYNC,
+        void                   *object,
+        void                  (*pFunctSignalPre)(void *object));
+#endif
 
 
 /**

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -193,12 +193,15 @@ extern "C" {
  * Configuration of PDO
  *
  * Possible flags, can be ORed:
+ * - #CO_CONFIG_FLAG_CALLBACK_PRE - Enable custom callback after preprocessing
+ *   received RPDO CAN message.
+ *   Callback is configured by CO_RPDO_initCallbackPre().
  * - #CO_CONFIG_FLAG_TIMERNEXT - Enable calculation of timerNext_us variable
  *   inside CO_TPDO_process().
  * - CO_CONFIG_PDO_SYNC_ENABLE - Enable SYNC object inside PDO objects.
  */
 #ifdef CO_DOXYGEN
-#define CO_CONFIG_PDO (CO_CONFIG_FLAG_TIMERNEXT | CO_CONFIG_PDO_SYNC_ENABLE)
+#define CO_CONFIG_PDO (CO_CONFIG_FLAG_CALLBACK_PRE | CO_CONFIG_FLAG_TIMERNEXT | CO_CONFIG_PDO_SYNC_ENABLE)
 #endif
 #define CO_CONFIG_PDO_SYNC_ENABLE 0x01
 

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -210,11 +210,14 @@ extern "C" {
  * Configuration of SYNC
  *
  * Possible flags, can be ORed:
+ * - #CO_CONFIG_FLAG_CALLBACK_PRE - Enable custom callback after preprocessing
+ *   received SYNC CAN message.
+ *   Callback is configured by CO_SYNC_initCallbackPre().
  * - #CO_CONFIG_FLAG_TIMERNEXT - Enable calculation of timerNext_us variable
  *   inside CO_SYNC_process().
  */
 #ifdef CO_DOXYGEN
-#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_TIMERNEXT)
+#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_CALLBACK_PRE | CO_CONFIG_FLAG_TIMERNEXT)
 #endif
 
 

--- a/example/CO_driver_target.h
+++ b/example/CO_driver_target.h
@@ -78,7 +78,8 @@ extern "C" {
 #endif
 
 #ifndef CO_CONFIG_PDO
-#define CO_CONFIG_PDO (CO_CONFIG_FLAG_TIMERNEXT | \
+#define CO_CONFIG_PDO (CO_CONFIG_FLAG_CALLBACK_PRE | \
+                       CO_CONFIG_FLAG_TIMERNEXT | \
                        CO_CONFIG_PDO_SYNC_ENABLE)
 #endif
 

--- a/example/CO_driver_target.h
+++ b/example/CO_driver_target.h
@@ -84,7 +84,8 @@ extern "C" {
 #endif
 
 #ifndef CO_CONFIG_SYNC
-#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_TIMERNEXT)
+#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_CALLBACK_PRE | \
+                        CO_CONFIG_FLAG_TIMERNEXT)
 #endif
 
 #ifndef CO_CONFIG_SDO_CLI

--- a/socketCAN/CO_driver_target.h
+++ b/socketCAN/CO_driver_target.h
@@ -84,7 +84,8 @@ extern "C" {
 #endif
 
 #ifndef CO_CONFIG_PDO
-#define CO_CONFIG_PDO (CO_CONFIG_FLAG_TIMERNEXT | \
+#define CO_CONFIG_PDO (CO_CONFIG_FLAG_CALLBACK_PRE | \
+                       CO_CONFIG_FLAG_TIMERNEXT | \
                        CO_CONFIG_PDO_SYNC_ENABLE)
 #endif
 

--- a/socketCAN/CO_driver_target.h
+++ b/socketCAN/CO_driver_target.h
@@ -90,7 +90,8 @@ extern "C" {
 #endif
 
 #ifndef CO_CONFIG_SYNC
-#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_TIMERNEXT)
+#define CO_CONFIG_SYNC (CO_CONFIG_FLAG_CALLBACK_PRE | \
+                        CO_CONFIG_FLAG_TIMERNEXT)
 #endif
 
 #ifndef CO_CONFIG_SDO_CLI


### PR DESCRIPTION
Add CO_RPDO_initCallbackPre() and CO_SYNC_initCallbackPre(), which are functionally identical to functions for SDO, NMT, HB and so on. With the addition of these two new functions, a callback invoked after reception of SYNC or RPDO can immediately wake the thread that processes these messages. Moreover - it is now much easier to handle CANopenNode in _one_ thread (instead of two - one for CO_process() and another one for periodic processing of SYNC, RPDO and TPDO). With these callbacks everything can be easily and efficiently handled in a single thread. Such change will drastically reduce RAM consumption (1 thread instead of 2) and also OS overhead (less context switches), at zero cost - due to callbacks the default value of timerNext_us can be extremely big (say UINT32_MAX), but the latency will be nearly zero, there will also be nearaly zero useless runs of this thread.