### PR TITLE
fixed some warnings & potential bugs

### DIFF
--- a/301/CO_Emergency.c
+++ b/301/CO_Emergency.c
@@ -259,7 +259,7 @@ static ODR_t OD_read_statusBits(OD_stream_t *stream, void *buf,
     CO_EM_t *em = (CO_EM_t *)stream->object;
 
     /* get MAX(errorStatusBitsSize, bufSize, ODsizeIndication) */
-    size_t countReadLocal = CO_CONFIG_EM_ERR_STATUS_BITS_COUNT / 8;
+    OD_size_t countReadLocal = CO_CONFIG_EM_ERR_STATUS_BITS_COUNT / 8;
     if (countReadLocal > count) {
         countReadLocal = count;
     }
@@ -288,7 +288,7 @@ static ODR_t OD_write_statusBits(OD_stream_t *stream, const void *buf,
     CO_EM_t *em = (CO_EM_t *)stream->object;
 
     /* get MAX(errorStatusBitsSize, bufSize, ODsizeIndication) */
-    size_t countWrite = CO_CONFIG_EM_ERR_STATUS_BITS_COUNT / 8;
+    OD_size_t countWrite = CO_CONFIG_EM_ERR_STATUS_BITS_COUNT / 8;
     if (countWrite > count) {
         countWrite = count;
     }

--- a/301/CO_NMT_Heartbeat.h
+++ b/301/CO_NMT_Heartbeat.h
@@ -315,7 +315,7 @@ CO_NMT_reset_cmd_t CO_NMT_process(CO_NMT_t *NMT,
  * @return @ref CO_NMT_internalState_t
  */
 static inline CO_NMT_internalState_t CO_NMT_getInternalState(CO_NMT_t *NMT) {
-    return (NMT == NULL) ? CO_NMT_INITIALIZING : NMT->operatingState;
+    return (NMT == NULL) ? CO_NMT_INITIALIZING : (CO_NMT_internalState_t)NMT->operatingState;
 }
 
 
@@ -330,7 +330,7 @@ static inline CO_NMT_internalState_t CO_NMT_getInternalState(CO_NMT_t *NMT) {
 static inline void CO_NMT_sendInternalCommand(CO_NMT_t *NMT,
                                               CO_NMT_command_t command)
 {
-    if (NMT != NULL) NMT->internalCommand = command;
+    if (NMT != NULL) NMT->internalCommand = (uint8_t)command;
 }
 
 

--- a/301/CO_fifo.h
+++ b/301/CO_fifo.h
@@ -136,9 +136,9 @@ static inline bool_t CO_fifo_purge(CO_fifo_t *fifo) {
  * @return number of available bytes
  */
 static inline size_t CO_fifo_getSpace(CO_fifo_t *fifo) {
-    int sizeLeft = (int)fifo->readPtr - fifo->writePtr - 1;
+    int sizeLeft = (int)fifo->readPtr - (int)fifo->writePtr - 1;
     if (sizeLeft < 0) {
-        sizeLeft += fifo->bufSize;
+        sizeLeft += (int)fifo->bufSize;
     }
 
     return (size_t) sizeLeft;
@@ -153,9 +153,9 @@ static inline size_t CO_fifo_getSpace(CO_fifo_t *fifo) {
  * @return number of occupied bytes
  */
 static inline size_t CO_fifo_getOccupied(CO_fifo_t *fifo) {
-    int sizeOccupied = (int)fifo->writePtr - fifo->readPtr;
+    int sizeOccupied = (int)fifo->writePtr - (int)fifo->readPtr;
     if (sizeOccupied < 0) {
-        sizeOccupied += fifo->bufSize;
+        sizeOccupied += (int)fifo->bufSize;
     }
 
     return (size_t) sizeOccupied;
@@ -295,9 +295,9 @@ void CO_fifo_altFinish(CO_fifo_t *fifo, uint16_t *crc);
  * @return number of occupied bytes.
  */
 static inline size_t CO_fifo_altGetOccupied(CO_fifo_t *fifo) {
-    int sizeOccupied = (int)fifo->writePtr - fifo->altReadPtr;
+    int sizeOccupied = (int)fifo->writePtr - (int)fifo->altReadPtr;
     if (sizeOccupied < 0) {
-        sizeOccupied += fifo->bufSize;
+        sizeOccupied += (int)fifo->bufSize;
     }
 
     return (size_t) sizeOccupied;

--- a/305/CO_LSSmaster.c
+++ b/305/CO_LSSmaster.c
@@ -129,10 +129,10 @@ CO_ReturnError_t CO_LSSmaster_init(
         uint16_t                timeout_ms,
         CO_CANmodule_t         *CANdevRx,
         uint16_t                CANdevRxIdx,
-        uint32_t                CANidLssSlave,
+        uint16_t                CANidLssSlave,
         CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
-        uint32_t                CANidLssMaster)
+        uint16_t                CANidLssMaster)
 {
     CO_ReturnError_t ret = CO_ERROR_NO;
 

--- a/305/CO_LSSmaster.h
+++ b/305/CO_LSSmaster.h
@@ -158,10 +158,10 @@ CO_ReturnError_t CO_LSSmaster_init(
         uint16_t                timeout_ms,
         CO_CANmodule_t         *CANdevRx,
         uint16_t                CANdevRxIdx,
-        uint32_t                CANidLssSlave,
+        uint16_t                CANidLssSlave,
         CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
-        uint32_t                CANidLssMaster);
+        uint16_t                CANidLssMaster);
 
 /**
  * Change LSS master timeout

--- a/305/CO_LSSslave.c
+++ b/305/CO_LSSslave.c
@@ -199,10 +199,10 @@ CO_ReturnError_t CO_LSSslave_init(
         uint8_t                *pendingNodeID,
         CO_CANmodule_t         *CANdevRx,
         uint16_t                CANdevRxIdx,
-        uint32_t                CANidLssMaster,
+        uint16_t                CANidLssMaster,
         CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
-        uint32_t                CANidLssSlave)
+        uint16_t                CANidLssSlave)
 {
     CO_ReturnError_t ret = CO_ERROR_NO;
 

--- a/305/CO_LSSslave.h
+++ b/305/CO_LSSslave.h
@@ -164,10 +164,10 @@ CO_ReturnError_t CO_LSSslave_init(
         uint8_t                *pendingNodeID,
         CO_CANmodule_t         *CANdevRx,
         uint16_t                CANdevRxIdx,
-        uint32_t                CANidLssMaster,
+        uint16_t                CANidLssMaster,
         CO_CANmodule_t         *CANdevTx,
         uint16_t                CANdevTxIdx,
-        uint32_t                CANidLssSlave);
+        uint16_t                CANidLssSlave);
 
 /**
  * Process LSS communication

--- a/309/CO_gateway_ascii.c
+++ b/309/CO_gateway_ascii.c
@@ -485,7 +485,7 @@ static void responseWithError(CO_GTWA_t *gtwa,
 
     for (i = 0; i < len; i++) {
         const errorDescs_t *ed = &errorDescs[i];
-        if(ed->code == respErrorCode) {
+        if((CO_GTWA_respErrorCode_t)ed->code == respErrorCode) {
             desc = ed->desc;
         }
     }
@@ -507,7 +507,7 @@ static void responseWithErrorSDO(CO_GTWA_t *gtwa,
 
     for (i = 0; i < len; i++) {
         const errorDescs_t *ed = &errorDescsSDO[i];
-        if(ed->code == abortCode) {
+        if((CO_SDO_abortCode_t)ed->code == abortCode) {
             desc = ed->desc;
         }
     }
@@ -605,7 +605,7 @@ static inline void convertToLower(char *token, size_t maxCount) {
         if (*c == 0) {
             break;
         } else {
-            *c = tolower((int)*c);
+            *c = (char)tolower((int)*c);
         }
         c++;
     }
@@ -1404,7 +1404,7 @@ void CO_GTWA_process(CO_GTWA_t *gtwa,
             if (closed == 0) {
                 /* more arguments follow */
                 CO_fifo_readToken(&gtwa->commFifo,tok,sizeof(tok),&closed,&err);
-                gtwa->lssNID = getU32(tok, 1, 127, &err);
+                gtwa->lssNID = (uint8_t)getU32(tok, 1, 127, &err);
                 if (err) break;
 
                 closed = -1;


### PR DESCRIPTION
Hello, I fixed some warnings, that occured on my setup. A good bunch are just just typecasts, mostly because 
`sizeof(OD_size_t) != sizeof(size_t)` on 64 bit. I added the casts also in 301/CO_SDOclient.c but I am not sure if it is better to switch the function signatures instead (would also be consistent with the server part). 

bugs:

* 301/CO_SDOclient.c L 415 set invalid after return (noreachable code)
* 301/CO_SDOserver.c L 342 could lead to NULL access
* 301/CO_NMT_Heartbeat.hL 318 does not compile without cast when included in cpp file