### PR TITLE
fix bug in check nodeId in CO_LSSmaster.c file

### DIFF
--- a/305/CO_LSSmaster.c
+++ b/305/CO_LSSmaster.c
@@ -478,7 +478,7 @@ CO_LSSmaster_return_t CO_LSSmaster_configureNodeId(
     if ((LSSmaster->state==CO_LSSmaster_STATE_CFG_SLECTIVE ||
         /* Let un-config node ID also be run in global mode for unconfiguring all nodes */
         (LSSmaster->state==CO_LSSmaster_STATE_CFG_GLOBAL &&
-         nodeId == CO_LSS_NODE_ID_ASSIGNMENT)) &&
+         nodeId != CO_LSS_NODE_ID_ASSIGNMENT)) &&
          LSSmaster->command==CO_LSSmaster_COMMAND_WAITING) {
 
         LSSmaster->command = CO_LSSmaster_COMMAND_CFG_NODE_ID;


### PR DESCRIPTION
when this function get nodeId to send on the bus to set new nodeId to new slave device, in line 481 nodeId compare with CO_LSS_NODE_ID_ASSIGNMENT (a fixed value) so all time this condition false and lss_set_node command fails.