### PR TITLE
SDO: fix broken block download

### DIFF
--- a/stack/CO_SDO.c
+++ b/stack/CO_SDO.c
@@ -219,24 +219,26 @@ static void CO_SDO_receive(void *object, const CO_CANrxMsg_t *msg){
             /* check correct sequence number. */
             if(seqno == (SDO->sequence + 1U)) {
                 /* sequence is correct */
-                uint8_t i;
 
-                SDO->sequence++;
+                /* check if buffer can store whole message just in case */
+                if (CO_SDO_BUFFER_SIZE - SDO->bufferOffset >= 7) {
+                    uint8_t i;
 
-                /* copy data */
-                for(i=1; i<8; i++) {
-                    SDO->ODF_arg.data[SDO->bufferOffset++] = msg->data[i]; //SDO->ODF_arg.data is equal as SDO->databuffer
-                    if(SDO->bufferOffset >= CO_SDO_BUFFER_SIZE) {
-                        /* buffer full, break reception */
+                    SDO->sequence++;
+
+                    /* copy data */
+                    for(i=1; i<8; i++) {
+                        SDO->ODF_arg.data[SDO->bufferOffset++] = msg->data[i]; //SDO->ODF_arg.data is equal as SDO->databuffer
+                    }
+
+                    /* break reception if last segment, block ends or block sequence is too large */
+                    if(((CANrxData[0] & 0x80U) == 0x80U) || (SDO->sequence >= SDO->blksize)) {
                         SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP;
                         CO_SDO_receive_done(SDO);
-                        break;
                     }
-                }
-
-                /* break reception if last segment, block ends or block sequence is too large */
-                if(((CANrxData[0] & 0x80U) == 0x80U) || (SDO->sequence >= SDO->blksize)) {
-                    SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP;
+                } else {
+                    /* buffer is full, ignore this segment, send response without resetting sequence */
+                    SDO->state = CO_SDO_ST_DOWNLOAD_BL_SUB_RESP_2;
                     CO_SDO_receive_done(SDO);
                 }
             }


### PR DESCRIPTION
Fix wrong double calling CO_SDO_receive_done for last segment in subblock/block.

This is critical fix for PR #174
issue #39

Before this patch SDO block download was not working if there is no sequence breaks or timeouts (if SDO buffer not gets empty while receiving block). If data size is bigger or equal to blocksize, on receiving last segment, bug caused SDO to process wrong message buffer from FIFO while waiting block end sequence that leads to SDO abort 0504 0001h (client/server command specifier not valid or unknown).

It was caused by wrong double calling CO_SDO_receive_done on block end (one call in full buffer check and one in block end check) that broke FIFO receive pointer. Workaround was to set CO_SDO_BUFFER_SIZE greater than 127*7 (889 bytes) or work with CANopen master that always brake sequence on downloading :)

This fix preserve "old logic" we discuss in #205 issue.