### PR TITLE
MNT: Add a function to set internal state

### DIFF
--- a/stack/CO_NMT_Heartbeat.c
+++ b/stack/CO_NMT_Heartbeat.c
@@ -351,3 +351,9 @@ CO_NMT_internalState_t CO_NMT_getInternalState(
     return CO_NMT_INITIALIZING;
 }
 
+void CO_NMT_setInternalState(
+        CO_NMT_t               *NMT,
+        CO_NMT_internalState_t state)
+{
+	NMT->operatingState = state;
+}

--- a/stack/CO_NMT_Heartbeat.h
+++ b/stack/CO_NMT_Heartbeat.h
@@ -252,6 +252,17 @@ CO_NMT_reset_cmd_t CO_NMT_process(
 CO_NMT_internalState_t CO_NMT_getInternalState(
         CO_NMT_t               *NMT);
 
+/**
+ * Set current NMT state
+ *
+ * @param NMT This object.
+ * @param CO_NMT_internalState_t State to set
+ *
+ */
+void CO_NMT_setInternalState(
+        CO_NMT_t               *NMT,
+        CO_NMT_internalState_t state);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When master, it's up to the application to put master state into operational.
We had a function to do this so that we don't have to write directly in NMT structure