### PR TITLE
Fix pointer bug in CO_OD_getFlagsPointer()

### DIFF
--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -451,13 +451,14 @@ void* CO_OD_getDataPointer(CO_SDO_t *SDO, uint16_t entryNo, uint8_t subIndex){
 
 /******************************************************************************/
 uint8_t* CO_OD_getFlagsPointer(CO_SDO_t *SDO, uint16_t entryNo, uint8_t subIndex){
-    CO_OD_extension_t* ext;
-
-    if((entryNo == 0xFFFFU) || (SDO->ODExtensions == 0)){
-        return 0;
+    if(entryNo == 0xFFFF || SDO->ODExtensions == NULL){
+        return NULL;
     }
 
-    ext = &SDO->ODExtensions[entryNo];
+    CO_OD_extension_t* ext = &SDO->ODExtensions[entryNo];
+    if (ext->flags == NULL){
+        return NULL;
+    }
 
     return &ext->flags[subIndex];
 }


### PR DESCRIPTION
Function did not check whether the object had any flags assigned. It
makes no difference for objects with no subindexes, because then the
function will return NULL anyway. But is subIndex argument is not zero,
then the function calculates addresses of flags as offsets from NULL.
For example, for an object with no flags assigned, when subIndex == 5,
the function would return 5 as the address instead of the expected NULL.