### PR TITLE
Fix fifo include

### DIFF
--- a/301/CO_SDOclient.h
+++ b/301/CO_SDOclient.h
@@ -32,9 +32,7 @@
 #if ((CO_CONFIG_SDO_CLI) & CO_CONFIG_SDO_CLI_LOCAL) || defined CO_DOXYGEN
 #include "301/CO_SDOserver.h"
 #endif
-#if ((CO_CONFIG_SDO_CLI) & CO_CONFIG_SDO_CLI_SEGMENTED) || defined CO_DOXYGEN
 #include "301/CO_fifo.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -237,8 +237,8 @@ extern "C" {
  * - #CO_CONFIG_FLAG_TIMERNEXT - Enable calculation of timerNext_us variable
  *   inside CO_SDOclientDownloadInitiate(), CO_SDOclientDownload(),
  *   CO_SDOclientUploadInitiate(), CO_SDOclientUpload().
- * - CO_CONFIG_SDO_CLI_SEGMENTED - Enable SDO server segmented transfer.
- * - CO_CONFIG_SDO_CLI_BLOCK - Enable SDO server block transfer. If set, then
+ * - CO_CONFIG_SDO_CLI_SEGMENTED - Enable SDO client segmented transfer.
+ * - CO_CONFIG_SDO_CLI_BLOCK - Enable SDO client block transfer. If set, then
  *   CO_CONFIG_SDO_CLI_SEGMENTED must also be set.
  * - CO_CONFIG_SDO_CLI_LOCAL - Enable local transfer, if Node-ID of the SDO
  *   server is the same as node-ID of the SDO client. (SDO client is the same


### PR DESCRIPTION
Include `CO_fifo.h` in `CO_SDOclient.h` in all cases

Struct `CO_SDOclient_t` has `CO_fifo_t` member no matter what configuration
is set, so the header is always required. Without this change the build
fails when `CO_CONFIG_SDO_CLI_SEGMENTED` is not enabled.