### PR TITLE
Fix HBcons entries count

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -140,8 +140,8 @@ CO_ReturnError_t CO_HBconsumer_init(CO_HBconsumer_t *HBcons,
 
     /* get actual number of monitored nodes */
     HBcons->numberOfMonitoredNodes =
-        OD_1016_HBcons->subEntriesCount < CO_CONFIG_HB_CONS_SIZE ?
-        OD_1016_HBcons->subEntriesCount : CO_CONFIG_HB_CONS_SIZE;
+        OD_1016_HBcons->subEntriesCount-1 < CO_CONFIG_HB_CONS_SIZE ?
+        OD_1016_HBcons->subEntriesCount-1 : CO_CONFIG_HB_CONS_SIZE;
 
     for (uint8_t i = 0; i < HBcons->numberOfMonitoredNodes; i++) {
         uint32_t val;


### PR DESCRIPTION
HB Consumer sub index 0 is `Highest sub-index supported` and should not be counted on number of HB consumers.
Without this, `CO_CANopenInit()` fails with error code -12 : `CO_ERROR_OD_PARAMETERS`