### PR TITLE
Make "remote NMT changed" callback of HB consumer node-specific

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -321,18 +321,16 @@ void CO_HBconsumer_process(
 {
     (void)timerNext_us; /* may be unused */
 
-    uint8_t i;
     bool_t allMonitoredActiveCurrent = true;
     uint8_t allMonitoredOperationalCurrent = CO_NMT_OPERATIONAL;
-    CO_HBconsNode_t *monitoredNode = &HBcons->monitoredNodes[0];
 
     if (NMTisPreOrOperational && HBcons->NMTisPreOrOperationalPrev) {
-        for (i=0; i<HBcons->numberOfMonitoredNodes; i++) {
+        for (uint8_t i=0; i<HBcons->numberOfMonitoredNodes; i++) {
             uint32_t timeDifference_us_copy = timeDifference_us;
+            CO_HBconsNode_t * const monitoredNode = &HBcons->monitoredNodes[i];
 
             if (monitoredNode->HBstate == CO_HBconsumer_UNCONFIGURED) {
                 /* continue, if node is not monitored */
-                monitoredNode++;
                 continue;
             }
             /* Verify if received message is heartbeat or bootup */
@@ -420,12 +418,12 @@ void CO_HBconsumer_process(
                 monitoredNode->NMTstatePrev = monitoredNode->NMTstate;
             }
 #endif
-            monitoredNode++;
         }
     }
     else if (NMTisPreOrOperational || HBcons->NMTisPreOrOperationalPrev) {
         /* (pre)operational state changed, clear variables */
-        for(i=0; i<HBcons->numberOfMonitoredNodes; i++) {
+        for(uint8_t i=0; i<HBcons->numberOfMonitoredNodes; i++) {
+            CO_HBconsNode_t * const monitoredNode = &HBcons->monitoredNodes[i];
             monitoredNode->NMTstate = CO_NMT_UNKNOWN;
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
             monitoredNode->NMTstatePrev = CO_NMT_UNKNOWN;
@@ -434,7 +432,6 @@ void CO_HBconsumer_process(
             if (monitoredNode->HBstate != CO_HBconsumer_UNCONFIGURED) {
                 monitoredNode->HBstate = CO_HBconsumer_UNKNOWN;
             }
-            monitoredNode++;
         }
         allMonitoredActiveCurrent = false;
         allMonitoredOperationalCurrent = CO_NMT_UNKNOWN;

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -133,10 +133,8 @@ CO_ReturnError_t CO_HBconsumer_init(
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_FLAG_CALLBACK_PRE
             HBcons->monitoredNodes[i].pFunctSignalPre = NULL;
 #endif
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
-            HBcons->monitoredNodes[i].pFunctSignalNmtChanged = NULL;
-#endif
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
+            HBcons->monitoredNodes[i].pFunctSignalNmtChanged = NULL;
             HBcons->monitoredNodes[i].pFunctSignalHbStarted = NULL;
             HBcons->monitoredNodes[i].pFunctSignalTimeout = NULL;
             HBcons->monitoredNodes[i].pFunctSignalRemoteReset = NULL;
@@ -185,7 +183,7 @@ CO_ReturnError_t CO_HBconsumer_initEntry(
         monitoredNode->nodeId = nodeId;
         monitoredNode->time_us = (int32_t)consumerTime_ms * 1000;
         monitoredNode->NMTstate = CO_NMT_UNKNOWN;
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
         monitoredNode->NMTstatePrev = CO_NMT_UNKNOWN;
 #endif
         CO_FLAG_CLEAR(monitoredNode->CANrxNew);
@@ -234,7 +232,7 @@ void CO_HBconsumer_initCallbackPre(
 #endif
 
 
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
 /******************************************************************************/
 void CO_HBconsumer_initCallbackNmtChanged(
         CO_HBconsumer_t        *HBcons,
@@ -252,10 +250,8 @@ void CO_HBconsumer_initCallbackNmtChanged(
     monitoredNode->pFunctSignalNmtChanged = pFunctSignal;
     monitoredNode->pFunctSignalObjectNmtChanged = object;
 }
-#endif
 
 
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
 /******************************************************************************/
 void CO_HBconsumer_initCallbackHeartbeatStarted(
     CO_HBconsumer_t        *HBcons,
@@ -409,7 +405,7 @@ void CO_HBconsumer_process(
             if (monitoredNode->NMTstate != CO_NMT_OPERATIONAL) {
                 allMonitoredOperationalCurrent = CO_NMT_UNKNOWN;
             }
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
             /* Verify, if NMT state of monitored node changed */
             if(monitoredNode->NMTstate != monitoredNode->NMTstatePrev) {
                 if (monitoredNode->pFunctSignalNmtChanged != NULL) {
@@ -427,7 +423,7 @@ void CO_HBconsumer_process(
         for(uint8_t i=0; i<HBcons->numberOfMonitoredNodes; i++) {
             CO_HBconsNode_t * const monitoredNode = &HBcons->monitoredNodes[i];
             monitoredNode->NMTstate = CO_NMT_UNKNOWN;
-#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI
             monitoredNode->NMTstatePrev = CO_NMT_UNKNOWN;
 #endif
             CO_FLAG_CLEAR(monitoredNode->CANrxNew);

--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -91,7 +91,7 @@ typedef struct {
     /** From CO_HBconsumer_initCallbackPre() or NULL */
     void               *functSignalObjectPre;
 #endif
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) || defined CO_DOXYGEN
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
     /** Previous value of the remote node (Heartbeat payload) */
     CO_NMT_internalState_t NMTstatePrev;
     /** Callback for remote NMT changed event.
@@ -101,8 +101,6 @@ typedef struct {
                                    void *object);
     /** Pointer to object */
     void *pFunctSignalObjectNmtChanged;
-#endif
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
     /** Callback for heartbeat state change to active event.
      *  From CO_HBconsumer_initCallbackHeartbeatStarted() or NULL. */
     void (*pFunctSignalHbStarted)(uint8_t nodeId, uint8_t idx, void *object);
@@ -212,7 +210,7 @@ void CO_HBconsumer_initCallbackPre(
         void                  (*pFunctSignal)(void *object));
 #endif
 
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) || defined CO_DOXYGEN
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
 /**
  * Initialize Heartbeat consumer NMT changed callback function.
  *
@@ -232,9 +230,7 @@ void CO_HBconsumer_initCallbackNmtChanged(
         void                  (*pFunctSignal)(uint8_t nodeId, uint8_t idx,
                                               CO_NMT_internalState_t state,
                                               void *object));
-#endif
 
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
 /**
  * Initialize Heartbeat consumer started callback function.
  *
@@ -252,7 +248,6 @@ void CO_HBconsumer_initCallbackHeartbeatStarted(
         uint8_t                 idx,
         void                   *object,
         void                  (*pFunctSignal)(uint8_t nodeId, uint8_t idx, void *object));
-
 
 /**
  * Initialize Heartbeat consumer timeout callback function.

--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -94,6 +94,13 @@ typedef struct {
 #if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) || defined CO_DOXYGEN
     /** Previous value of the remote node (Heartbeat payload) */
     CO_NMT_internalState_t NMTstatePrev;
+    /** Callback for remote NMT changed event.
+     *  From CO_HBconsumer_initCallbackNmtChanged() or NULL. */
+    void (*pFunctSignalNmtChanged)(uint8_t nodeId, uint8_t idx,
+                                   CO_NMT_internalState_t state,
+                                   void *object);
+    /** Pointer to object */
+    void *pFunctSignalObjectNmtChanged;
 #endif
 #if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
     /** Callback for heartbeat state change to active event.
@@ -135,15 +142,6 @@ typedef struct{
     bool_t              NMTisPreOrOperationalPrev; /**< previous state of var */
     CO_CANmodule_t     *CANdevRx;         /**< From CO_HBconsumer_init() */
     uint16_t            CANdevRxIdxStart; /**< From CO_HBconsumer_init() */
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) || defined CO_DOXYGEN
-    /** Callback for remote NMT changed event.
-     *  From CO_HBconsumer_initCallbackNmtChanged() or NULL. */
-    void (*pFunctSignalNmtChanged)(uint8_t nodeId,
-                                   CO_NMT_internalState_t state,
-                                   void *object);
-    /** Pointer to object */
-    void *pFunctSignalObjectNmtChanged;
-#endif
 }CO_HBconsumer_t;
 
 
@@ -222,14 +220,16 @@ void CO_HBconsumer_initCallbackPre(
  * state from the remote node changes.
  *
  * @param HBcons This object.
+ * @param idx index of the node in HBcons object
  * @param object Pointer to object, which will be passed to pFunctSignal().
  *               Can be NULL.
  * @param pFunctSignal Pointer to the callback function. Not called if NULL.
  */
 void CO_HBconsumer_initCallbackNmtChanged(
         CO_HBconsumer_t        *HBcons,
+        uint8_t                 idx,
         void                   *object,
-        void                  (*pFunctSignal)(uint8_t nodeId,
+        void                  (*pFunctSignal)(uint8_t nodeId, uint8_t idx,
                                               CO_NMT_internalState_t state,
                                               void *object));
 #endif

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -135,11 +135,9 @@ extern "C" {
  * - #CO_CONFIG_FLAG_TIMERNEXT - Enable calculation of timerNext_us variable
  *   inside CO_HBconsumer_process().
  * - CO_CONFIG_HB_CONS_ENABLE - Enable heartbeat consumer.
- * - CO_CONFIG_HB_CONS_CALLBACK_CHANGE - Enable custom callback after NMT
- *   state of the monitored node changes. Callback is configured by
- *   CO_HBconsumer_initCallbackNmtChanged().
  * - CO_CONFIG_HB_CONS_CALLBACK_MULTI - Enable multiple custom callbacks, which
  *   can be configured for each monitored node. Callback are configured by
+ *   CO_HBconsumer_initCallbackNmtChanged(),
  *   CO_HBconsumer_initCallbackHeartbeatStarted(),
  *   CO_HBconsumer_initCallbackTimeout() and
  *   CO_HBconsumer_initCallbackRemoteReset() functions.
@@ -150,9 +148,8 @@ extern "C" {
 #define CO_CONFIG_HB_CONS (CO_CONFIG_HB_CONS_ENABLE)
 #endif
 #define CO_CONFIG_HB_CONS_ENABLE 0x01
-#define CO_CONFIG_HB_CONS_CALLBACK_CHANGE 0x02
-#define CO_CONFIG_HB_CONS_CALLBACK_MULTI 0x04
-#define CO_CONFIG_HB_CONS_QUERY_FUNCT 0x08
+#define CO_CONFIG_HB_CONS_CALLBACK_MULTI 0x02
+#define CO_CONFIG_HB_CONS_QUERY_FUNCT 0x04
 
 /**
  * Number of heartbeat consumer objects, where each object corresponds to one

--- a/example/CO_driver_target.h
+++ b/example/CO_driver_target.h
@@ -53,7 +53,6 @@ extern "C" {
 
 #ifndef CO_CONFIG_HB_CONS
 #define CO_CONFIG_HB_CONS (CO_CONFIG_HB_CONS_ENABLE | \
-                           CO_CONFIG_HB_CONS_CALLBACK_CHANGE | \
                            CO_CONFIG_HB_CONS_CALLBACK_MULTI | \
                            CO_CONFIG_HB_CONS_QUERY_FUNCT | \
                            CO_CONFIG_FLAG_CALLBACK_PRE | \

--- a/socketCAN/CO_driver_target.h
+++ b/socketCAN/CO_driver_target.h
@@ -70,7 +70,7 @@ extern "C" {
 
 #ifndef CO_CONFIG_HB_CONS
 #define CO_CONFIG_HB_CONS (CO_CONFIG_HB_CONS_ENABLE | \
-                           CO_CONFIG_HB_CONS_CALLBACK_CHANGE | \
+                           CO_CONFIG_HB_CONS_CALLBACK_MULTI | \
                            CO_CONFIG_FLAG_CALLBACK_PRE_USED | \
                            CO_CONFIG_FLAG_TIMERNEXT)
 #endif

--- a/socketCAN/CO_main_basic.c
+++ b/socketCAN/CO_main_basic.c
@@ -167,7 +167,7 @@ static void NmtChangedCallback(CO_NMT_internalState_t state)
 }
 
 /* callback for monitoring Heartbeat remote NMT state change */
-static void HeartbeatNmtChangedCallback(uint8_t nodeId,
+static void HeartbeatNmtChangedCallback(uint8_t nodeId, uint8_t idx,
                                         CO_NMT_internalState_t state,
                                         void *object)
 {
@@ -479,8 +479,9 @@ int main (int argc, char *argv[]) {
         if(!CO->nodeIdUnconfigured) {
             CO_EM_initCallbackRx(CO->em, EmergencyRxCallback);
             CO_NMT_initCallbackChanged(CO->NMT, NmtChangedCallback);
-            CO_HBconsumer_initCallbackNmtChanged(CO->HBcons, NULL,
-                                                 HeartbeatNmtChangedCallback);
+            for (size_t idx = 0; idx < CO->HBcons->numberOfMonitoredNodes; ++idx)
+                CO_HBconsumer_initCallbackNmtChanged(CO->HBcons, idx, NULL,
+                                                     HeartbeatNmtChangedCallback);
 #if CO_OD_STORAGE == 1
             /* initialize OD objects 1010 and 1011 and verify errors. */
             CO_OD_configure(CO->SDO[0], OD_H1010_STORE_PARAM_FUNC, CO_ODF_1010, (void*)&odStor, 0, 0U);


### PR DESCRIPTION
* This way "remote NMT changed" callback is much more similar to other "multi" callbacks of HB consumer, and it was node-specific anyway, as you have to first configure the monitoring node to have that callback executed.

* Merge CO_CONFIG_HB_CONS_CALLBACK_CHANGE with ..._HB_CONS_CALLBACK_MULTI
These settings are now very similar, so there's no need to have two separate config options.

* Implement a better solution for #229
Instead of playing with incrementing pointers in various places it is better to just set it once at the start of loop.

These changes break the API.