### PR TITLE
Add CO_SYNCsend()

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -889,7 +889,7 @@ uint8_t CO_TPDOisCOS(CO_TPDO_t *TPDO){
 }
 
 /******************************************************************************/
-int16_t CO_TPDOsend(CO_TPDO_t *TPDO){
+CO_ReturnError_t CO_TPDOsend(CO_TPDO_t *TPDO){
     int16_t i;
     uint8_t* pPDOdataByte;
     uint8_t** ppODdataByte;

--- a/301/CO_PDO.h
+++ b/301/CO_PDO.h
@@ -392,7 +392,7 @@ uint8_t CO_TPDOisCOS(CO_TPDO_t *TPDO);
  *
  * @return Same as CO_CANsend().
  */
-int16_t CO_TPDOsend(CO_TPDO_t *TPDO);
+CO_ReturnError_t CO_TPDOsend(CO_TPDO_t *TPDO);
 
 
 /**

--- a/301/CO_SYNC.h
+++ b/301/CO_SYNC.h
@@ -171,6 +171,21 @@ void CO_SYNC_initCallbackPre(
 
 
 /**
+ * Send SYNC message.
+ *
+ * This function prepares and sends a SYNC object. The application should only
+ * call this if direct control of SYNC transmission is needed, otherwise use
+ * CO_SYNC_process().
+ *
+ *
+ * @param TPDO TPDO object.
+ *
+ * @return Same as CO_CANsend().
+ */
+CO_ReturnError_t CO_SYNCsend(CO_SYNC_t *SYNC);
+
+
+/**
  * Process SYNC communication.
  *
  * Function must be called cyclically.


### PR DESCRIPTION
This change adds the function CO_SYNCsend to allow for easier manual control of SYNC message generation. For example generating the SYNC message based on an external timer rather than from the process loop.

I also changed the return type of CO_TPDOsend() to CO_ReturnError_t to match CO_CANsend().
