### PR TITLE
Suppressed unused heapMemoryUsed warning when using CO_USE_GLOBAL

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -458,6 +458,8 @@ void CO_delete(void *CANptr) {
 CO_ReturnError_t CO_new(uint32_t *heapMemoryUsed) {
     int16_t i;
 
+    (void)heapMemoryUsed;
+
     /* If CANopen was initialized before, return. */
     if (CO != NULL) {
         return CO_ERROR_NO;


### PR DESCRIPTION
When using global CO objects, the heapMemoryUsed parameter of `CO_new(uint32_t *heapMemoryUsed)` is unused and generates a warning. This simply `(void)`'s it to suppress the warning.