### PR TITLE
lssAddress parameter by value

### DIFF
--- a/305/CO_LSSslave.c
+++ b/305/CO_LSSslave.c
@@ -192,7 +192,7 @@ static void CO_LSSslave_receive(void *object, void *msg)
 /******************************************************************************/
 CO_ReturnError_t CO_LSSslave_init(
         CO_LSSslave_t          *LSSslave,
-        CO_LSS_address_t        lssAddress,
+        CO_LSS_address_t       *lssAddress,
         uint16_t               *pendingBitRate,
         uint8_t                *pendingNodeID,
         CO_CANmodule_t         *CANdevRx,
@@ -218,7 +218,7 @@ CO_ReturnError_t CO_LSSslave_init(
     memset(LSSslave, 0, sizeof(CO_LSSslave_t));
 
     /* Configure object variables */
-    memcpy(&LSSslave->lssAddress, &lssAddress, sizeof(LSSslave->lssAddress));
+    memcpy(&LSSslave->lssAddress, lssAddress, sizeof(LSSslave->lssAddress));
     LSSslave->lssState = CO_LSS_STATE_WAITING;
     LSSslave->fastscanPos = CO_LSS_FASTSCAN_VENDOR_ID;
 

--- a/305/CO_LSSslave.h
+++ b/305/CO_LSSslave.h
@@ -158,7 +158,7 @@ typedef struct{
  */
 CO_ReturnError_t CO_LSSslave_init(
         CO_LSSslave_t          *LSSslave,
-        CO_LSS_address_t        lssAddress,
+        CO_LSS_address_t       *lssAddress,
         uint16_t               *pendingBitRate,
         uint8_t                *pendingNodeID,
         CO_CANmodule_t         *CANdevRx,

--- a/CANopen.c
+++ b/CANopen.c
@@ -611,7 +611,7 @@ CO_ReturnError_t CO_LSSinit(uint8_t *nodeId,
     lssAddress.identity.vendorID = OD_identity.vendorID;
 
     err = CO_LSSslave_init(CO->LSSslave,
-                           lssAddress,
+                           &lssAddress,
                            bitRate,
                            nodeId,
                            CO->CANmodule[0],


### PR DESCRIPTION
This just disturbs my OCD.
It is inefficient, generates more code on smaller processors.
Some very old compilers for 8-bit controllers might not support this.