### PR TITLE
Change array of pointers to a pointer + size

### DIFF
--- a/301/CO_SDOserver.h
+++ b/301/CO_SDOserver.h
@@ -422,16 +422,16 @@ typedef enum{
  * can also be used to access the OD by index like this.
  *
  * \code{.c}
- * index = CO_OD_find(CO->SDO[0], OD_H1001_ERR_REG);
+ * index = CO_OD_find(&CO->SDO[0], OD_H1001_ERR_REG);
  * if (index == 0xffff) {
  *     return;
  * }
- * length = CO_OD_getLength(CO->SDO[0], index, 1);
+ * length = CO_OD_getLength(&CO->SDO[0], index, 1);
  * if (length != sizeof(new_data)) {
  *    return;
  * }
  *
- * p = CO_OD_getDataPointer(CO->SDO[0], index, 1);
+ * p = CO_OD_getDataPointer(&CO->SDO[0], index, 1);
  * if (p == NULL) {
  *     return;
  * }

--- a/CANopen.c
+++ b/CANopen.c
@@ -280,16 +280,16 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
 
 #if CO_NO_TRACE > 0
     /* Trace */
-    for (i = 0; i < CO_NO_TRACE; i++) {
-        CO->trace[i] = (CO_trace_t *)calloc(1, sizeof(CO_trace_t));
-        if (CO->trace[i] == NULL) errCnt++;
+    CO->trace = calloc(CO_NO_TRACE, sizeof(CO_trace_t));
+    if (CO->trace == NULL) {
+        errCnt++;
+    } else {
+        CO->traceCount = CO_NO_TRACE;
     }
-    CO_memoryUsed += sizeof(CO_trace_t) * CO_NO_TRACE;
-    for (i = 0; i < CO_NO_TRACE; i++) {
-        CO_traceTimeBuffers[i] =
-            (uint32_t *)calloc(OD_traceConfig[i].size, sizeof(uint32_t));
-        CO_traceValueBuffers[i] =
-            (int32_t *)calloc(OD_traceConfig[i].size, sizeof(int32_t));
+    CO_memoryUsed += sizeof(CO_trace_t) * CO->traceCount;
+    for (i = 0; i < CO->traceCount; i++) {
+        CO_traceTimeBuffers[i] = calloc(OD_traceConfig[i].size, sizeof(uint32_t));
+        CO_traceValueBuffers[i] = calloc(OD_traceConfig[i].size, sizeof(int32_t));
         if (CO_traceTimeBuffers[i] != NULL &&
             CO_traceValueBuffers[i] != NULL) {
             CO_traceBufferSize[i] = OD_traceConfig[i].size;
@@ -323,8 +323,8 @@ void CO_delete(void *CANptr) {
 
 #if CO_NO_TRACE > 0
     /* Trace */
-    for (i = 0; i < CO_NO_TRACE; i++) {
-        free(CO->trace[i]);
+    free(CO->trace);
+    for (i = 0; i < CO->traceCount; i++) {
         free(CO_traceTimeBuffers[i]);
         free(CO_traceValueBuffers[i]);
     }
@@ -546,8 +546,9 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
 
 #if CO_NO_TRACE > 0
     /* Trace */
-    for (i = 0; i < CO_NO_TRACE; i++) {
-        CO->trace[i] = &COO_trace[i];
+    CO->trace = COO_trace;
+    CO->traceCount = sizeof(COO_trace) / sizeof(*COO_trace);
+    for (i = 0; i < CO->traceCount; i++) {
         CO_traceTimeBuffers[i] = &COO_traceTimeBuffers[i][0];
         CO_traceValueBuffers[i] = &COO_traceValueBuffers[i][0];
         CO_traceBufferSize[i] = CO_TRACE_BUFFER_SIZE_FIXED;
@@ -929,8 +930,8 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 
 #if CO_NO_TRACE > 0
     /* Trace */
-    for (i = 0; i < CO_NO_TRACE; i++) {
-        CO_trace_init(CO->trace[i],
+    for (i = 0; i < CO->traceCount; i++) {
+        CO_trace_init(&CO->trace[i],
                       &CO->SDO[0],
                       OD_traceConfig[i].axisNo,
                       CO_traceTimeBuffers[i],

--- a/CANopen.c
+++ b/CANopen.c
@@ -141,8 +141,8 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
     CO = &COO;
 
     /* CANmodule */
-    CO->CANmodule[0] = (CO_CANmodule_t *)calloc(1, sizeof(CO_CANmodule_t));
-    if (CO->CANmodule[0] == NULL) errCnt++;
+    CO->CANmodule = calloc(1, sizeof(CO_CANmodule_t));
+    if (CO->CANmodule == NULL) errCnt++;
     CO_CANmodule_rxArray0 =
         (CO_CANrx_t *)calloc(CO_RXCAN_NO_MSGS, sizeof(CO_CANrx_t));
     if (CO_CANmodule_rxArray0 == NULL) errCnt++;
@@ -310,7 +310,7 @@ void CO_delete(void *CANptr) {
         return;
     }
 
-    CO_CANmodule_disable(CO->CANmodule[0]);
+    CO_CANmodule_disable(CO->CANmodule);
 
 #if CO_NO_TRACE > 0
     /* Trace */
@@ -396,7 +396,7 @@ void CO_delete(void *CANptr) {
     /* CANmodule */
     free(CO_CANmodule_txArray0);
     free(CO_CANmodule_rxArray0);
-    free(CO->CANmodule[0]);
+    free(CO->CANmodule);
 
     /* globals */
     CO = NULL;
@@ -467,7 +467,7 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
     CO = &COO;
 
     /* CANmodule */
-    CO->CANmodule[0] = &COO_CANmodule;
+    CO->CANmodule = &COO_CANmodule;
     CO_CANmodule_rxArray0 = &COO_CANmodule_rxArray0[0];
     CO_CANmodule_txArray0 = &COO_CANmodule_txArray0[0];
 
@@ -580,11 +580,11 @@ CO_ReturnError_t CO_CANinit(void *CANptr,
 {
     CO_ReturnError_t err;
 
-    CO->CANmodule[0]->CANnormal = false;
+    CO->CANmodule->CANnormal = false;
     CO_CANsetConfigurationMode(CANptr);
 
     /* CANmodule */
-    err = CO_CANmodule_init(CO->CANmodule[0],
+    err = CO_CANmodule_init(CO->CANmodule,
                             CANptr,
                             CO_CANmodule_rxArray0,
                             CO_RXCAN_NO_MSGS,
@@ -614,10 +614,10 @@ CO_ReturnError_t CO_LSSinit(uint8_t *nodeId,
                            lssAddress,
                            bitRate,
                            nodeId,
-                           CO->CANmodule[0],
+                           CO->CANmodule,
                            CO_RXCAN_LSS_SLV,
                            CO_CAN_ID_LSS_SRV,
-                           CO->CANmodule[0],
+                           CO->CANmodule,
                            CO_TXCAN_LSS_SLV,
                            CO_CAN_ID_LSS_CLI);
 
@@ -700,9 +700,9 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                           CO_SDO_ODExtensions,
                           nodeId,
                           1000,
-                          CO->CANmodule[0],
+                          CO->CANmodule,
                           CO_RXCAN_SDO_SRV + i,
-                          CO->CANmodule[0],
+                          CO->CANmodule,
                           CO_TXCAN_SDO_SRV + i);
 
         if (err) return err;
@@ -718,9 +718,9 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                      &OD_errorRegister,
                      &OD_preDefinedErrorField[0],
                      ODL_preDefinedErrorField_arrayLength,
-                     CO->CANmodule[0],
+                     CO->CANmodule,
                      CO_RXCAN_EMERG,
-                     CO->CANmodule[0],
+                     CO->CANmodule,
                      CO_TXCAN_EMERG,
                      (uint16_t)CO_CAN_ID_EMERGENCY + nodeId);
 
@@ -731,13 +731,13 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                       CO->emPr,
                       nodeId,
                       500,
-                      CO->CANmodule[0],
+                      CO->CANmodule,
                       CO_RXCAN_NMT,
                       CO_CAN_ID_NMT_SERVICE,
-                      CO->CANmodule[0],
+                      CO->CANmodule,
                       CO_TXCAN_NMT,
                       CO_CAN_ID_NMT_SERVICE,
-                      CO->CANmodule[0],
+                      CO->CANmodule,
                       CO_TXCAN_HB,
                       CO_CAN_ID_HEARTBEAT + nodeId);
 
@@ -752,9 +752,9 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                        OD_COB_ID_SYNCMessage,
                        OD_communicationCyclePeriod,
                        OD_synchronousCounterOverflowValue,
-                       CO->CANmodule[0],
+                       CO->CANmodule,
                        CO_RXCAN_SYNC,
-                       CO->CANmodule[0],
+                       CO->CANmodule,
                        CO_TXCAN_SYNC);
 
     if (err) return err;
@@ -768,9 +768,9 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                        &CO->NMT->operatingState,
                        OD_COB_ID_TIME,
                        0,
-                       CO->CANmodule[0],
+                       CO->CANmodule,
                        CO_RXCAN_TIME,
-                       CO->CANmodule[0],
+                       CO->CANmodule,
                        CO_TXCAN_TIME);
 
     if (err) return err;
@@ -780,10 +780,10 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
     /* GFC */
     CO_GFC_init(CO->GFC,
                 &OD_globalFailSafeCommandParameter,
-                CO->CANmodule[0],
+                CO->CANmodule,
                 CO_RXCAN_GFC,
                 CO_CAN_ID_GFC,
-                CO->CANmodule[0],
+                CO->CANmodule,
                 CO_TXCAN_GFC,
                 CO_CAN_ID_GFC);
 #endif
@@ -799,7 +799,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
     if (err) return err;
 
     for (i = 0; i < CO_NO_SRDO; i++) {
-        CO_CANmodule_t *CANdev = CO->CANmodule[0];
+        CO_CANmodule_t *CANdev = CO->CANmodule;
         uint16_t CANdevRxIdx = CO_RXCAN_SRDO + 2*i;
         uint16_t CANdevTxIdx = CO_TXCAN_SRDO + 2*i;
 
@@ -826,7 +826,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 
     /* RPDO */
     for (i = 0; i < CO_NO_RPDO; i++) {
-        CO_CANmodule_t *CANdevRx = CO->CANmodule[0];
+        CO_CANmodule_t *CANdevRx = CO->CANmodule;
         uint16_t CANdevRxIdx = CO_RXCAN_RPDO + i;
 
         err = CO_RPDO_init(CO->RPDO[i],
@@ -865,7 +865,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                            (CO_TPDOMapPar_t *)&OD_TPDOMappingParameter[i],
                            OD_H1800_TXPDO_1_PARAM + i,
                            OD_H1A00_TXPDO_1_MAPPING + i,
-                           CO->CANmodule[0],
+                           CO->CANmodule,
                            CO_TXCAN_TPDO + i);
 
         if (err) return err;
@@ -878,7 +878,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                              &OD_consumerHeartbeatTime[0],
                              CO_HBcons_monitoredNodes,
                              CO_NO_HB_CONS,
-                             CO->CANmodule[0],
+                             CO->CANmodule,
                              CO_RXCAN_CONS_HB);
 
     if (err) return err;
@@ -889,9 +889,9 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
         err = CO_SDOclient_init(CO->SDOclient[i],
                                 (void *)CO->SDO[0],
                                 (CO_SDOclientPar_t *)&OD_SDOClientParameter[i],
-                                CO->CANmodule[0],
+                                CO->CANmodule,
                                 CO_RXCAN_SDO_CLI + i,
-                                CO->CANmodule[0],
+                                CO->CANmodule,
                                 CO_TXCAN_SDO_CLI + i);
 
         if (err) return err;
@@ -902,10 +902,10 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
     /* LSSmaster */
     err = CO_LSSmaster_init(CO->LSSmaster,
                             CO_LSSmaster_DEFAULT_TIMEOUT,
-                            CO->CANmodule[0],
+                            CO->CANmodule,
                             CO_RXCAN_LSS_MST,
                             CO_CAN_ID_LSS_CLI,
-                            CO->CANmodule[0],
+                            CO->CANmodule,
                             CO_TXCAN_LSS_MST,
                             CO_CAN_ID_LSS_SRV);
 
@@ -968,7 +968,7 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
     bool_t NMTisPreOrOperational = false;
     CO_NMT_reset_cmd_t reset = CO_RESET_NOT;
 
-    CO_CANmodule_process(CO->CANmodule[0]);
+    CO_CANmodule_process(CO->CANmodule);
 
 #if CO_NO_LSS_SLAVE == 1
     bool_t resetLSS = CO_LSSslave_process(co->LSSslave);
@@ -976,7 +976,7 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
 
 #if (CO_CONFIG_LEDS) & CO_CONFIG_LEDS_ENABLE
     bool_t unc = co->nodeIdUnconfigured;
-    uint16_t CANerrorStatus = CO->CANmodule[0]->CANerrorStatus;
+    uint16_t CANerrorStatus = CO->CANmodule->CANerrorStatus;
     CO_LEDs_process(co->LEDs,
                     timeDifference_us,
                     unc ? CO_NMT_INITIALIZING : co->NMT->operatingState,
@@ -1084,7 +1084,7 @@ bool_t CO_process_SYNC(CO_t *co,
         syncWas = true;
         break;
     case CO_SYNC_OUTSIDE_WINDOW:
-        CO_CANclearPendingSyncPDOs(co->CANmodule[0]);
+        CO_CANclearPendingSyncPDOs(co->CANmodule);
         break;
     }
 

--- a/CANopen.c
+++ b/CANopen.c
@@ -128,7 +128,6 @@ static uint32_t             CO_traceBufferSize[CO_NO_TRACE];
 /* Create objects from heap ***************************************************/
 #ifndef CO_USE_GLOBALS
 CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
-    int16_t i;
     uint16_t errCnt = 0;
     uint32_t CO_memoryUsed = 0;
 
@@ -287,7 +286,7 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
         CO->traceCount = CO_NO_TRACE;
     }
     CO_memoryUsed += sizeof(CO_trace_t) * CO->traceCount;
-    for (i = 0; i < CO->traceCount; i++) {
+    for (size_t i = 0; i < CO->traceCount; i++) {
         CO_traceTimeBuffers[i] = calloc(OD_traceConfig[i].size, sizeof(uint32_t));
         CO_traceValueBuffers[i] = calloc(OD_traceConfig[i].size, sizeof(int32_t));
         if (CO_traceTimeBuffers[i] != NULL &&
@@ -310,8 +309,6 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
 
 /******************************************************************************/
 void CO_delete(void *CANptr) {
-    int16_t i;
-
     CO_CANsetConfigurationMode(CANptr);
 
     /* If CANopen isn't initialized, return. */
@@ -324,7 +321,7 @@ void CO_delete(void *CANptr) {
 #if CO_NO_TRACE > 0
     /* Trace */
     free(CO->trace);
-    for (i = 0; i < CO->traceCount; i++) {
+    for (size_t i = 0; i < CO->traceCount; i++) {
         free(CO_traceTimeBuffers[i]);
         free(CO_traceValueBuffers[i]);
     }
@@ -455,8 +452,6 @@ void CO_delete(void *CANptr) {
 #endif
 
 CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
-    int16_t i;
-
     /* If CANopen was initialized before, return. */
     if (CO != NULL) {
         return CO_ERROR_NO;
@@ -548,7 +543,7 @@ CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
     /* Trace */
     CO->trace = COO_trace;
     CO->traceCount = sizeof(COO_trace) / sizeof(*COO_trace);
-    for (i = 0; i < CO->traceCount; i++) {
+    for (size_t i = 0; i < CO->traceCount; i++) {
         CO_traceTimeBuffers[i] = &COO_traceTimeBuffers[i][0];
         CO_traceValueBuffers[i] = &COO_traceValueBuffers[i][0];
         CO_traceBufferSize[i] = CO_TRACE_BUFFER_SIZE_FIXED;
@@ -623,7 +618,6 @@ CO_ReturnError_t CO_LSSinit(uint8_t *nodeId,
 
 /******************************************************************************/
 CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
-    int16_t i;
     CO_ReturnError_t err;
 
     /* Verify CANopen Node-ID */
@@ -670,7 +664,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 #endif
 
     /* SDOserver */
-    for (i = 0; i < CO->sdoCount; i++) {
+    for (size_t i = 0; i < CO->sdoCount; i++) {
         uint32_t COB_IDClientToServer;
         uint32_t COB_IDServerToClient;
         if (i == 0) {
@@ -793,7 +787,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
                       OD_H13FF_SRDO_CHECKSUM);
     if (err) return err;
 
-    for (i = 0; i < CO->srdoCount; i++) {
+    for (size_t i = 0; i < CO->srdoCount; i++) {
         CO_CANmodule_t *CANdev = CO->CANmodule;
         uint16_t CANdevRxIdx = CO_RXCAN_SRDO + 2*i;
         uint16_t CANdevTxIdx = CO_TXCAN_SRDO + 2*i;
@@ -820,7 +814,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 #endif
 
     /* RPDO */
-    for (i = 0; i < CO->rpdoCount; i++) {
+    for (size_t i = 0; i < CO->rpdoCount; i++) {
         CO_CANmodule_t *CANdevRx = CO->CANmodule;
         uint16_t CANdevRxIdx = CO_RXCAN_RPDO + i;
 
@@ -845,7 +839,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
     }
 
     /* TPDO */
-    for (i = 0; i < CO->tpdoCount; i++) {
+    for (size_t i = 0; i < CO->tpdoCount; i++) {
         err = CO_TPDO_init(&CO->TPDO[i],
                            CO->em,
                            &CO->SDO[0],
@@ -880,7 +874,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 
 #if CO_NO_SDO_CLIENT != 0
     /* SDOclient */
-    for (i = 0; i < CO->sdoClientCount; i++) {
+    for (size_t i = 0; i < CO->sdoClientCount; i++) {
         err = CO_SDOclient_init(&CO->SDOclient[i],
                                 &CO->SDO[0],
                                 (CO_SDOclientPar_t *)&OD_SDOClientParameter[i],
@@ -930,7 +924,7 @@ CO_ReturnError_t CO_CANopenInit(uint8_t nodeId) {
 
 #if CO_NO_TRACE > 0
     /* Trace */
-    for (i = 0; i < CO->traceCount; i++) {
+    for (size_t i = 0; i < CO->traceCount; i++) {
         CO_trace_init(&CO->trace[i],
                       &CO->SDO[0],
                       OD_traceConfig[i].axisNo,
@@ -959,7 +953,6 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
                               uint32_t timeDifference_us,
                               uint32_t *timerNext_us)
 {
-    uint8_t i;
     bool_t NMTisPreOrOperational = false;
     CO_NMT_reset_cmd_t reset = CO_RESET_NOT;
 
@@ -1006,7 +999,7 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
         NMTisPreOrOperational = true;
 
     /* SDOserver */
-    for (i = 0; i < co->sdoCount; i++) {
+    for (size_t i = 0; i < co->sdoCount; i++) {
         CO_SDO_process(&co->SDO[i],
                        NMTisPreOrOperational,
                        timeDifference_us,
@@ -1092,15 +1085,13 @@ bool_t CO_process_SYNC(CO_t *co,
 void CO_process_RPDO(CO_t *co,
                      bool_t syncWas)
 {
-    int16_t i;
-
 #if CO_NO_LSS_SLAVE == 1
     if (co->nodeIdUnconfigured) {
         return;
     }
 #endif
 
-    for (i = 0; i < co->rpdoCount; i++) {
+    for (size_t i = 0; i < co->rpdoCount; i++) {
         CO_RPDO_process(&co->RPDO[i], syncWas);
     }
 }
@@ -1112,8 +1103,6 @@ void CO_process_TPDO(CO_t *co,
                      uint32_t timeDifference_us,
                      uint32_t *timerNext_us)
 {
-    int16_t i;
-
 #if CO_NO_LSS_SLAVE == 1
     if (co->nodeIdUnconfigured) {
         return;
@@ -1121,7 +1110,7 @@ void CO_process_TPDO(CO_t *co,
 #endif
 
     /* Verify PDO Change Of State and process PDOs */
-    for (i = 0; i < co->tpdoCount; i++) {
+    for (size_t i = 0; i < co->tpdoCount; i++) {
         if (!co->TPDO[i].sendRequest)
             co->TPDO[i].sendRequest = CO_TPDOisCOS(&co->TPDO[i]);
         CO_TPDO_process(&co->TPDO[i], syncWas, timeDifference_us, timerNext_us);
@@ -1134,7 +1123,6 @@ void CO_process_SRDO(CO_t *co,
                      uint32_t timeDifference_us,
                      uint32_t *timerNext_us)
 {
-    int16_t i;
     uint8_t firstOperational;
 
 #if CO_NO_LSS_SLAVE == 1
@@ -1146,7 +1134,7 @@ void CO_process_SRDO(CO_t *co,
     firstOperational = CO_SRDOGuard_process(co->SRDOGuard);
 
     /* Verify PDO Change Of State and process PDOs */
-    for (i = 0; i < co->srdoCount; i++) {
+    for (size_t i = 0; i < co->srdoCount; i++) {
         CO_SRDO_process(&co->SRDO[i], firstOperational, timeDifference_us, timerNext_us);
     }
 }

--- a/CANopen.h
+++ b/CANopen.h
@@ -281,7 +281,7 @@ extern "C" {
  */
 typedef struct {
     bool_t nodeIdUnconfigured;       /**< True in unconfigured LSS slave */
-    CO_CANmodule_t *CANmodule[1];    /**< CAN module objects */
+    CO_CANmodule_t *CANmodule;       /**< CAN module objects */
     CO_SDO_t *SDO[CO_NO_SDO_SERVER]; /**< SDO object */
     CO_EM_t *em;                     /**< Emergency report object */
     CO_EMpr_t *emPr;                 /**< Emergency process object */

--- a/CANopen.h
+++ b/CANopen.h
@@ -28,10 +28,6 @@
 #ifndef CANopen_H
 #define CANopen_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @defgroup CO_CANopen CANopen
  * @{
@@ -275,6 +271,10 @@ extern "C" {
     #include "extra/CO_trace.h"
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * CANopen object with pointers to all CANopenNode objects.

--- a/CANopen.h
+++ b/CANopen.h
@@ -305,7 +305,7 @@ typedef struct {
 #endif
 #if CO_NO_SRDO != 0 || defined CO_DOXYGEN
     CO_SRDOGuard_t *SRDOGuard;       /**< SRDO objects */
-    CO_SRDO_t *SRDO[CO_NO_SRDO];     /**< SRDO objects */
+    CO_SRDO_t *SRDO;                 /**< SRDO objects */
 #endif
 #if CO_NO_LSS_SLAVE == 1 || defined CO_DOXYGEN
     CO_LSSslave_t *LSSslave;         /**< LSS slave object */
@@ -324,6 +324,9 @@ typedef struct {
     uint8_t sdoCount;                /**< number of SDO server objects in \a SDO field */
 #if CO_NO_SDO_CLIENT != 0 || defined CO_DOXYGEN
     uint8_t sdoClientCount;          /**< number of SDO client objects in \a SDOclient field */
+#endif
+#if CO_NO_SRDO != 0 || defined CO_DOXYGEN
+    uint8_t srdoCount;               /**< number of SRDO objects in \a SRDO field */
 #endif
 } CO_t;
 

--- a/CANopen.h
+++ b/CANopen.h
@@ -292,7 +292,7 @@ typedef struct {
 #endif
     CO_TIME_t *TIME;                 /**< TIME object */
     CO_RPDO_t *RPDO;                 /**< RPDO objects */
-    CO_TPDO_t *TPDO[CO_NO_TPDO];     /**< TPDO objects */
+    CO_TPDO_t *TPDO;                 /**< TPDO objects */
     CO_HBconsumer_t *HBcons;         /**< Heartbeat consumer object*/
 #if CO_NO_SDO_CLIENT != 0 || defined CO_DOXYGEN
     CO_SDOclient_t *SDOclient[CO_NO_SDO_CLIENT]; /**< SDO client object */
@@ -320,6 +320,7 @@ typedef struct {
     CO_trace_t *trace[CO_NO_TRACE];  /**< Trace object for recording variables */
 #endif
     uint16_t rpdoCount;              /**< number of RPDO objects in \a RPDO field */
+    uint16_t tpdoCount;              /**< number of TPDO objects in \a TPDO field */
     uint8_t sdoCount;                /**< number of SDO server objects in \a SDO field */
 } CO_t;
 

--- a/CANopen.h
+++ b/CANopen.h
@@ -174,7 +174,7 @@
 /** Number of GFC objects, 0 or 1 (consumer(CANrx) + producer(CANtx)) */
 #define CO_NO_GFC (0 - 1)
 /** Number of SRDO objects, 0 to 64 (consumer(CANrx) + producer(CANtx)) */
-#define CO_NO_RPDO (0 - 64)
+#define CO_NO_SRDO (0 - 64)
 /** Number of RPDO objects, 1 to 512 consumers (CANrx) */
 #define CO_NO_RPDO (1 - 512)
 /** Number of TPDO objects, 1 to 512 producers (CANtx) */

--- a/CANopen.h
+++ b/CANopen.h
@@ -137,6 +137,7 @@
  * @{
  */
 
+    #include <stddef.h>
     #include <stdint.h>
     #include "301/CO_driver.h"
     #include "301/CO_SDOserver.h"
@@ -317,7 +318,8 @@ typedef struct {
     CO_GTWA_t *gtwa;                 /**< Gateway-ascii object (CiA309-3) */
 #endif
 #if CO_NO_TRACE > 0 || defined CO_DOXYGEN
-    CO_trace_t *trace[CO_NO_TRACE];  /**< Trace object for recording variables */
+    CO_trace_t *trace;               /**< Trace object for recording variables */
+    size_t traceCount;               /**< number of trace objects in \a trace field */
 #endif
     uint16_t rpdoCount;              /**< number of RPDO objects in \a RPDO field */
     uint16_t tpdoCount;              /**< number of TPDO objects in \a TPDO field */

--- a/CANopen.h
+++ b/CANopen.h
@@ -291,7 +291,7 @@ typedef struct {
     CO_SYNC_t *SYNC;                 /**< SYNC object */
 #endif
     CO_TIME_t *TIME;                 /**< TIME object */
-    CO_RPDO_t *RPDO[CO_NO_RPDO];     /**< RPDO objects */
+    CO_RPDO_t *RPDO;                 /**< RPDO objects */
     CO_TPDO_t *TPDO[CO_NO_TPDO];     /**< TPDO objects */
     CO_HBconsumer_t *HBcons;         /**< Heartbeat consumer object*/
 #if CO_NO_SDO_CLIENT != 0 || defined CO_DOXYGEN
@@ -319,6 +319,7 @@ typedef struct {
 #if CO_NO_TRACE > 0 || defined CO_DOXYGEN
     CO_trace_t *trace[CO_NO_TRACE];  /**< Trace object for recording variables */
 #endif
+    uint16_t rpdoCount;              /**< number of RPDO objects in \a RPDO field */
     uint8_t sdoCount;                /**< number of SDO server objects in \a SDO field */
 } CO_t;
 

--- a/CANopen.h
+++ b/CANopen.h
@@ -137,6 +137,7 @@
  * @{
  */
 
+    #include <stdint.h>
     #include "301/CO_driver.h"
     #include "301/CO_SDOserver.h"
     #include "301/CO_Emergency.h"
@@ -282,7 +283,7 @@ extern "C" {
 typedef struct {
     bool_t nodeIdUnconfigured;       /**< True in unconfigured LSS slave */
     CO_CANmodule_t *CANmodule;       /**< CAN module objects */
-    CO_SDO_t *SDO[CO_NO_SDO_SERVER]; /**< SDO object */
+    CO_SDO_t *SDO;                   /**< SDO server objects */
     CO_EM_t *em;                     /**< Emergency report object */
     CO_EMpr_t *emPr;                 /**< Emergency process object */
     CO_NMT_t *NMT;                   /**< NMT object */
@@ -313,11 +314,12 @@ typedef struct {
     CO_LSSmaster_t *LSSmaster;       /**< LSS master object */
 #endif
 #if ((CO_CONFIG_GTW) & CO_CONFIG_GTW_ASCII) || defined CO_DOXYGEN
-    CO_GTWA_t *gtwa;                /**< Gateway-ascii object (CiA309-3) */
+    CO_GTWA_t *gtwa;                 /**< Gateway-ascii object (CiA309-3) */
 #endif
 #if CO_NO_TRACE > 0 || defined CO_DOXYGEN
-    CO_trace_t *trace[CO_NO_TRACE]; /**< Trace object for recording variables */
+    CO_trace_t *trace[CO_NO_TRACE];  /**< Trace object for recording variables */
 #endif
+    uint8_t sdoCount;                /**< number of SDO server objects in \a SDO field */
 } CO_t;
 
 

--- a/CANopen.h
+++ b/CANopen.h
@@ -295,7 +295,7 @@ typedef struct {
     CO_TPDO_t *TPDO;                 /**< TPDO objects */
     CO_HBconsumer_t *HBcons;         /**< Heartbeat consumer object*/
 #if CO_NO_SDO_CLIENT != 0 || defined CO_DOXYGEN
-    CO_SDOclient_t *SDOclient[CO_NO_SDO_CLIENT]; /**< SDO client object */
+    CO_SDOclient_t *SDOclient;       /**< SDO client objects */
 #endif
 #if ((CO_CONFIG_LEDS) & CO_CONFIG_LEDS_ENABLE) || defined CO_DOXYGEN
     CO_LEDs_t *LEDs;                 /**< LEDs object */
@@ -322,6 +322,9 @@ typedef struct {
     uint16_t rpdoCount;              /**< number of RPDO objects in \a RPDO field */
     uint16_t tpdoCount;              /**< number of TPDO objects in \a TPDO field */
     uint8_t sdoCount;                /**< number of SDO server objects in \a SDO field */
+#if CO_NO_SDO_CLIENT != 0 || defined CO_DOXYGEN
+    uint8_t sdoClientCount;          /**< number of SDO client objects in \a SDOclient field */
+#endif
 } CO_t;
 
 

--- a/example/main_blank.c
+++ b/example/main_blank.c
@@ -119,7 +119,7 @@ int main (void){
 
 
         /* start CAN */
-        CO_CANsetNormalMode(CO->CANmodule[0]);
+        CO_CANsetNormalMode(CO->CANmodule);
 
         reset = CO_RESET_NOT;
         timer1msPrevious = CO_timer1ms;
@@ -173,7 +173,7 @@ void tmrTask_thread(void){
 
         INCREMENT_1MS(CO_timer1ms);
 
-        if(CO->CANmodule[0]->CANnormal) {
+        if(CO->CANmodule->CANnormal) {
             bool_t syncWas;
 
             /* Process Sync */

--- a/socketCAN/CO_Linux_threads.c
+++ b/socketCAN/CO_Linux_threads.c
@@ -131,7 +131,7 @@ void threadMainWait_init(bool_t CANopenConfiguredOK)
 
     /* Configure callback functions */
     CO_NMT_initCallbackPre(CO->NMT, NULL, threadMainWait_callback);
-    CO_SDO_initCallbackPre(CO->SDO[0], NULL, threadMainWait_callback);
+    CO_SDO_initCallbackPre(&CO->SDO[0], NULL, threadMainWait_callback);
     CO_EM_initCallbackPre(CO->em, NULL, threadMainWait_callback);
     CO_HBconsumer_initCallbackPre(CO->HBcons, NULL, threadMainWait_callback);
 #if CO_NO_SDO_CLIENT != 0

--- a/socketCAN/CO_Linux_threads.c
+++ b/socketCAN/CO_Linux_threads.c
@@ -554,14 +554,14 @@ uint32_t CANrx_threadTmr_process(void)
     bool_t syncWas;
     uint64_t missed = 0;
 
-    result = CO_CANrxWait(CO->CANmodule[0], threadRT.interval_fd, NULL);
+    result = CO_CANrxWait(CO->CANmodule, threadRT.interval_fd, NULL);
     if (result < 0) {
         result = read(threadRT.interval_fd, &missed, sizeof(missed));
         if (result > 0) {
         /* at least one timer interval occurred */
         CO_LOCK_OD();
 
-        if(CO->CANmodule[0]->CANnormal) {
+        if(CO->CANmodule->CANnormal) {
 
             for (i = 0; i <= missed; i++) {
 

--- a/socketCAN/CO_Linux_threads.c
+++ b/socketCAN/CO_Linux_threads.c
@@ -135,7 +135,7 @@ void threadMainWait_init(bool_t CANopenConfiguredOK)
     CO_EM_initCallbackPre(CO->em, NULL, threadMainWait_callback);
     CO_HBconsumer_initCallbackPre(CO->HBcons, NULL, threadMainWait_callback);
 #if CO_NO_SDO_CLIENT != 0
-    CO_SDOclient_initCallbackPre(CO->SDOclient[0], NULL,
+    CO_SDOclient_initCallbackPre(&CO->SDOclient[0], NULL,
                                  threadMainWait_callback);
 #endif
 #if (CO_CONFIG_TIME) & CO_CONFIG_FLAG_CALLBACK_PRE

--- a/socketCAN/CO_main_basic.c
+++ b/socketCAN/CO_main_basic.c
@@ -551,8 +551,8 @@ static void* rt_thread(void* arg) {
 #if CO_NO_TRACE > 0
         /* Monitor variables with trace objects */
         CO_time_process(&CO_time);
-        for(i=0; i<OD_traceEnable && i<CO_NO_TRACE; i++) {
-            CO_trace_process(CO->trace[i], *CO_time.epochTimeOffsetMs);
+        for(i = 0; i < OD_traceEnable && i < CO->traceCount; i++) {
+            CO_trace_process(&CO->trace[i], *CO_time.epochTimeOffsetMs);
         }
 #endif
 

--- a/socketCAN/CO_main_basic.c
+++ b/socketCAN/CO_main_basic.c
@@ -420,8 +420,8 @@ int main (int argc, char *argv[]) {
             CO_HBconsumer_initCallbackNmtChanged(CO->HBcons, NULL,
                                                  HeartbeatNmtChangedCallback);
             /* initialize OD objects 1010 and 1011 and verify errors. */
-            CO_OD_configure(CO->SDO[0], OD_H1010_STORE_PARAM_FUNC, CO_ODF_1010, (void*)&odStor, 0, 0U);
-            CO_OD_configure(CO->SDO[0], OD_H1011_REST_PARAM_FUNC, CO_ODF_1011, (void*)&odStor, 0, 0U);
+            CO_OD_configure(&CO->SDO[0], OD_H1010_STORE_PARAM_FUNC, CO_ODF_1010, (void*)&odStor, 0, 0U);
+            CO_OD_configure(&CO->SDO[0], OD_H1011_REST_PARAM_FUNC, CO_ODF_1011, (void*)&odStor, 0, 0U);
             if(odStorStatus_rom != CO_ERROR_NO) {
                 CO_errorReport(CO->em, CO_EM_NON_VOLATILE_MEMORY, CO_EMC_HARDWARE, (uint32_t)odStorStatus_rom);
             }
@@ -431,7 +431,7 @@ int main (int argc, char *argv[]) {
 
 #if CO_NO_TRACE > 0
             /* Initialize time */
-            CO_time_init(&CO_time, CO->SDO[0], &OD_time.epochTimeBaseMs, &OD_time.epochTimeOffsetMs, 0x2130);
+            CO_time_init(&CO_time, &CO->SDO[0], &OD_time.epochTimeBaseMs, &OD_time.epochTimeOffsetMs, 0x2130);
 #endif
             log_printf(LOG_INFO, DBG_CAN_OPEN_INFO, CO_activeNodeId, "communication reset");
         }

--- a/socketCAN/CO_main_basic.c
+++ b/socketCAN/CO_main_basic.c
@@ -376,7 +376,7 @@ int main (int argc, char *argv[]) {
         /* Wait rt_thread. */
         if(!firstRun) {
             CO_LOCK_OD();
-            CO->CANmodule[0]->CANnormal = false;
+            CO->CANmodule->CANnormal = false;
             CO_UNLOCK_OD();
         }
 
@@ -480,7 +480,7 @@ int main (int argc, char *argv[]) {
 
 
         /* start CAN */
-        CO_CANsetNormalMode(CO->CANmodule[0]);
+        CO_CANsetNormalMode(CO->CANmodule);
 
         reset = CO_RESET_NOT;
 


### PR DESCRIPTION
This is a first stage of an effort to making CANopenNode support multiple instances #173 . If the general direction I'm heading at with these changes is acceptable, there will be more pull requests.

The `CO_t` struct has multiple fields which are arrays of pointers, of fixed size (`CO_NO_...`). This serves no purpose, just makes the code more complex. Turn these fields into normal pointer to the first element of an array, additionally add a field which holds current size of the array assigned to the pointer. This way the global constants/defines (`CO_NO_...`, like `CO_NO_TPDO`) are used in smaller number of places (basically only in the `CO_new()`), making some of the functions (more or completely) independent from the global state.

These changes may break some user code, however the fixes are very trivial:
- replace `CO->CANmodule[0]` with `CO->CANmodule`,
- for all `..._initCallbackPre()` add `&` to the first argument, e.g. `CO->SDO[0]` ->`&CO->SDO[0]` (`CO_SDO_initCallbackPre(CO->SDO[0], NULL, threadMainWait_callback)` -> `CO_SDO_initCallbackPre(&CO->SDO[0], NULL, threadMainWait_callback)`),
- as above for `CO_trace_process()` - `CO_trace_process(CO->trace[i], *CO_time.epochTimeOffsetMs)` -> `CO_trace_process(&CO->trace[i], *CO_time.epochTimeOffsetMs)`,
- in some user loops, fixed numbers like `CO_NO_TRACE` or `CO_NO_TPDO` should be replaced with appropriate counts, like `CO->traceCount` or `CO->tpdoCount`.

Please note that the changes for SRDO and trace were _not_ compile-tested, however they should work (;