### PR TITLE
Feature/always lock od config

### DIFF
--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -621,7 +621,7 @@ CO_SDO_return_t CO_SDOclientDownload(CO_SDOclient_t *SDO_C,
             }
             if (abortCode == CO_SDO_AB_NONE) {
                 OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
                 const bool_t lock = true;
 #else
                 bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);
@@ -1218,7 +1218,7 @@ CO_SDO_return_t CO_SDOclientUpload(CO_SDOclient_t *SDO_C,
                                  ? countData : (OD_size_t)countFifo;
             OD_size_t countRd = 0;
             uint8_t buf[CO_CONFIG_SDO_CLI_BUFFER_SIZE + 1];
-#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
             const bool_t lock = true;
 #else
             bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);

--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -621,17 +621,12 @@ CO_SDO_return_t CO_SDOclientDownload(CO_SDOclient_t *SDO_C,
             }
             if (abortCode == CO_SDO_AB_NONE) {
                 OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-                const bool_t lock = true;
-#else
-                bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);
-#endif
 
                 /* write data to Object Dictionary */
-                if (lock) { CO_LOCK_OD(SDO_C->CANdevTx); }
+                CO_LOCK_OD(SDO_C->CANdevTx);
                 ODR_t odRet = SDO_C->OD_IO.write(&SDO_C->OD_IO.stream, buf,
                                                  (OD_size_t)count, &countWritten);
