### PR TITLE
Fix bit shifting in CO_driver_blank/CO_CANtxBufferInit 

### DIFF
--- a/example/CO_driver_blank.c
+++ b/example/CO_driver_blank.c
@@ -178,7 +178,7 @@ CO_CANtx_t *CO_CANtxBufferInit(
         /* CAN identifier, DLC and rtr, bit aligned with CAN module transmit buffer.
          * Microcontroller specific. */
         buffer->ident = ((uint32_t)ident & 0x07FFU)
-                      | ((uint32_t)(((uint32_t)noOfBytes & 0xFU) << 12U))
+                      | ((uint32_t)(((uint32_t)noOfBytes & 0xFU) << 11U))
                       | ((uint32_t)(rtr ? 0x8000U : 0U));
 
         buffer->bufferFull = false;


### PR DESCRIPTION
TLDR:
Shifting ```noOfBytes``` by 12 is wrong, as it can overlap RTR bit, so all TX packets with 8 bytes payload will be RTR packets.

Details:
I developed my custom driver based on CO_driver_blank. I didn't care about how exactly CAN-ID, DLC and RTR bits are packed in the ```buffer.ident```, I just unpacked them later to send to the low-level driver, and figured out the packing was wrong.

I know it is just an example driver, but this small fix will probably save some time to someone else :)