### PR TITLE
Update documentation with further details on the Zephyr RTOS support

### DIFF
--- a/doc/deviceSupport.md
+++ b/doc/deviceSupport.md
@@ -48,12 +48,12 @@ Zephyr RTOS
 * CANopenNode integration with Zephyr RTOS
 * https://github.com/zephyrproject-rtos/zephyr/tree/master/subsys/canbus/canopen
 * Example integration: https://docs.zephyrproject.org/latest/samples/subsys/canbus/canopen/README.html
-* CANopenNode version:
+* CANopenNode version: v1.3
 * Status: stable
-* Features: OD storage, LED indicators, SDO server demo for Zephyr RTOS
+* Features: OD storage, LED indicators, Program Download, SDO server demo for Zephyr RTOS
 * Development tools: Zephyr SDK
 * Demo hardware: Any development board with CAN interface and Zephyr support (see https://docs.zephyrproject.org/latest/boards/index.html)
-* Information updated 2020-01-21
+* Information updated 2020-09-28
 
 
 Mbed-os RTOS + STM32 (F091RC, L496ZG)


### PR DESCRIPTION
Update documentation with further details on the Zephyr RTOS support for CANopenNode.