### PR TITLE
Differentiate between SDO_C states by use of flags

### DIFF
--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -323,7 +323,7 @@ CO_SDO_return_t CO_SDOclientDownloadInitiate(CO_SDOclient_t *SDO_C,
     if (SDO_C->SDO != NULL
         && SDO_C->SDOClientPar->nodeIDOfTheSDOServer == SDO_C->SDO->nodeId
     ) {
-        SDO_C->state = CO_SDO_ST_LOCAL_TRANSFER;
+        SDO_C->state = CO_SDO_ST_DOWNLOAD_LOCAL_TRANSFER;
     }
     else
 #endif
@@ -401,7 +401,7 @@ CO_SDO_return_t CO_SDOclientDownload(CO_SDOclient_t *SDO_C,
     }
 #if (CO_CONFIG_SDO_CLI) & CO_CONFIG_SDO_CLI_LOCAL
     /* Transfer data locally **************************************************/
-    else if (SDO_C->state == CO_SDO_ST_LOCAL_TRANSFER) {
+    else if (SDO_C->state == CO_SDO_ST_DOWNLOAD_LOCAL_TRANSFER) {
         if (SDO_C->SDO->state != CO_SDO_ST_IDLE) {
             abortCode = CO_SDO_AB_DEVICE_INCOMPAT;
             ret = CO_SDO_RT_endedWithClientAbort;
@@ -880,7 +880,7 @@ CO_SDO_return_t CO_SDOclientUploadInitiate(CO_SDOclient_t *SDO_C,
     if (SDO_C->SDO != NULL
         && SDO_C->SDOClientPar->nodeIDOfTheSDOServer == SDO_C->SDO->nodeId
     ) {
-        SDO_C->state = CO_SDO_ST_LOCAL_TRANSFER;
+        SDO_C->state = CO_SDO_ST_UPLOAD_LOCAL_TRANSFER;
     }
     else
 #endif
@@ -922,7 +922,7 @@ CO_SDO_return_t CO_SDOclientUpload(CO_SDOclient_t *SDO_C,
     }
 #if (CO_CONFIG_SDO_CLI) & CO_CONFIG_SDO_CLI_LOCAL
     /* Transfer data locally **************************************************/
-    else if (SDO_C->state == CO_SDO_ST_LOCAL_TRANSFER) {
+    else if (SDO_C->state == CO_SDO_ST_UPLOAD_LOCAL_TRANSFER) {
         if (SDO_C->SDO->state != 0) {
             abortCode = CO_SDO_AB_DEVICE_INCOMPAT;
             ret = CO_SDO_RT_endedWithClientAbort;


### PR DESCRIPTION
This is a subtle change to the CO_SDO_state_t enumeration that allows the upper nibble of the byte to be parsed as flags indicating whether the state is for an upload or download, and if it is a block transfer or not.

The idea behind this change is that a generic SDO client thread can wake up via the CO_SDOclient_initCallbackPre() defined callback function and check the SDO_C->state value to determine whether an upload or download is in progress (and optionally if it is a block type transfer). This allows the appropriate processing functions to be called without needing to track the state externally. Basically the thread just does a bitwise AND with SDO_C->state to determine if it needs to call CO_SDOclientDownload or CO_SDOclientUpload.