### PR TITLE
Fix example tx bus warning checking

### DIFF
--- a/example/CO_driver_blank.c
+++ b/example/CO_driver_blank.c
@@ -290,7 +290,7 @@ void CO_CANmodule_process(CO_CANmodule_t *CANmodule) {
             /* tx bus warning or passive */
             if (txErrors >= 128) {
                 status |= CO_CAN_ERRTX_WARNING | CO_CAN_ERRTX_PASSIVE;
-            } else if (rxErrors >= 96) {
+            } else if (txErrors >= 96) {
                 status |= CO_CAN_ERRTX_WARNING;
             }
 


### PR DESCRIPTION
I think there is copy-paste error in the example and the `rxErrors` should be replaced by `txErrors` when the tx bus warning is checked.