### PR TITLE
Added missing check for CO_NO_TIME definition to CANopen.h

### DIFF
--- a/CANopen.h
+++ b/CANopen.h
@@ -268,7 +268,9 @@ typedef struct {
 #if CO_NO_SYNC == 1 || defined CO_DOXYGEN
     CO_SYNC_t *SYNC;                 /**< SYNC object */
 #endif
+#if CO_NO_TIME == 1 || defined CO_DOXYGEN
     CO_TIME_t *TIME;                 /**< TIME object */
+#endif
     CO_RPDO_t *RPDO[CO_NO_RPDO];     /**< RPDO objects */
     CO_TPDO_t *TPDO[CO_NO_TPDO];     /**< TPDO objects */
     CO_HBconsumer_t *HBcons;         /**< Heartbeat consumer object*/


### PR DESCRIPTION
This adds a missing TIME object check to the CO_t struct. Without this, compilation fails with the following error message if no TIME object is enabled: ```CANopenNode/CANopen.h:271:5: error: unknown type name 'CO_TIME_t'```