-                if (lock) { CO_UNLOCK_OD(SDO_C->CANdevTx); }
+                CO_UNLOCK_OD(SDO_C->CANdevTx);
 
                 /* verify for errors in write */
                 if (odRet != ODR_OK && odRet != ODR_PARTIAL) {
@@ -1218,17 +1213,12 @@ CO_SDO_return_t CO_SDOclientUpload(CO_SDOclient_t *SDO_C,
                                  ? countData : (OD_size_t)countFifo;
             OD_size_t countRd = 0;
             uint8_t buf[CO_CONFIG_SDO_CLI_BUFFER_SIZE + 1];
-#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-            const bool_t lock = true;
-#else
-            bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);
-#endif
 
             /* load data from OD variable into the buffer */
-            if (lock) { CO_LOCK_OD(SDO_C->CANdevTx); }
+            CO_LOCK_OD(SDO_C->CANdevTx);
             ODR_t odRet = SDO_C->OD_IO.read(&SDO_C->OD_IO.stream,
                                             buf, countBuf, &countRd);
-            if (lock) { CO_UNLOCK_OD(SDO_C->CANdevTx); }
+            CO_UNLOCK_OD(SDO_C->CANdevTx);
 
             if (odRet != ODR_OK && odRet != ODR_PARTIAL) {
                 abortCode = (CO_SDO_abortCode_t)OD_getSDOabCode(odRet);

--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -621,7 +621,11 @@ CO_SDO_return_t CO_SDOclientDownload(CO_SDOclient_t *SDO_C,
             }
             if (abortCode == CO_SDO_AB_NONE) {
                 OD_size_t countWritten = 0;
+#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+                const bool_t lock = true;
+#else
                 bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);
+#endif
 
                 /* write data to Object Dictionary */
                 if (lock) { CO_LOCK_OD(SDO_C->CANdevTx); }
@@ -1214,7 +1218,11 @@ CO_SDO_return_t CO_SDOclientUpload(CO_SDOclient_t *SDO_C,
                                  ? countData : (OD_size_t)countFifo;
             OD_size_t countRd = 0;
             uint8_t buf[CO_CONFIG_SDO_CLI_BUFFER_SIZE + 1];
+#if (CO_CONFIG_SDO_CLI) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+            const bool_t lock = true;
+#else
             bool_t lock = OD_mappable(&SDO_C->OD_IO.stream);
+#endif
 
             /* load data from OD variable into the buffer */
             if (lock) { CO_LOCK_OD(SDO_C->CANdevTx); }

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -551,7 +551,7 @@ static bool_t validateAndWriteToOD(CO_SDOserver_t *SDO,
 
     /* write data */
     OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
     const bool_t lock = true;
 #else
     bool_t lock = OD_mappable(&SDO->OD_IO.stream);
@@ -617,7 +617,7 @@ static bool_t readFromOd(CO_SDOserver_t *SDO,
         /* load data from OD variable into the buffer */
         OD_size_t countRd = 0;
         uint8_t *bufShifted = SDO->buf + countRemain;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
         const bool_t lock = true;
 #else
         bool_t lock = OD_mappable(&SDO->OD_IO.stream);
@@ -858,7 +858,7 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 
                 /* Copy data */
                 OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
                 const bool_t lock = true;
 #else
                 bool_t lock = OD_mappable(&SDO->OD_IO.stream);
@@ -1311,7 +1311,7 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 #else /* Expedited transfer only */
             /* load data from OD variable */
             OD_size_t count = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
             const bool_t lock = true;
 #else
             bool_t lock = OD_mappable(&SDO->OD_IO.stream);

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -551,16 +551,11 @@ static bool_t validateAndWriteToOD(CO_SDOserver_t *SDO,
 
     /* write data */
     OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-    const bool_t lock = true;
-#else
-    bool_t lock = OD_mappable(&SDO->OD_IO.stream);
-#endif
-    if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
 
+    CO_LOCK_OD(SDO->CANdevTx);
     ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, SDO->buf,
                                    SDO->bufOffsetWr, &countWritten);
-    if (lock) { CO_UNLOCK_OD(SDO->CANdevTx); }
+    CO_UNLOCK_OD(SDO->CANdevTx);
 
     SDO->bufOffsetWr = 0;
 
@@ -617,16 +612,11 @@ static bool_t readFromOd(CO_SDOserver_t *SDO,
         /* load data from OD variable into the buffer */
         OD_size_t countRd = 0;
         uint8_t *bufShifted = SDO->buf + countRemain;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-        const bool_t lock = true;
-#else
-        bool_t lock = OD_mappable(&SDO->OD_IO.stream);
-#endif
 
-        if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
+        CO_LOCK_OD(SDO->CANdevTx);
         ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, bufShifted,
                                       countRdRequest, &countRd);
-        if (lock) { CO_UNLOCK_OD(SDO->CANdevTx); }
+        CO_UNLOCK_OD(SDO->CANdevTx);
 
         if (odRet != ODR_OK && odRet != ODR_PARTIAL) {
             *abortCode = (CO_SDO_abortCode_t)OD_getSDOabCode(odRet);
@@ -858,16 +848,11 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 
                 /* Copy data */
                 OD_size_t countWritten = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-                const bool_t lock = true;
-#else
-                bool_t lock = OD_mappable(&SDO->OD_IO.stream);
-#endif
 
-                if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
+                CO_LOCK_OD(SDO->CANdevTx);
                 ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, buf,
                                                dataSizeToWrite, &countWritten);
-                if (lock) { CO_UNLOCK_OD(SDO->CANdevTx); }
+                CO_UNLOCK_OD(SDO->CANdevTx);
 
                 if (odRet != ODR_OK) {
                     abortCode = (CO_SDO_abortCode_t)OD_getSDOabCode(odRet);
@@ -1311,16 +1296,11 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 #else /* Expedited transfer only */
             /* load data from OD variable */
             OD_size_t count = 0;
-#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD
-            const bool_t lock = true;
-#else
-            bool_t lock = OD_mappable(&SDO->OD_IO.stream);
-#endif
 
-            if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
+            CO_LOCK_OD(SDO->CANdevTx);
             ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream,
                                           &SDO->CANtxBuff->data[4], 4, &count);
-            if (lock) { CO_UNLOCK_OD(SDO->CANdevTx); }
+            CO_UNLOCK_OD(SDO->CANdevTx);
 
             /* strings are allowed to be shorter */
             if (odRet == ODR_PARTIAL

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -551,9 +551,13 @@ static bool_t validateAndWriteToOD(CO_SDOserver_t *SDO,
 
     /* write data */
     OD_size_t countWritten = 0;
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+    const bool_t lock = true;
+#else
     bool_t lock = OD_mappable(&SDO->OD_IO.stream);
-
+#endif
     if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
+
     ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, SDO->buf,
                                    SDO->bufOffsetWr, &countWritten);
     if (lock) { CO_UNLOCK_OD(SDO->CANdevTx); }
@@ -613,7 +617,11 @@ static bool_t readFromOd(CO_SDOserver_t *SDO,
         /* load data from OD variable into the buffer */
         OD_size_t countRd = 0;
         uint8_t *bufShifted = SDO->buf + countRemain;
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+        const bool_t lock = true;
+#else
         bool_t lock = OD_mappable(&SDO->OD_IO.stream);
+#endif
 
         if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
         ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, bufShifted,
@@ -850,7 +858,11 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 
                 /* Copy data */
                 OD_size_t countWritten = 0;
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+                const bool_t lock = true;
+#else
                 bool_t lock = OD_mappable(&SDO->OD_IO.stream);
+#endif
 
                 if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
                 ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, buf,
@@ -1299,7 +1311,11 @@ CO_SDO_return_t CO_SDOserver_process(CO_SDOserver_t *SDO,
 #else /* Expedited transfer only */
             /* load data from OD variable */
             OD_size_t count = 0;
+#if (CO_CONFIG_SDO_SRV) & CO_CONFIG_FLAG_ALWAYS_LOCK_OD
+            const bool_t lock = true;
+#else
             bool_t lock = OD_mappable(&SDO->OD_IO.stream);
+#endif
 
             if (lock) { CO_LOCK_OD(SDO->CANdevTx); }
             ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream,

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -100,18 +100,6 @@ extern "C" {
  */
 #define CO_CONFIG_FLAG_OD_DYNAMIC 0x4000
 
-/**
- * Always lock the Object Dictionary when doing a SDO read/write
- *
- * By default the Object Dictionary is only locked if a Object Dictionary variable
- * is mappable to a PDO or SRDO. If your application uses a RTOS with multiple
- * tasks accessing the Object Dictionary, you want to lock the Object Dictionary on
- * every SDO read/write.
- *
- * This flag is common to multiple configuration macros.
- */
-#define CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD 0x8000
-
 /** This flag may be set globally for mainline objects to
  * @ref CO_CONFIG_FLAG_CALLBACK_PRE */
 #ifdef CO_DOXYGEN
@@ -132,11 +120,6 @@ extern "C" {
 /** This flag may be set globally to (0) */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC CO_CONFIG_FLAG_OD_DYNAMIC
-#endif
-
-/** This flag may be set globally to @ref CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD */
-#ifdef CO_DOXYGEN
-#define CO_CONFIG_GLOBAL_FLAG_SDO_ALWAYS_LOCK_OD (0)
 #endif
 /** @} */ /* CO_STACK_CONFIG_COMMON */
 
@@ -346,10 +329,9 @@ extern "C" {
  *   inside CO_SDOserver_process().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of additional SDO
  *   servers (Writing to object 0x1201+ re-configures the additional server).
- * - #CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
-#define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT | CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC | CO_CONFIG_GLOBAL_FLAG_ALWAYS_LOCK_OD)
+#define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT | CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC)
 #endif
 #define CO_CONFIG_SDO_SRV_SEGMENTED 0x02
 #define CO_CONFIG_SDO_SRV_BLOCK 0x04
@@ -385,7 +367,6 @@ extern "C" {
  *   CO_SDOclientUploadInitiate(), CO_SDOclientUpload().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of SDO clients
  *   (Writing to object 0x1280+ re-configures the client).
- * - #CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_SDO_CLI (0)

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -101,15 +101,16 @@ extern "C" {
 #define CO_CONFIG_FLAG_OD_DYNAMIC 0x4000
 
 /**
- * Always lock the Object Dictionary using the CO_LOCK_OD / CO_UNLOCK_OD macros
+ * Always lock the Object Dictionary when doing a SDO read/write
  *
  * By default the Object Dictionary is only locked if a Object Dictionary variable
- * is mappable to a PDO or SRDO. If your application uses a RTOS with multiple tasks
- * using the Object Dictionary, you want to lock the Object Dictionary on every read/write.
+ * is mappable to a PDO or SRDO. If your application uses a RTOS with multiple
+ * tasks accessing the Object Dictionary, you want to lock the Object Dictionary on
+ * every SDO read/write.
  *
  * This flag is common to multiple configuration macros.
  */
-#define CO_CONFIG_FLAG_ALWAYS_LOCK_OD 0x8000
+#define CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD 0x8000
 
 /** This flag may be set globally for mainline objects to
  * @ref CO_CONFIG_FLAG_CALLBACK_PRE */
@@ -133,9 +134,9 @@ extern "C" {
 #define CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC CO_CONFIG_FLAG_OD_DYNAMIC
 #endif
 
-/** This flag may be set globally to @ref CO_CONFIG_FLAG_ALWAYS_LOCK_OD */
+/** This flag may be set globally to @ref CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD */
 #ifdef CO_DOXYGEN
-#define CO_CONFIG_GLOBAL_FLAG_ALWAYS_LOCK_OD (0)
+#define CO_CONFIG_GLOBAL_FLAG_SDO_ALWAYS_LOCK_OD (0)
 #endif
 /** @} */ /* CO_STACK_CONFIG_COMMON */
 
@@ -345,7 +346,7 @@ extern "C" {
  *   inside CO_SDOserver_process().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of additional SDO
  *   servers (Writing to object 0x1201+ re-configures the additional server).
- * - #CO_CONFIG_FLAG_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
+ * - #CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT | CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC | CO_CONFIG_GLOBAL_FLAG_ALWAYS_LOCK_OD)
@@ -384,7 +385,7 @@ extern "C" {
  *   CO_SDOclientUploadInitiate(), CO_SDOclientUpload().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of SDO clients
  *   (Writing to object 0x1280+ re-configures the client).
- * - #CO_CONFIG_FLAG_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
+ * - #CO_CONFIG_FLAG_SDO_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_SDO_CLI (0)

--- a/301/CO_config.h
+++ b/301/CO_config.h
@@ -100,6 +100,17 @@ extern "C" {
  */
 #define CO_CONFIG_FLAG_OD_DYNAMIC 0x4000
 
+/**
+ * Always lock the Object Dictionary using the CO_LOCK_OD / CO_UNLOCK_OD macros
+ *
+ * By default the Object Dictionary is only locked if a Object Dictionary variable
+ * is mappable to a PDO or SRDO. If your application uses a RTOS with multiple tasks
+ * using the Object Dictionary, you want to lock the Object Dictionary on every read/write.
+ *
+ * This flag is common to multiple configuration macros.
+ */
+#define CO_CONFIG_FLAG_ALWAYS_LOCK_OD 0x8000
+
 /** This flag may be set globally for mainline objects to
  * @ref CO_CONFIG_FLAG_CALLBACK_PRE */
 #ifdef CO_DOXYGEN
@@ -120,6 +131,11 @@ extern "C" {
 /** This flag may be set globally to (0) */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC CO_CONFIG_FLAG_OD_DYNAMIC
+#endif
+
+/** This flag may be set globally to @ref CO_CONFIG_FLAG_ALWAYS_LOCK_OD */
+#ifdef CO_DOXYGEN
+#define CO_CONFIG_GLOBAL_FLAG_ALWAYS_LOCK_OD (0)
 #endif
 /** @} */ /* CO_STACK_CONFIG_COMMON */
 
@@ -329,9 +345,10 @@ extern "C" {
  *   inside CO_SDOserver_process().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of additional SDO
  *   servers (Writing to object 0x1201+ re-configures the additional server).
+ * - #CO_CONFIG_FLAG_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
-#define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT | CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC)
+#define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT | CO_CONFIG_GLOBAL_FLAG_OD_DYNAMIC | CO_CONFIG_GLOBAL_FLAG_ALWAYS_LOCK_OD)
 #endif
 #define CO_CONFIG_SDO_SRV_SEGMENTED 0x02
 #define CO_CONFIG_SDO_SRV_BLOCK 0x04
@@ -367,6 +384,7 @@ extern "C" {
  *   CO_SDOclientUploadInitiate(), CO_SDOclientUpload().
  * - #CO_CONFIG_FLAG_OD_DYNAMIC - Enable dynamic configuration of SDO clients
  *   (Writing to object 0x1280+ re-configures the client).
+ * - #CO_CONFIG_FLAG_ALWAYS_LOCK_OD - Always lock object dictionary (regardless if OD var is PDO/SRDO mappable)
  */
 #ifdef CO_DOXYGEN
 #define CO_CONFIG_SDO_CLI (0)

--- a/301/CO_driver.h
+++ b/301/CO_driver.h
@@ -418,16 +418,15 @@ typedef struct {
  * variable. CO_LOCK_OD(CAN_MODULE) and CO_UNLOCK_OD(CAN_MODULE) macros
  * are used to protect:
  * - Whole real-time thread,
- * - SDO server protects read/write access to OD variable, if specific OD
- *   variable has ODA_TRPDO or ODA_TRSRDO from @ref OD_attributes_t set. If
- *   those attributes are not set, OD variable is not locked by SDO server.
+ * - SDO server protects read/write access to OD variable.
  *   Locking of long OD variables, not accessible from real-time thread, may
  *   block RT thread.
  * - Any mainline code, which accesses PDO-mappable OD variable, must protect
  *   read/write with locking macros. Use @ref OD_mappable() for check.
  * - Other cases, where non-PDO-mappable OD variable is used inside real-time
  *   thread by some other part of the user application must be considered with
- *   special care.
+ *   special care. Also when there are multiple threads accessing the OD (e.g.
+ *   when using a RTOS), you should always lock the OD.
  *
  * #### Synchronization functions for CAN receive
  * After CAN message is received, it is pre-processed in CANrx_callback(), which


### PR DESCRIPTION
Add CO_CONFIG_FLAG_ALWAYS_LOCK_OD which can be used to lock the Object Dictionary for every SDO read/write operation. This is needed when you have a RTOS with multiple tasks accessing the Object Dictionary.
Modify the code in CO_SDOserver.c and CO_SDOclient.c to check this config flag.