### PR TITLE
NMT: On startup, set state to operational when master

### DIFF
--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -226,8 +226,9 @@ CO_NMT_reset_cmd_t CO_NMT_process(
             if(HBtime > NMT->firstHBTime) NMT->HBproducerTimer = HBtime - NMT->firstHBTime;
             else                          NMT->HBproducerTimer = 0;
             
-            /* NMT slave self starting */
-            if (NMTstartup == 0x00000008U) NMT->operatingState = CO_NMT_OPERATIONAL;
+            /* NMT slave self starting or master */
+            if ((NMTstartup == 0x00000008U) || (NMTstartup & 0x00000001U))
+                                           NMT->operatingState = CO_NMT_OPERATIONAL;
             else                           NMT->operatingState = CO_NMT_PRE_OPERATIONAL;
         }
     }


### PR DESCRIPTION
This problem was introduced by 06a0493c787e6232a04d1e24376854d8339f1e80
Since this commit, the master don't start to operational state