### PR TITLE
removed symlink to doc.html, not supported on Windows

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,1 +1,0 @@
-html/index.html


### PR DESCRIPTION
I ran a quick test with compiling on Windows WSL using a Yocto genereted SDK.
So far its working well, only problem I found is that the doc/index.html file is symlinked.
This is not supported on Windows, hence the repo gets flagged *dirty*.
I've checked on my linux system and the link is broken anyway so I guess it is not a problem to just remove that file?