### PR TITLE
CO_HBconsumer_process - skipped monitored nodes, useless cycles

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -332,6 +332,7 @@ void CO_HBconsumer_process(
 
             if (monitoredNode->HBstate == CO_HBconsumer_UNCONFIGURED) {
                 /* continue, if node is not monitored */
+                monitoredNode++;
                 continue;
             }
             /* Verify if received message is heartbeat or bootup */


### PR DESCRIPTION
When current node is CO_HBconsumer_UNCONFIGURED then other nodes are skipped. You can increment pointer to node or break the cycle. 