### PR TITLE
remove the need to specify the number OD entries

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -33,7 +33,18 @@
 /* Global variables ***********************************************************/
 /* #define CO_USE_GLOBALS */    /* If defined, global variables will be used
                                    instead of dynamically allocated. */
-extern const CO_OD_entry_t CO_OD[CO_OD_NoOfElements];   /* Object Dictionary */
+
+#ifdef CO_USE_STATIC_ALLOCATION
+    /* When CO_USE_STATIC_ALLOCATION is defined this implies that the global
+     * (and staticly) allocated variables will be used.
+     * CO_USE_STATIC_ALLOCATION also implies that the Object Dictionary
+     * extensions array is already staticly allocated in CO_OD.c and we do
+     * not (and can not) define it in this file.
+     */
+    #define CO_USE_GLOBALS
+#endif
+
+extern const CO_OD_entry_t CO_OD[];   /* Object Dictionary */
 static CO_t COO;                    /* Pointers to CANopen objects */
 CO_t *CO = NULL;                    /* Pointer to COO */
 
@@ -362,7 +373,14 @@ void CO_delete(void *CANptr) {
     static CO_CANrx_t           COO_CANmodule_rxArray0[CO_RXCAN_NO_MSGS];
     static CO_CANtx_t           COO_CANmodule_txArray0[CO_TXCAN_NO_MSGS];
     static CO_SDO_t             COO_SDO[CO_NO_SDO_SERVER];
-    static CO_OD_extension_t    COO_SDO_ODExtensions[CO_OD_NoOfElements];
+#ifndef CO_USE_STATIC_ALLOCATION
+    /* In case of static allocation this variable MUST be defined in the object
+     * dictionary.
+     * But in case we force the use of globals we must define it ourselves and 
+     * then we require that CO_OD_NoOfElements is predefined.
+     */
+    static CO_OD_extension_t COO_SDO_ODExtensions[CO_OD_NoOfElements];
+#endif
     static CO_EM_t              COO_EM;
     static CO_EMpr_t            COO_EMpr;
     static CO_NMT_t             COO_NMT;

--- a/example/CO_OD.c
+++ b/example/CO_OD.c
@@ -34,7 +34,6 @@
 #include "CO_OD.h"
 #include "301/CO_SDOserver.h"
 
-
 /*******************************************************************************
    DEFINITION AND INITIALIZATION OF OBJECT DICTIONARY VARIABLES
 *******************************************************************************/
@@ -286,7 +285,7 @@ struct sCO_OD_EEPROM CO_OD_EEPROM = {
 /*******************************************************************************
    OBJECT DICTIONARY
 *******************************************************************************/
-const CO_OD_entry_t CO_OD[CO_OD_NoOfElements] = {
+const CO_OD_entry_t CO_OD[] = {
 {0x1000, 0x00, 0x85,  4, (void*)&CO_OD_ROM.deviceType},
 {0x1001, 0x00, 0x36,  1, (void*)&CO_OD_RAM.errorRegister},
 {0x1002, 0x00, 0xB6,  4, (void*)&CO_OD_RAM.manufacturerStatusRegister},
@@ -345,4 +344,11 @@ const CO_OD_entry_t CO_OD[CO_OD_NoOfElements] = {
 {0x6401, 0x0C, 0xB6,  2, (void*)&CO_OD_RAM.readAnalogueInput16Bit[0]},
 {0x6411, 0x08, 0xBE,  2, (void*)&CO_OD_RAM.writeAnalogueOutput16Bit[0]},
 };
+
+#define OD_NrOfEntries (sizeof(CO_OD)/sizeof(CO_OD[0]))
+const uint16_t CO_OD_NoOfElements = OD_NrOfEntries;
+
+#ifdef CO_USE_STATIC_ALLOCATION
+CO_OD_extension_t COO_SDO_ODExtensions[OD_NrOfEntries];
+#endif
 

--- a/example/CO_OD.h
+++ b/example/CO_OD.h
@@ -33,6 +33,21 @@
 #ifndef CO_OD_H
 #define CO_OD_H
 
+/* If CO_USE_STATIC_ALLOCATION is defined, either on the compiler command line
+ * or forced here, you are requesting CANopenNode to NOT use dynamicly allocated
+ * memory for its data, but to use staticly allocated global variables.
+ * (It implies defining CO_USE_GLOBALS in CANopen.c)
+ * If defined it is required to declare the ODExtensions array in this file.
+ *
+ * In case you only define CO_USE_GLOBALS, make sure CO_OD_NoOfElements is defined
+ * here as a constant number macro. The CO_USE_STATIC_ALLOCATION was introduced
+ * to remove the need to specify the specific number of elements in the OD here.
+ */
+//#define CO_USE_STATIC_ALLOCATION
+
+#ifdef CO_USE_STATIC_ALLOCATION
+#include "301/CO_SDOserver.h"
+#endif
 
 /*******************************************************************************
    CANopen DATA DYPES
@@ -101,8 +116,10 @@
 /*******************************************************************************
    OBJECT DICTIONARY
 *******************************************************************************/
-   #define CO_OD_NoOfElements             57
-
+extern const uint16_t CO_OD_NoOfElements;
+#ifdef CO_USE_STATIC_ALLOCATION
+    extern CO_OD_extension_t COO_SDO_ODExtensions[];
+#endif
 
 /*******************************************************************************
    TYPE DEFINITIONS FOR RECORDS


### PR DESCRIPTION
The number of entries in the OD was specified in CO_OD.h. This is fine as long
as the CO_OD.h and CO_OD.c files are generated automatically, but is very error
prone in cases where these files are maintained manually.

Here we remove the need to specify that count up front, while still staying
compatible with existing code.