### PR TITLE
GCC 10: Fix dereference of NULL warning

### DIFF
--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -511,7 +511,7 @@ uint32_t CO_SDO_readOD(CO_SDO_t *SDO, uint16_t SDOBufferSize){
     uint8_t *SDObuffer = SDO->ODF_arg.data;
     uint8_t *ODdata = (uint8_t*)SDO->ODF_arg.ODdataStorage;
     uint16_t length = SDO->ODF_arg.dataLength;
-    CO_OD_extension_t *ext = 0;
+    CO_OD_extension_t *ext = NULL;
 
     /* is object readable? */
     if((SDO->ODF_arg.attribute & CO_ODA_READABLE) == 0)
@@ -530,7 +530,7 @@ uint32_t CO_SDO_readOD(CO_SDO_t *SDO, uint16_t SDOBufferSize){
     }
     /* if domain, Object dictionary function MUST exist */
     else{
-        if(ext->pODFunc == NULL){
+        if(ext && ext->pODFunc == NULL){
             CO_UNLOCK_OD();
             return CO_SDO_AB_DEVICE_INCOMPAT;     /* general internal incompatibility in the device */
         }
@@ -538,7 +538,7 @@ uint32_t CO_SDO_readOD(CO_SDO_t *SDO, uint16_t SDOBufferSize){
 
     /* call Object dictionary function if registered */
     SDO->ODF_arg.reading = true;
-    if(ext->pODFunc != NULL){
+    if(ext && ext->pODFunc != NULL){
         uint32_t abortCode = ext->pODFunc(&SDO->ODF_arg);
         if(abortCode != 0U){
             CO_UNLOCK_OD();


### PR DESCRIPTION
GCC 10 static analyzer (`-fanalyzer`) warn about possible dereference of NULL ‘ext’ on 'ext->pODFunc'.

This patch adds a guard on 'ext' to fix the issue.