### PR TITLE
Restore CO_CONFIG_HB_CONS_CALLBACK_CHANGE option

### DIFF
--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -91,9 +91,13 @@ typedef struct {
     /** From CO_HBconsumer_initCallbackPre() or NULL */
     void               *functSignalObjectPre;
 #endif
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) \
+    || ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) \
+    || defined CO_DOXYGEN
     /** Previous value of the remote node (Heartbeat payload) */
     CO_NMT_internalState_t NMTstatePrev;
+#endif
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
     /** Callback for remote NMT changed event.
      *  From CO_HBconsumer_initCallbackNmtChanged() or NULL. */
     void (*pFunctSignalNmtChanged)(uint8_t nodeId, uint8_t idx,
@@ -140,6 +144,15 @@ typedef struct{
     bool_t              NMTisPreOrOperationalPrev; /**< previous state of var */
     CO_CANmodule_t     *CANdevRx;         /**< From CO_HBconsumer_init() */
     uint16_t            CANdevRxIdxStart; /**< From CO_HBconsumer_init() */
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) || defined CO_DOXYGEN
+    /** Callback for remote NMT changed event.
+     *  From CO_HBconsumer_initCallbackNmtChanged() or NULL. */
+    void (*pFunctSignalNmtChanged)(uint8_t nodeId, uint8_t idx,
+                                   CO_NMT_internalState_t state,
+                                   void *object);
+    /** Pointer to object */
+    void *pFunctSignalObjectNmtChanged;
+#endif
 }CO_HBconsumer_t;
 
 
@@ -210,7 +223,9 @@ void CO_HBconsumer_initCallbackPre(
         void                  (*pFunctSignal)(void *object));
 #endif
 
-#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_CHANGE) \
+    || ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) \
+    || defined CO_DOXYGEN
 /**
  * Initialize Heartbeat consumer NMT changed callback function.
  *
@@ -218,19 +233,24 @@ void CO_HBconsumer_initCallbackPre(
  * state from the remote node changes.
  *
  * @param HBcons This object.
- * @param idx index of the node in HBcons object
+ * @param idx index of the node in HBcons object (only when
+ *            CO_CONFIG_HB_CONS_CALLBACK_MULTI is enabled)
  * @param object Pointer to object, which will be passed to pFunctSignal().
  *               Can be NULL.
  * @param pFunctSignal Pointer to the callback function. Not called if NULL.
  */
 void CO_HBconsumer_initCallbackNmtChanged(
         CO_HBconsumer_t        *HBcons,
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
         uint8_t                 idx,
+#endif
         void                   *object,
         void                  (*pFunctSignal)(uint8_t nodeId, uint8_t idx,
                                               CO_NMT_internalState_t state,
                                               void *object));
+#endif
 
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_CALLBACK_MULTI) || defined CO_DOXYGEN
 /**
  * Initialize Heartbeat consumer started callback function.
  *

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -135,21 +135,27 @@ extern "C" {
  * - #CO_CONFIG_FLAG_TIMERNEXT - Enable calculation of timerNext_us variable
  *   inside CO_HBconsumer_process().
  * - CO_CONFIG_HB_CONS_ENABLE - Enable heartbeat consumer.
+ * - CO_CONFIG_HB_CONS_CALLBACK_CHANGE - Enable custom common callback after NMT
+ *   state of the monitored node changes. Callback is configured by
+ *   CO_HBconsumer_initCallbackNmtChanged().
  * - CO_CONFIG_HB_CONS_CALLBACK_MULTI - Enable multiple custom callbacks, which
- *   can be configured for each monitored node. Callback are configured by
- *   CO_HBconsumer_initCallbackNmtChanged(),
+ *   can be configured individually for each monitored node. Callbacks are
+ *   configured by CO_HBconsumer_initCallbackNmtChanged(),
  *   CO_HBconsumer_initCallbackHeartbeatStarted(),
  *   CO_HBconsumer_initCallbackTimeout() and
  *   CO_HBconsumer_initCallbackRemoteReset() functions.
  * - CO_CONFIG_HB_CONS_QUERY_FUNCT - Enable functions for query HB state or
  *   NMT state of the specific monitored node.
+ * Note that CO_CONFIG_HB_CONS_CALLBACK_CHANGE and
+ * CO_CONFIG_HB_CONS_CALLBACK_MULTI cannot be set simultaneously.
  */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_HB_CONS (CO_CONFIG_HB_CONS_ENABLE)
 #endif
 #define CO_CONFIG_HB_CONS_ENABLE 0x01
