### PR TITLE
CO_SYNC_process: use enums instead of uint8_t

### DIFF
--- a/301/CO_SYNC.h
+++ b/301/CO_SYNC.h
@@ -109,6 +109,11 @@ typedef struct{
     uint16_t            CANdevTxIdx;    /**< From CO_SYNC_init() */
 }CO_SYNC_t;
 
+typedef enum {
+    CO_SYNC_NONE            = 0, /**< SYNC not received */
+    CO_SYNC_RECEIVED        = 1, /**< SYNC received */
+    CO_SYNC_OUTSIDE_WINDOW  = 2, /**< SYNC received outside SYNC window */
+}CO_SYNC_status_t;
 
 /**
  * Initialize SYNC object.
@@ -173,11 +178,9 @@ void CO_SYNC_initCallbackPre(
  * Object dictionary (index 0x1007).
  * @param [out] timerNext_us info to OS - see CO_process_SYNC_PDO().
  *
- * @return 0: No special meaning.
- * @return 1: New SYNC message recently received or was just transmitted.
- * @return 2: SYNC time was just passed out of window.
+ * @return #CO_SYNC_status_t: CO_SYNC_NONE, CO_SYNC_RECEIVED or CO_SYNC_OUTSIDE_WINDOW.
  */
-uint8_t CO_SYNC_process(
+CO_SYNC_status_t CO_SYNC_process(
         CO_SYNC_t              *SYNC,
         uint32_t                timeDifference_us,
         uint32_t                ObjDict_synchronousWindowLength,

--- a/CANopen.c
+++ b/CANopen.c
@@ -826,18 +826,24 @@ bool_t CO_process_SYNC(CO_t *co,
                        uint32_t timeDifference_us,
                        uint32_t *timerNext_us)
 {
-    bool_t syncWas = false;
-    uint8_t sync_process = CO_SYNC_process(co->SYNC,
-                                           timeDifference_us,
-                                           OD_synchronousWindowLength,
-                                           timerNext_us);
+    bool_t syncWas;
+    CO_SYNC_status_t sync_process;
+
+    sync_process = CO_SYNC_process(co->SYNC,
+                                   timeDifference_us,
+                                   OD_synchronousWindowLength,
+                                   timerNext_us);
 
     switch (sync_process) {
-    case 1: // immediately after the SYNC message
+    case CO_SYNC_NONE:
+        syncWas = false;
+        break;
+    case CO_SYNC_RECEIVED:
         syncWas = true;
         break;
-    case 2: // outside SYNC window
+    case CO_SYNC_OUTSIDE_WINDOW:
         CO_CANclearPendingSyncPDOs(co->CANmodule[0]);
+        syncWas = false;
         break;
     }
 


### PR DESCRIPTION
Replace hard-coded values with enums and explicit manage all enumeration
values in CO_process_SYNC() to avoid warnings like this:

CANopen.c:837:5: warning: enumeration value ‘CO_SYNC_NONE’ not handled in switch [-Wswitch]
  837 |     switch (sync_process) {
      |     ^~~~~~