### PR TITLE
Add conditional compile statement for unused vars

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -1325,8 +1325,9 @@ void CO_TPDO_process(CO_TPDO_t *TPDO,
 {
     CO_PDO_common_t *PDO = &TPDO->PDO_common;
 #if ((CO_CONFIG_PDO) & CO_CONFIG_TPDO_TIMERS_ENABLE)
-    (void) syncWas; (void) timerNext_us;
+    (void) timerNext_us;
 #endif
+    (void) syncWas;
 
     if (PDO->valid && NMTisOperational) {
 

--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -1323,8 +1323,10 @@ void CO_TPDO_process(CO_TPDO_t *TPDO,
                      bool_t NMTisOperational,
                      bool_t syncWas)
 {
-    (void) syncWas; (void) timerNext_us;
     CO_PDO_common_t *PDO = &TPDO->PDO_common;
+#if ((CO_CONFIG_PDO) & CO_CONFIG_TPDO_TIMERS_ENABLE)
+    (void) syncWas; (void) timerNext_us;
+#endif
 
     if (PDO->valid && NMTisOperational) {
 


### PR DESCRIPTION
Otherwise it may trigger error (if timer is not enabled)