### PR TITLE
Create CO_process_initCallbackPre().

### DIFF
--- a/CANopen.c
+++ b/CANopen.c
@@ -1403,6 +1403,53 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
     return reset;
 }
 
+/******************************************************************************/
+void CO_process_initCallbackPre(CO_t *co,
+                                void *object,
+                                void (*pFunctSignal)(void *object)) {
+#if ((CO_CONFIG_LSS) & CO_CONFIG_LSS_SLAVE)             \
+    && ((CO_CONFIG_LSS) & CO_CONFIG_FLAG_CALLBACK_PRE)
+    if (CO_GET_CNT(LSS_SLV) == 1) {
+        CO_LSSslave_initCallbackPre(co->LSSslave, object, pFunctSignal);
+    }
+#endif
+
+#if (CO_CONFIG_EM) & CO_CONFIG_FLAG_CALLBACK_PRE
+    /* Emergency */
+    if (CO_GET_CNT(EM) == 1) {
+        CO_EM_initCallbackPre(co->em, object, pFunctSignal);
+    }
+#endif
+
+#if (CO_CONFIG_NMT) & CO_CONFIG_FLAG_CALLBACK_PRE
+    /* NMT_Heartbeat */
+    if (CO_GET_CNT(NMT) == 1) {
+        CO_NMT_initCallbackPre(co->NMT, object, pFunctSignal);
+    }
+#endif
+
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_CALLBACK_PRE
+    /* SDOserver */
+    for (uint8_t i = 0; i < CO_GET_CNT(SDO_SRV); i++) {
+        CO_SDOserver_initCallbackPre(&co->SDOserver[i], object, pFunctSignal);
+    }
+#endif
+
+#if ((CO_CONFIG_HB_CONS) & CO_CONFIG_HB_CONS_ENABLE)        \
+    && ((CO_CONFIG_HB_CONS) & CO_CONFIG_FLAG_CALLBACK_PRE)
+    if (CO_GET_CNT(HB_CONS) == 1) {
+        CO_HBconsumer_initCallbackPre(co->HBcons, object, pFunctSignal);
+    }
+#endif
+
+#if ((CO_CONFIG_TIME) & CO_CONFIG_TIME_ENABLE)          \
+    && ((CO_CONFIG_TIME) & CO_CONFIG_FLAG_CALLBACK_PRE)
+    if (CO_GET_CNT(TIME) == 1) {
+        CO_TIME_initCallbackPre(co->TIME, object, pFunctSignal);
+    }
+#endif
+}
+
 
 /******************************************************************************/
 #if (CO_CONFIG_SYNC) & CO_CONFIG_SYNC_ENABLE

--- a/CANopen.h
+++ b/CANopen.h
@@ -584,6 +584,22 @@ CO_NMT_reset_cmd_t CO_process(CO_t *co,
                               uint32_t *timerNext_us);
 
 
+/**
+ * Initialize callback functions for objects processed by CO_process().
+ *
+ * Function initializes optional callback functions, which should immediately
+ * start processing of CO_process() function in lainline thread.
+ *
+ * @param co CANopen object.
+ * @param object Pointer to object, which will be passed to pFunctSignal(). Can
+ * be NULL
+ * @param pFunctSignal Pointer to the callback function. Not called if NULL.
+ */
+void CO_process_initCallbackPre(CO_t *co,
+                                void *object,
+                                void (*pFunctSignal)(void *object));
+
+
 #if ((CO_CONFIG_SYNC) & CO_CONFIG_SYNC_ENABLE) || defined CO_DOXYGEN
 /**
  * Process CANopen SYNC objects.


### PR DESCRIPTION
Create CO_process_initCallbackPre(). This function calls initCallbackPre functions for all functions called by CO_process() where they have been enabled. This simplifies application development where the user does not wish to call the functions in CO_process() individually but does want callbacks from those functions.