### PR TITLE
Fix build in NewOD for certain combinations of options

### DIFF
--- a/301/CO_Emergency.c
+++ b/301/CO_Emergency.c
@@ -554,6 +554,7 @@ void CO_EM_process(CO_EM_t *em,
     (void)timerNext_us; /* may be unused */
 
     /* verify errors from driver */
+#if ((CO_CONFIG_EM) & CO_CONFIG_EM_PRODUCER)
     uint16_t CANerrSt = em->CANdevTx->CANerrorStatus;
     if (CANerrSt != em->CANerrorStatusOld) {
         uint16_t CANerrStChanged = CANerrSt ^ em->CANerrorStatusOld;
@@ -588,6 +589,7 @@ void CO_EM_process(CO_EM_t *em,
             CO_error(em, (CANerrSt & CO_CAN_ERRRX_OVERFLOW) != 0,
                      CO_EM_CAN_RXB_OVERFLOW, CO_EM_CAN_RXB_OVERFLOW, 0);
     }
+#endif
 
     /* calculate Error register */
     uint8_t errorRegister = 0U;

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -333,7 +333,9 @@ CO_ReturnError_t CO_SDOserver_init(CO_SDOserver_t *SDO,
     /* Configure object variables */
     SDO->OD = OD;
     SDO->nodeId = nodeId;
+#if ((CO_CONFIG_SDO_SRV) & CO_CONFIG_SDO_SRV_SEGMENTED)
     SDO->SDOtimeoutTime_us = (uint32_t)SDOtimeoutTime_ms * 1000;
+#endif
 #if (CO_CONFIG_SDO_SRV) & CO_CONFIG_SDO_SRV_BLOCK
     SDO->block_SDOtimeoutTime_us = (uint32_t)SDOtimeoutTime_ms * 700;
 #endif
@@ -1137,7 +1139,9 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
             SDO->state = CO_SDO_ST_ABORT;
         }
         } /* switch (SDO->state) */
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_SDO_SRV_SEGMENTED
         SDO->timeoutTimer = 0;
+#endif
         timeDifference_us = 0;
         CO_FLAG_CLEAR(SDO->CANrxNew);
     } /* if (isNew) */
@@ -1206,7 +1210,9 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
             SDO->CANtxBuff->data[3] = SDO->subIndex;
 
             /* reset timeout timer and send message */
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_SDO_SRV_SEGMENTED
             SDO->timeoutTimer = 0;
+#endif
             CO_CANsend(SDO->CANdevTx, SDO->CANtxBuff);
 #if (CO_CONFIG_SDO_SRV) & CO_CONFIG_SDO_SRV_SEGMENTED
             if (SDO->finished) {

--- a/301/CO_TIME.h
+++ b/301/CO_TIME.h
@@ -181,7 +181,9 @@ static inline void CO_TIME_set(CO_TIME_t *TIME,
         TIME->residual_us = 0;
         TIME->ms = ms;
         TIME->days = days;
+#if ((CO_CONFIG_TIME) & CO_CONFIG_TIME_PRODUCER)
         TIME->producerTimer_ms = TIME->producerInterval_ms =producerInterval_ms;
+#endif
     }
 }
 


### PR DESCRIPTION
Some structure members are only present when explicitly enabled by options.
Consequently, these members can only be used when the corresponding option is enabled.
I found some instances where this check in the code was missing and thus resulted in compile errors