### PR TITLE
Dynamic monitored nodes

### DIFF
--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -143,7 +143,11 @@ typedef struct {
     /** From CO_HBconsumer_init() */
     CO_EM_t *em;
     /** Array of monitored nodes, maximum size CO_CONFIG_HB_CONS_SIZE */
-    CO_HBconsNode_t monitoredNodes[CO_CONFIG_HB_CONS_SIZE];
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_DYNAMIC
+    CO_HBconsNode_t* monitoredNodes;
+#else
+	CO_HBconsNode_t monitoredNodes[CO_CONFIG_HB_CONS_SIZE];
+#endif
     /** Actual number of monitored nodes,
      * MIN(CO_CONFIG_HB_CONS_SIZE or number-of-array-elements-in-OD-0x1016) */
     uint8_t numberOfMonitoredNodes;
@@ -181,6 +185,7 @@ typedef struct {
  * Function must be called in the communication reset section.
  *
  * @param HBcons This object will be initialized.
+ * @param monitoredNodes points an array of CO_HBconsNode_t must be as long as the number of monitorednodes(0x1016 sub 0). If NULL
  * @param em Emergency object.
  * @param OD_1016_HBcons OD entry for 0x1016 - "Consumer heartbeat time", entry
  * is required, IO extension will be applied.
@@ -192,7 +197,10 @@ typedef struct {
  * @return @ref CO_ReturnError_t CO_ERROR_NO in case of success.
  */
 CO_ReturnError_t CO_HBconsumer_init(CO_HBconsumer_t *HBcons,
-                                    CO_EM_t *em,
+									CO_EM_t *em,
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_DYNAMIC
+									CO_HBconsNode_t *monitoredNodes,
+#endif
                                     OD_entry_t *OD_1016_HBcons,
                                     CO_CANmodule_t *CANdevRx,
                                     uint16_t CANdevRxIdxStart,

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -163,6 +163,7 @@ extern "C" {
  *   CO_HBconsumer_initCallbackHeartbeatStarted(),
  *   CO_HBconsumer_initCallbackTimeout() and
  *   CO_HBconsumer_initCallbackRemoteReset() functions.
+ * - CO_CONFIG_HB_CONS_DYNAMIC - Uses dynamic memory for monitoredNodes.
  * - CO_CONFIG_HB_CONS_QUERY_FUNCT - Enable functions for query HB state or
  *   NMT state of the specific monitored node.
  * - #CO_CONFIG_FLAG_CALLBACK_PRE - Enable custom callback after preprocessing
@@ -183,6 +184,7 @@ extern "C" {
 #define CO_CONFIG_HB_CONS_CALLBACK_CHANGE 0x02
 #define CO_CONFIG_HB_CONS_CALLBACK_MULTI 0x04
 #define CO_CONFIG_HB_CONS_QUERY_FUNCT 0x08
+#define CO_CONFIG_HB_CONS_DYNAMIC 0x10
 
 /**
  * Number of heartbeat consumer objects, where each object corresponds to one

--- a/CANopen.c
+++ b/CANopen.c
@@ -309,15 +309,15 @@ CO_t *CO_new(CO_config_t *config, uint32_t *heapMemoryUsed) {
     do {
 #ifdef CO_MULTIPLE_OD
         /* verify arguments */
-        if (config == NULL || config->CNT_NMT > 1 || config->CNT_HB_CONS > 1
-            || config->CNT_EM > 1 || config->CNT_SDO_SRV > 128
-            || config->CNT_SDO_CLI > 128 || config->CNT_SYNC > 1
-            || config->CNT_RPDO > 512 || config->CNT_TPDO > 512
-            || config->CNT_TIME > 1 || config->CNT_LEDS > 1
-            || config->CNT_GFC > 1 || config->CNT_SRDO > 64
-            || config->CNT_LSS_SLV > 1 || config->CNT_LSS_MST > 1
-            || config->CNT_GTWA > 1
-        ) {
+        if (config == NULL || config->CNT_NMT > 1
+                || config->CNT_EM > 1 || config->CNT_SDO_SRV > 128
+                || config->CNT_SDO_CLI > 128 || config->CNT_SYNC > 1
+                || config->CNT_RPDO > 512 || config->CNT_TPDO > 512
+                || config->CNT_TIME > 1 || config->CNT_LEDS > 1
+                || config->CNT_GFC > 1 || config->CNT_SRDO > 64
+                || config->CNT_LSS_SLV > 1 || config->CNT_LSS_MST > 1
+                || config->CNT_GTWA > 1
+            ) {
             break;
         }
 #else
@@ -352,12 +352,12 @@ CO_t *CO_new(CO_config_t *config, uint32_t *heapMemoryUsed) {
 
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_ENABLE
         ON_MULTI_OD(uint8_t RX_CNT_HB_CONS = 0);
-        if (CO_GET_CNT(HB_CONS) == 1) {
-            p = calloc(1, sizeof(CO_HBconsumer_t));
+        if (CO_GET_CNT(HB_CONS) > 0) {
+            p = calloc(CO_GET_CNT(HB_CONS), sizeof(CO_HBconsumer_t));
             if (p == NULL) break;
             else co->HBcons = (CO_HBconsumer_t *)p;
-            mem += sizeof(CO_HBconsumer_t);
             ON_MULTI_OD(RX_CNT_HB_CONS = CO_CONFIG_HB_CONS_SIZE);
+            mem += sizeof(CO_HBconsumer_t)*CO_GET_CNT(HB_CONS);
         }
 #endif
 
@@ -1009,7 +1009,7 @@ CO_ReturnError_t CO_CANopenInit(CO_t *co,
     }
 
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_ENABLE
-    if (CO_GET_CNT(HB_CONS) == 1) {
+    if (CO_GET_CNT(HB_CONS) > 0) {
         err = CO_HBconsumer_init(co->HBcons,
                                  em,
                                  OD_GET(H1016, OD_H1016_CONSUMER_HB_TIME),
@@ -1365,7 +1365,7 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
     }
 
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_ENABLE
-    if (CO_GET_CNT(HB_CONS) == 1) {
+    if (CO_GET_CNT(HB_CONS) > 0) {
         CO_HBconsumer_process(co->HBcons,
                               NMTisPreOrOperational,
                               timeDifference_us,

--- a/CANopen.c
+++ b/CANopen.c
@@ -356,8 +356,12 @@ CO_t *CO_new(CO_config_t *config, uint32_t *heapMemoryUsed) {
             p = calloc(CO_GET_CNT(HB_CONS), sizeof(CO_HBconsumer_t));
             if (p == NULL) break;
             else co->HBcons = (CO_HBconsumer_t *)p;
-            ON_MULTI_OD(RX_CNT_HB_CONS = CO_CONFIG_HB_CONS_SIZE);
             mem += sizeof(CO_HBconsumer_t)*CO_GET_CNT(HB_CONS);
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_DYNAMIC
+            ON_MULTI_OD(RX_CNT_HB_CONS = CO_GET_CNT(HB_CONS));
+#else
+            ON_MULTI_OD(RX_CNT_HB_CONS = CO_GET_CNT(HB_CONS)>CO_CONFIG_HB_CONS_SIZE?CO_CONFIG_HB_CONS_SIZE:CO_GET_CNT(HB_CONS));
+#endif
         }
 #endif
 
@@ -1011,7 +1015,10 @@ CO_ReturnError_t CO_CANopenInit(CO_t *co,
 #if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_ENABLE
     if (CO_GET_CNT(HB_CONS) > 0) {
         err = CO_HBconsumer_init(co->HBcons,
-                                 em,
+        						 em,
+#if (CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_DYNAMIC
+                                 NULL,
+#endif
                                  OD_GET(H1016, OD_H1016_CONSUMER_HB_TIME),
                                  co->CANmodule,
                                  CO_GET_CO(RX_IDX_HB_CONS),


### PR DESCRIPTION
a) Fixed the ability to have more than one monitored node.
b) Added a feature to allocate dynamic memory for the monitoredNodes array.
This is an advantage if you have less than CO_CONFIG_HB_CONS_SIZE nodes you want to monitor.
If you want to monitor more than CO_CONFIG_HB_CONS_SIZE nodes. If you have multiple OD's. and
you monitor a large amount of node in one OD and few in the other. You would waste a lot of memory, if you just raise CO_CONFIG_HB_CONS_SIZE.