### PR TITLE
BUGFIX: updating nmt internal state doesn't trigger callback function

### DIFF
--- a/301/CO_NMT_Heartbeat.c
+++ b/301/CO_NMT_Heartbeat.c
@@ -328,6 +328,25 @@ CO_NMT_reset_cmd_t CO_NMT_process(
     return (CO_NMT_reset_cmd_t) NMT->resetCommand;
 }
 
+/******************************************************************************/
+void CO_NMT_setInternalState(CO_NMT_t *NMT,
+                                           CO_NMT_internalState_t state)
+{
+    if (NMT == NULL) 
+        return;
+
+    if (NMT->operatingState == state)
+        return;
+
+    NMT->operatingState = state;
+
+#if (CO_CONFIG_NMT) & CO_CONFIG_NMT_CALLBACK_CHANGE
+    if (NMT->pFunctNMT != NULL) {
+        NMT->pFunctNMT(NMT->operatingState);
+    }
+#endif
+}
+
 
 #if (CO_CONFIG_NMT) & CO_CONFIG_NMT_MASTER
 /******************************************************************************/

--- a/301/CO_NMT_Heartbeat.h
+++ b/301/CO_NMT_Heartbeat.h
@@ -265,11 +265,8 @@ static inline CO_NMT_internalState_t CO_NMT_getInternalState(CO_NMT_t *NMT) {
  * @param NMT This object.
  * @param state New state.
  */
-static inline void CO_NMT_setInternalState(CO_NMT_t *NMT,
-                                           CO_NMT_internalState_t state)
-{
-    if (NMT != NULL) NMT->operatingState = state;
-}
+void CO_NMT_setInternalState(CO_NMT_t *NMT,
+                                           CO_NMT_internalState_t state);
 
 
 #if ((CO_CONFIG_NMT) & CO_CONFIG_NMT_MASTER) || defined CO_DOXYGEN


### PR DESCRIPTION
Noticed that when we set the nmt internal state directly that the attached callbacks are not triggered.
Easiest way to fix is as I did: trigger the callback from the setter function.

Let me know if the solution is not satisfying.