### PR TITLE
Fixed bug with CANrxData buffer indexing

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -811,7 +811,7 @@ void CO_RPDO_process(CO_RPDO_t *RPDO,
         bool_t rpdoReceived = false;
         while (CO_FLAG_READ(RPDO->CANrxNew[bufNo])) {
             rpdoReceived = true;
-            uint8_t *dataRPDO = &RPDO->CANrxData[0][bufNo];
+            uint8_t *dataRPDO = RPDO->CANrxData[bufNo];
 
             /* Clear the flag. If between the copy operation CANrxNew is set
              * by receive thread, then copy the latest data again. */


### PR DESCRIPTION
The `CANrxData` field of the `CO_RPDO_t` struct is an array of `uint8_t` buffer with two elements if the node is SYNC-enabled; when copying the content of an RPDO to the object dictionary `CANrxData` is mistakenly indexed with an extra `[0]`, which ends up pointing to either the first or the second byte of the first buffer, resulting in erroneous RPDO transfers. 