### PR TITLE
Workarounds for bugs and limits in xc8.

### DIFF
--- a/301/CO_Emergency.c
+++ b/301/CO_Emergency.c
@@ -753,8 +753,11 @@ void CO_error(CO_EM_t *em, bool_t setError, const uint8_t errorBit,
 
     /* safely write data, and increment pointers */
     CO_LOCK_EMCY(em->CANdevTx);
-    if (setError) *errorStatusBits |= bitmask;
-    else          *errorStatusBits &= ~bitmask;
+    if (setError) {
+        *errorStatusBits = *errorStatusBits | bitmask;
+    } else {
+        *errorStatusBits = *errorStatusBits & ~bitmask;;
+    }
 
 #if (CO_CONFIG_EM) & (CO_CONFIG_EM_PRODUCER | CO_CONFIG_EM_HISTORY)
     if (em->fifoSize >= 2) {
@@ -773,7 +776,9 @@ void CO_error(CO_EM_t *em, bool_t setError, const uint8_t errorBit,
             em->fifo[fifoWrPtr].info = infoCodeSwapped;
  #endif
             em->fifoWrPtr = fifoWrPtrNext;
-            if (em->fifoCount < (em->fifoSize - 1)) em->fifoCount++;
+            if (em->fifoCount < (em->fifoSize - 1)) {
+                em->fifoCount = em->fifoCount + 1;
+            }
         }
     }
 #endif /* (CO_CONFIG_EM) & (CO_CONFIG_EM_PRODUCER | CO_CONFIG_EM_HISTORY) */

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -415,7 +415,8 @@ void CO_HBconsumer_process(
 
             /* Verify timeout */
             if (monitoredNode->HBstate == CO_HBconsumer_ACTIVE) {
-                monitoredNode->timeoutTimer += timeDifference_us_copy;
+                monitoredNode->timeoutTimer
+                    = monitoredNode->timeoutTimer + timeDifference_us_copy;
 
                 if (monitoredNode->timeoutTimer >= monitoredNode->time_us) {
                     /* timeout expired */

--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -105,7 +105,8 @@ static ODR_t PDOconfigMap(CO_PDO_common_t *PDO,
     if (index < 0x20 && subIndex == 0) {
         OD_stream_t *stream = &OD_IO->stream;
         memset(stream, 0, sizeof(OD_stream_t));
-        stream->dataLength = stream->dataOffset = mappedLength;
+        stream->dataLength = mappedLength;
+        stream->dataOffset = mappedLength;
         OD_IO->read = OD_read_dummy;
         OD_IO->write = OD_write_dummy;
         return ODR_OK;
@@ -129,7 +130,9 @@ static ODR_t PDOconfigMap(CO_PDO_common_t *PDO,
     }
 
     /* Copy values and store mappedLength temporary. */
-    *OD_IO = OD_IOcopy;
+    /* Hack to keep xc8 happy. */
+    /* *OD_IO = OD_IOcopy; */
+    memcpy(OD_IO, &OD_IOcopy, sizeof(*OD_IO));
     OD_IO->stream.dataOffset = mappedLength;
 
     /* get TPDO request flag byte from extension */
@@ -1020,7 +1023,8 @@ static ODR_t OD_write_18xx(OD_stream_t *stream, const void *buf,
         TPDO->transmissionType = transmissionType;
         TPDO->sendRequest = true;
 #if (CO_CONFIG_PDO) & CO_CONFIG_TPDO_TIMERS_ENABLE
-        TPDO->inhibitTimer = TPDO->eventTimer = 0;
+        TPDO->inhibitTimer = 0;
+        TPDO->eventTimer = 0;
 #endif
         break;
     }

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -1353,7 +1353,8 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
             /* verify, if this is the last segment */
             if (count < 7 || (SDO->finished && count == 7)) {
                 /* indicate last segment and nnn */
-                SDO->CANtxBuff->data[0] |= ((7 - count) << 1) | 0x01;
+                SDO->CANtxBuff->data[0] 
+                        = SDO->CANtxBuff->data[0] | (((7 - count) << 1) | 0x01);
                 SDO->state = CO_SDO_ST_IDLE;
                 ret = CO_SDO_RT_ok_communicationEnd;
             }

--- a/storage/CO_storageEeprom.c
+++ b/storage/CO_storageEeprom.c
@@ -34,6 +34,11 @@
  * For more information see file CO_storage.h, CO_storage_entry_t.
  */
 static ODR_t storeEeprom(CO_storage_entry_t *entry, CO_CANmodule_t *CANmodule) {
+    // For xc8 bug, see below.
+    if (entry == NULL) {
+        return 0;
+    }
+
     bool_t writeOk;
 
     /* save data to the eeprom */
@@ -80,6 +85,11 @@ static ODR_t storeEeprom(CO_storage_entry_t *entry, CO_CANmodule_t *CANmodule) {
 static ODR_t restoreEeprom(CO_storage_entry_t *entry,
                            CO_CANmodule_t *CANmodule)
 {
+    // For xc8 bug, see below.
+    if (entry == NULL) {
+        return 0;
+    }
+
     (void) CANmodule;
     bool_t writeOk;
 
@@ -116,6 +126,11 @@ CO_ReturnError_t CO_storageEeprom_init(CO_storage_t *storage,
 {
     CO_ReturnError_t ret;
     bool_t eepromOvf = false;
+
+    // Magic to make xc8 work, if these functions aren't called xc8 is convinced
+    // they don't exist.
+    storeEeprom(NULL, NULL);
+    restoreEeprom(NULL, NULL);
 
     /* verify arguments */
     if (storage == NULL || entries == NULL || entriesCount == 0


### PR DESCRIPTION
These changes allow xc8 to compile CANopenNode. Perhaps not suitable to be merged but helpful for anyone that comes looking.