### PR TITLE
Fix variable name and use of pointer for big endian system

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -1266,8 +1266,8 @@ static CO_ReturnError_t CO_TPDOsend(CO_TPDO_t *TPDO) {
         /* swap multibyte data if big-endian */
  #ifdef CO_BIG_ENDIAN
         if ((stream->attribute & ODA_MB) != 0) {
-            uint8_t *lo = dataOD;
-            uint8_t *hi = dataOD + ODdataLength - 1;
+            uint8_t *lo = dataTPDOCopy;
+            uint8_t *hi = dataTPDOCopy + ODdataLength - 1;
             while (lo < hi) {
                 uint8_t swap = *lo;
                 *lo++ = *hi;

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -661,7 +661,7 @@ static bool_t readFromOd(CO_SDOserver_t *SDO,
                 reverseBytes(bufShifted, countRd);
             }
             else {
-                abortCode = CO_SDO_AB_PRAM_INCOMPAT;
+                *abortCode = CO_SDO_AB_PRAM_INCOMPAT;
                 SDO->state = CO_SDO_ST_ABORT;
                 return false;
             }


### PR DESCRIPTION
1. Variable name update in CO_PDO.c file
2. Correct use of pointer in the CO_SDOserver.c file