### PR TITLE
Add SYNC timeout reset

### DIFF
--- a/301/CO_SYNC.h
+++ b/301/CO_SYNC.h
@@ -121,6 +121,8 @@ typedef struct {
     uint16_t CANdevRxIdx;
     /** Extension for OD object */
     OD_extension_t OD_1005_extension;
+    /** Extension for OD object */
+    OD_extension_t OD_1006_extension;
     /** CAN ID of the SYNC message. Calculated from _COB ID SYNC Message_
     variable from Object dictionary (index 0x1005). */
     uint16_t CAN_ID;


### PR DESCRIPTION
When testing after upgrading to CANopenNode v4, there were some premature SYNC timeouts after re-enabling the 1006 Communication cycle period.  This issue was previously discussed as part of issue #409 a while back but doesn't seem to have been addressed yet.  See commit for more details.

I did some testing of the changes, but don't have access to the CANopen conformance testing tool mentioned in #409.
