### PR TITLE
remove warnings in CO_LSS (backport from v4)

### DIFF
--- a/stack/CO_LSS.h
+++ b/stack/CO_LSS.h
@@ -144,7 +144,7 @@ typedef enum {
     CO_LSS_FASTSCAN_CONFIRM = 0x80U  /**< All LSS slaves waiting for scan respond and previous scan is reset */
 } CO_LSS_fastscan_bitcheck;
 
-#define CO_LSS_FASTSCAN_BITCHECK_VALID(bit) ((bit>=CO_LSS_FASTSCAN_BIT0 && bit<=CO_LSS_FASTSCAN_BIT31) || bit==CO_LSS_FASTSCAN_CONFIRM)
+#define CO_LSS_FASTSCAN_BITCHECK_VALID(bit) (bit<=CO_LSS_FASTSCAN_BIT31 || bit==CO_LSS_FASTSCAN_CONFIRM)
 
 /**
  * Fastscan LSSsub, LSSnext
@@ -156,7 +156,7 @@ typedef enum {
     CO_LSS_FASTSCAN_SERIAL    = 3  /**< Serial number */
 } CO_LSS_fastscan_lss_sub_next;
 
-#define CO_LSS_FASTSCAN_LSS_SUB_NEXT_VALID(index) (index>=CO_LSS_FASTSCAN_VENDOR_ID && index<=CO_LSS_FASTSCAN_SERIAL)
+#define CO_LSS_FASTSCAN_LSS_SUB_NEXT_VALID(index) (index<=CO_LSS_FASTSCAN_SERIAL)
 
 /**
  * The LSS address is a 128 bit number, uniquely identifying each node. It
@@ -222,7 +222,7 @@ static const uint16_t CO_LSS_bitTimingTableLookup[]  = {
 /**
  * Macro to check if index contains valid bit timing
  */
-#define CO_LSS_BIT_TIMING_VALID(index) (index != 5 && (index >= CO_LSS_BIT_TIMING_1000 && index <= CO_LSS_BIT_TIMING_AUTO))
+#define CO_LSS_BIT_TIMING_VALID(index) (index != 5 && index <= CO_LSS_BIT_TIMING_AUTO)
 
 /**
  * Invalid node ID triggers node ID assignment


### PR DESCRIPTION
Some part of https://github.com/CANopenNode/CANopenNode/commit/267a2dafb29124b814215c5046922075ea03b48f about emitting warnings is now backported to v1.3