### PR TITLE
Redefine CO_SDO_state_t numbers to allow parsing of upper nibble as flags

### DIFF
--- a/301/CO_SDOserver.h
+++ b/301/CO_SDOserver.h
@@ -169,7 +169,7 @@ CO_SDO_ST_UPLOAD_SEGMENT_RSP = 0x24U,
  *  - byte 1..3: Object index and subIndex.
  *  - byte 4..7: If s=1, then size of data for block download is indicated here.
  * - SDO server is in #CO_SDO_ST_IDLE state and waits for client request. */
-CO_SDO_ST_DOWNLOAD_BLK_INITIATE_REQ = 0x31U,
+CO_SDO_ST_DOWNLOAD_BLK_INITIATE_REQ = 0x51U,
 /**
  * - SDO client waits for response.
  * - SDO server responses:
@@ -179,7 +179,7 @@ CO_SDO_ST_DOWNLOAD_BLK_INITIATE_REQ = 0x31U,
  *  - byte 4: blksize: Number of segments per block that shall be used by the
  *    client for the following block download with 0 < blksize < 128.
  *  - byte 5..7: Reserved. */
-CO_SDO_ST_DOWNLOAD_BLK_INITIATE_RSP = 0x32U,
+CO_SDO_ST_DOWNLOAD_BLK_INITIATE_RSP = 0x52U,
 /**
  * - SDO client sends 'blksize' segments of data in sequence:
  *  - byte 0: @b cnnnnnnn binary: (c=1 if no more segments to be downloaded,
@@ -187,7 +187,7 @@ CO_SDO_ST_DOWNLOAD_BLK_INITIATE_RSP = 0x32U,
  *    1..127.
  *  - byte 1..7: At most 7 bytes of segment data to be downloaded.
  * - SDO server reads sequence of 'blksize' blocks. */
-CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_REQ = 0x33U,
+CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_REQ = 0x53U,
 /**
  * - SDO client waits for response.
  * - SDO server responses:
@@ -202,7 +202,7 @@ CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_REQ = 0x33U,
  *  - byte 3..7: Reserved.
  * - If c was set to 1, then communication enters SDO block download end phase.
  */
-CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_RSP = 0x34U,
+CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_RSP = 0x54U,
 /**
  * - SDO client sends SDO block download end:
  *  - byte 0: @b 110nnn01 binary: (nnn: number of data bytes, that do @b not
@@ -210,7 +210,7 @@ CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_RSP = 0x34U,
  *  - byte 1..2: 16 bit CRC for the data set, if enabled by client and server.
  *  - byte 3..7: Reserved.
  * - SDO server waits for client request. */
-CO_SDO_ST_DOWNLOAD_BLK_END_REQ = 0x35U,
+CO_SDO_ST_DOWNLOAD_BLK_END_REQ = 0x55U,
 /**
  * - SDO client waits for response.
  * - SDO server responses:
@@ -218,7 +218,7 @@ CO_SDO_ST_DOWNLOAD_BLK_END_REQ = 0x35U,
  *  - byte 1..7: Reserved.
  * - Block download successfully ends here.
  */
-CO_SDO_ST_DOWNLOAD_BLK_END_RSP = 0x36U,
+CO_SDO_ST_DOWNLOAD_BLK_END_RSP = 0x56U,
 
 /**
  * - SDO client initiates SDO block upload:
@@ -231,7 +231,7 @@ CO_SDO_ST_DOWNLOAD_BLK_END_RSP = 0x36U,
  *    upload protocol #CO_SDO_ST_UPLOAD_INITIATE_RSP.
  *  - byte 6..7: Reserved.
  * - SDO server is in #CO_SDO_ST_IDLE state and waits for client request. */
-CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ = 0x41U,
+CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ = 0x61U,
 /**
  * - SDO client waits for response.
  * - SDO server responses:
@@ -241,13 +241,13 @@ CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ = 0x41U,
  *  - byte 4..7: If s=1, then size of data for block upload is indicated here.
  * - If enabled by pst, then server may alternatively response with
  *   #CO_SDO_ST_UPLOAD_INITIATE_RSP */
-CO_SDO_ST_UPLOAD_BLK_INITIATE_RSP = 0x42U,
+CO_SDO_ST_UPLOAD_BLK_INITIATE_RSP = 0x62U,
 /**
  * - SDO client sends second initiate for SDO block upload:
  *  - byte 0: @b 10100011 binary.
  *  - byte 1..7: Reserved.
  * - SDO server waits for client request. */
-CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ2 = 0x43U,
+CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ2 = 0x63U,
 /**
  * - SDO client reads sequence of 'blksize' blocks.
  * - SDO server sends 'blksize' segments of data in sequence:
@@ -255,7 +255,7 @@ CO_SDO_ST_UPLOAD_BLK_INITIATE_REQ2 = 0x43U,
  *    enter SDO block upload end phase; nnnnnnn is sequence number of segment,
  *    1..127.
  *  - byte 1..7: At most 7 bytes of segment data to be uploaded. */
-CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_SREQ = 0x44U,
+CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_SREQ = 0x64U,
 /**
  * - SDO client responses:
  *  - byte 0: @b 10100010 binary.
@@ -269,7 +269,7 @@ CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_SREQ = 0x44U,
  *  - byte 3..7: Reserved.
  * - SDO server waits for response.
  * - If c was set to 1, then communication enters SDO block upload end phase. */
-CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_CRSP = 0x45U,
+CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_CRSP = 0x65U,
 /**
  * - SDO client waits for server request.
  * - SDO server sends SDO block upload end:
@@ -277,7 +277,7 @@ CO_SDO_ST_UPLOAD_BLK_SUBBLOCK_CRSP = 0x45U,
  *    contain data)
  *  - byte 1..2: 16 bit CRC for the data set, if enabled by client and server.
  *  - byte 3..7: Reserved. */
-CO_SDO_ST_UPLOAD_BLK_END_SREQ = 0x46U,
+CO_SDO_ST_UPLOAD_BLK_END_SREQ = 0x66U,
 /**
  * - SDO client responses:
  *  - byte 0: @b 10100001 binary.
@@ -287,7 +287,7 @@ CO_SDO_ST_UPLOAD_BLK_END_SREQ = 0x46U,
  *   with client response. Client may then start next SDO communication
  *   immediately.
  */
-CO_SDO_ST_UPLOAD_BLK_END_CRSP = 0x47U,
+CO_SDO_ST_UPLOAD_BLK_END_CRSP = 0x67U,
 
 /* old state names, will be removed */
 CO_SDO_ST_DOWNLOAD_INITIATE = 0xA1U,

--- a/301/CO_SDOserver.h
+++ b/301/CO_SDOserver.h
@@ -72,6 +72,11 @@ extern "C" {
 /**
  * Internal states of the SDO state machine.
  *
+ * Upper nibble of byte indicates type of state:
+ * 0x10: Download
+ * 0x20: Upload
+ * 0x40: Block Mode
+ *
  * Note: CANopen has little endian byte order.
  */
 typedef enum {


### PR DESCRIPTION
This is a subtle change to the `CO_SDO_state_t` enumeration that allows the upper nibble of the byte to be parsed as flags indicating whether the state is for an upload or download, and if it is a block transfer or not.

The idea behind this change is that a generic SDO client thread can wake up via the `CO_SDOclient_initCallbackPre()` defined callback function and check the `SDO_C->state` value to determine whether an upload or download is in progress (and optionally if it is a block type transfer). This allows the appropriate processing functions to be called without implementing a series of global variables for each SDO client in existence to externally track the state of a client thread.

Effectively this allows multiple SDO client threads to operate independently to process any number of SDO client objects, because it keeps the state internal to the client object.