-#define CO_CONFIG_HB_CONS_CALLBACK_MULTI 0x02
-#define CO_CONFIG_HB_CONS_QUERY_FUNCT 0x04
+#define CO_CONFIG_HB_CONS_CALLBACK_CHANGE 0x02
+#define CO_CONFIG_HB_CONS_CALLBACK_MULTI 0x04
+#define CO_CONFIG_HB_CONS_QUERY_FUNCT 0x08
 
 /**
  * Number of heartbeat consumer objects, where each object corresponds to one

--- a/305/CO_LSSslave.c
+++ b/305/CO_LSSslave.c
@@ -73,24 +73,27 @@ static void CO_LSSslave_receive(void *object, void *msg)
             }
         }
         else if(LSSslave->lssState == CO_LSS_STATE_WAITING) {
-            uint32_t valSw;
             switch (cs) {
             case CO_LSS_SWITCH_STATE_SEL_VENDOR: {
+                uint32_t valSw;
                 memcpy(&valSw, &data[1], sizeof(valSw));
                 LSSslave->lssSelect.identity.vendorID = CO_SWAP_32(valSw);
                 break;
             }
             case CO_LSS_SWITCH_STATE_SEL_PRODUCT: {
+                uint32_t valSw;
                 memcpy(&valSw, &data[1], sizeof(valSw));
                 LSSslave->lssSelect.identity.productCode = CO_SWAP_32(valSw);
                 break;
             }
             case CO_LSS_SWITCH_STATE_SEL_REV: {
+                uint32_t valSw;
                 memcpy(&valSw, &data[1], sizeof(valSw));
                 LSSslave->lssSelect.identity.revisionNumber = CO_SWAP_32(valSw);
                 break;
             }
             case CO_LSS_SWITCH_STATE_SEL_SERIAL: {
+                uint32_t valSw;
                 memcpy(&valSw, &data[1], sizeof(valSw));
                 LSSslave->lssSelect.identity.serialNumber = CO_SWAP_32(valSw);
 

--- a/socketCAN/CO_driver_target.h
+++ b/socketCAN/CO_driver_target.h
@@ -70,7 +70,7 @@ extern "C" {
 
 #ifndef CO_CONFIG_HB_CONS
 #define CO_CONFIG_HB_CONS (CO_CONFIG_HB_CONS_ENABLE | \
-                           CO_CONFIG_HB_CONS_CALLBACK_MULTI | \
+                           CO_CONFIG_HB_CONS_CALLBACK_CHANGE | \
                            CO_CONFIG_FLAG_CALLBACK_PRE_USED | \
                            CO_CONFIG_FLAG_TIMERNEXT)
 #endif

--- a/socketCAN/CO_error_msgs.h
+++ b/socketCAN/CO_error_msgs.h
@@ -70,7 +70,7 @@ extern "C" {
 /* mainline */
 #define DBG_EMERGENCY_RX          "CANopen Emergency message from node 0x%02X: errorCode=0x%04X, errorRegister=0x%02X, errorBit=0x%02X, infoCode=0x%08X"
 #define DBG_NMT_CHANGE            "CANopen NMT state changed to: \"%s\" (%d)"
-#define DBG_HB_CONS_NMT_CHANGE    "CANopen Remote node ID = 0x%02X: NMT state changed to: \"%s\" (%d)"
+#define DBG_HB_CONS_NMT_CHANGE    "CANopen Remote node ID = 0x%02X (index = %d): NMT state changed to: \"%s\" (%d)"
 #define DBG_ARGUMENT_UNKNOWN      "(%s) Unknown %s argument: \"%s\"", __func__
 #define DBG_NOT_TCP_PORT          "(%s) -c argument \"%s\" is not a valid tcp port", __func__
 #define DBG_WRONG_NODE_ID         "(%s) Wrong node ID \"%d\"", __func__

--- a/socketCAN/CO_main_basic.c
+++ b/socketCAN/CO_main_basic.c
@@ -173,7 +173,7 @@ static void HeartbeatNmtChangedCallback(uint8_t nodeId, uint8_t idx,
 {
     (void)object;
     log_printf(LOG_NOTICE, DBG_HB_CONS_NMT_CHANGE,
-               nodeId, NmtState2Str(state), state);
+               nodeId, idx, NmtState2Str(state), state);
 }
 
 #if CO_OD_STORAGE == 1
@@ -479,9 +479,8 @@ int main (int argc, char *argv[]) {
         if(!CO->nodeIdUnconfigured) {
             CO_EM_initCallbackRx(CO->em, EmergencyRxCallback);
             CO_NMT_initCallbackChanged(CO->NMT, NmtChangedCallback);
-            for (size_t idx = 0; idx < CO->HBcons->numberOfMonitoredNodes; ++idx)
-                CO_HBconsumer_initCallbackNmtChanged(CO->HBcons, idx, NULL,
-                                                     HeartbeatNmtChangedCallback);
+            CO_HBconsumer_initCallbackNmtChanged(CO->HBcons, NULL,
+                                                 HeartbeatNmtChangedCallback);
 #if CO_OD_STORAGE == 1
             /* initialize OD objects 1010 and 1011 and verify errors. */
             CO_OD_configure(CO->SDO[0], OD_H1010_STORE_PARAM_FUNC, CO_ODF_1010, (void*)&odStor, 0, 0U);


### PR DESCRIPTION
The user may decide whether he/she wants one common callback for all
monitored nodes (CO_CONFIG_HB_CONS_CALLBACK_CHANGE) or maybe separate
callbacks configured individually for each monitored mode
(CO_CONFIG_HB_CONS_CALLBACK_MULTI). These options cannot be set
simultaneously.

This change is related to the discussion in #237

Also fix a warning about shadowed local variables in CO_LSSslave.c