### PR TITLE
Fix default CO_CONFIG_LSS value

### DIFF
--- a/305/CO_LSS.h
+++ b/305/CO_LSS.h
@@ -31,7 +31,7 @@
 
 /* default configuration, see CO_config.h */
 #ifndef CO_CONFIG_LSS
-#define CO_CONFIG_LSS (CO_CONFIG_LSS_SLAVE \
+#define CO_CONFIG_LSS (CO_CONFIG_LSS_SLAVE | \
                        CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE)
 #endif
 


### PR DESCRIPTION
The default CO_CONFIG_LSS value has a syntax error in it.