### PR TITLE
Handle dynamic changes of additional SDO servers parameters

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -526,34 +526,16 @@ CO_ReturnError_t CO_CANopenInit(
         return CO_ERROR_PARAMETERS;
     }
 
-    for (i=0; i<CO_NO_SDO_SERVER; i++)
-    {
-        uint32_t COB_IDClientToServer;
-        uint32_t COB_IDServerToClient;
-        if(i==0){
-            /*Default SDO server must be located at first index*/
-            COB_IDClientToServer = CO_CAN_ID_RSDO + nodeId;
-            COB_IDServerToClient = CO_CAN_ID_TSDO + nodeId;
-        }else{
-            COB_IDClientToServer = OD_SDOServerParameter[i].COB_IDClientToServer;
-            COB_IDServerToClient = OD_SDOServerParameter[i].COB_IDServerToClient;
-        }
-
-        err = CO_SDO_init(
-                CO->SDO[i],
-                COB_IDClientToServer,
-                COB_IDServerToClient,
-                OD_H1200_SDO_SERVER_PARAM+i,
-                i==0 ? 0 : CO->SDO[0],
-               &CO_OD[0],
-                CO_OD_NoOfElements,
-                CO_SDO_ODExtensions,
-                nodeId,
-                CO->CANmodule[0],
-                CO_RXCAN_SDO_SRV+i,
-                CO->CANmodule[0],
-                CO_TXCAN_SDO_SRV+i);
-    }
+    err = CO_SDO_init(
+            CO->SDO,
+           &CO_OD[0],
+            CO_OD_NoOfElements,
+            CO_SDO_ODExtensions,
+            nodeId,
+            CO->CANmodule[0],
+            CO_RXCAN_SDO_SRV,
+            CO->CANmodule[0],
+            CO_TXCAN_SDO_SRV);
 
     if(err){return err;}
 

--- a/stack/CO_SDO.h
+++ b/stack/CO_SDO.h
@@ -651,7 +651,13 @@ typedef struct{
     /** From CO_SDO_initCallback() or NULL */
     void              (*pFunctSignal)(void);
     /** From CO_SDO_init() */
+    CO_CANmodule_t     *CANdevRx;
+    /** From CO_SDO_init() */
+    uint16_t            CANdevRxIdx;
+    /** From CO_SDO_init() */
     CO_CANmodule_t     *CANdevTx;
+    /** From CO_SDO_init() */
+    uint16_t            CANdevTxIdx;
     /** CAN transmit buffer inside CANdev for CAN tx message */
     CO_CANtx_t         *CANtxBuff;
 }CO_SDO_t;
@@ -757,36 +763,25 @@ void CO_memcpySwap8(void* dest, const void* src);
 
 
 /**
- * Initialize SDO object.
+ * Initialize SDO objects.
  *
  * Function must be called in the communication reset section.
  *
- * @param SDO This object will be initialized.
- * @param COB_IDClientToServer COB ID for client to server for this SDO object.
- * @param COB_IDServerToClient COB ID for server to client for this SDO object.
- * @param ObjDictIndex_SDOServerParameter Index in Object dictionary.
- * @param parentSDO Pointer to SDO object, which contains object dictionary and
- * its extension. For first (default) SDO object this argument must be NULL.
- * If this argument is specified, then OD, ODSize and ODExtensions arguments
- * are ignored.
+ * @param SDO Pointer to array of SDO objects that will be initialized.
  * @param OD Pointer to @ref CO_SDO_objectDictionary array defined externally.
  * @param ODSize Size of the above array.
  * @param ODExtensions Pointer to the externally defined array of the same size
  * as ODSize.
  * @param nodeId CANopen Node ID of this device.
  * @param CANdevRx CAN device for SDO server reception.
- * @param CANdevRxIdx Index of receive buffer in the above CAN device.
+ * @param CANdevRxIdx Index of default SDO receive buffer in the above CAN device.
  * @param CANdevTx CAN device for SDO server transmission.
- * @param CANdevTxIdx Index of transmit buffer in the above CAN device.
+ * @param CANdevTxIdx Index of default SDO transmit buffer in the above CAN device.
  *
  * @return #CO_ReturnError_t: CO_ERROR_NO or CO_ERROR_ILLEGAL_ARGUMENT.
  */
 CO_ReturnError_t CO_SDO_init(
-        CO_SDO_t               *SDO,
-        uint32_t                COB_IDClientToServer,
-        uint32_t                COB_IDServerToClient,
-        uint16_t                ObjDictIndex_SDOServerParameter,
-        CO_SDO_t               *parentSDO,
+        CO_SDO_t               *SDO[],
         const CO_OD_entry_t     OD[],
         uint16_t                ODSize,
         CO_OD_extension_t       ODExtensions[],


### PR DESCRIPTION
I've tested it on hardware with one and then two additional servers (that is 3 including default one).
It works fine, I can config and reset servers from other SDO servers, and even can turn server from itself (it just stops working on writing COB-ID with invalid flag).

But let's discuss this a little before merging.

A make two separate commits.
First one changes CO_CANrxBufferInit to return pointer to receive buffer as I mentioned #192.
I encountered that only PDO checks CO_CANrxBufferInit result on error. Probably we should extend this commit as something separated and add checking to other places where CO_CANrxBufferInit is used?

Second commit related to dynamic changes of additional SDO servers parameters.
CO_SDO_ODF_12xx in CANopen reveal some internal SDO logic, but I think it is only suitable place, because CO_SDO related only for single SDO server and doesn't now anything about others.
Is CO_SDO_AB_DATA_OD the appropriate error to return if something wrong with index? Or CO_SDO_AB_NO_RESOURCE maybe suits better?

Also please review style and instructions-comments. Probably you may want to correct and extend them, and also maybe add feature explanations/instructions in readme, please fell totally free to do this.