### PR TITLE
Decorate crc16 functions with CO

### DIFF
--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -454,7 +454,7 @@ validateAndWriteToOD(CO_SDOserver_t* SDO, CO_SDO_abortCode_t* abortCode, uint8_t
 #if ((CO_CONFIG_SDO_SRV)&CO_CONFIG_SDO_SRV_BLOCK) != 0
     /* calculate crc on current data */
     if (SDO->block_crcEnabled && crcOperation > 0) {
-        SDO->block_crc = crc16_ccitt(SDO->buf, bufOffsetWrOrig, SDO->block_crc);
+        SDO->block_crc = CO_crc16_ccitt(SDO->buf, bufOffsetWrOrig, SDO->block_crc);
         if (crcOperation == 2 && crcClient != SDO->block_crc) {
             *abortCode = CO_SDO_AB_CRC;
             SDO->state = CO_SDO_ST_ABORT;
@@ -580,7 +580,7 @@ readFromOd(CO_SDOserver_t* SDO, CO_SDO_abortCode_t* abortCode, OD_size_t countMi
 #if ((CO_CONFIG_SDO_SRV)&CO_CONFIG_SDO_SRV_BLOCK) != 0
         /* update the crc */
         if (calculateCrc && SDO->block_crcEnabled) {
-            SDO->block_crc = crc16_ccitt(&SDO->buf[countRemain], countRd, SDO->block_crc);
+            SDO->block_crc = CO_crc16_ccitt(&SDO->buf[countRemain], countRd, SDO->block_crc);
         }
 #endif
     }
@@ -941,7 +941,7 @@ CO_SDOserver_process(CO_SDOserver_t* SDO, bool_t NMTisPreOrOperational, uint32_t
                         /* data were already loaded from OD variable, verify crc */
                         if ((SDO->CANrxData[0] & 0x04) != 0) {
                             SDO->block_crcEnabled = true;
-                            SDO->block_crc = crc16_ccitt(SDO->buf, SDO->bufOffsetWr, 0);
+                            SDO->block_crc = CO_crc16_ccitt(SDO->buf, SDO->bufOffsetWr, 0);
                         } else {
                             SDO->block_crcEnabled = false;
                         }

--- a/301/CO_fifo.c
+++ b/301/CO_fifo.c
@@ -97,7 +97,7 @@ CO_fifo_write(CO_fifo_t* fifo, const uint8_t* buf, size_t count, uint16_t* crc) 
 
 #if ((CO_CONFIG_FIFO)&CO_CONFIG_FIFO_CRC16_CCITT) != 0
         if (crc != NULL) {
-            crc16_ccitt_single(crc, *buf);
+            CO_crc16_ccitt_single(crc, *buf);
         }
 #endif
 
@@ -199,7 +199,7 @@ CO_fifo_altFinish(CO_fifo_t* fifo, uint16_t* crc) {
         const uint8_t* bufSrc = &fifo->buf[fifo->readPtr];
         while (fifo->readPtr != fifo->altReadPtr) {
 #if ((CO_CONFIG_FIFO)&CO_CONFIG_FIFO_CRC16_CCITT) != 0
-            crc16_ccitt_single(crc, *bufSrc);
+            CO_crc16_ccitt_single(crc, *bufSrc);
 #endif
             /* increment variable */
             if (++fifo->readPtr == fifo->bufSize) {

--- a/301/crc16-ccitt.c
+++ b/301/crc16-ccitt.c
@@ -63,13 +63,13 @@ static const uint16_t crc16_ccitt_table[256] = {
     0x9FF8U, 0x6E17U, 0x7E36U, 0x4E55U, 0x5E74U, 0x2E93U, 0x3EB2U, 0x0ED1U, 0x1EF0U};
 
 void
-crc16_ccitt_single(uint16_t* crc, const uint8_t chr) {
+CO_crc16_ccitt_single(uint16_t* crc, const uint8_t chr) {
     uint8_t tmp = (uint8_t)(*crc >> 8U) ^ chr;
     *crc = (uint16_t)((*crc << 8U) ^ crc16_ccitt_table[tmp]);
 }
 
 uint16_t
-crc16_ccitt(const uint8_t block[], size_t blockLength, uint16_t crc) {
+CO_crc16_ccitt(const uint8_t block[], size_t blockLength, uint16_t crc) {
     size_t i;
 
     for (i = 0U; i < blockLength; i++) {

--- a/301/crc16-ccitt.h
+++ b/301/crc16-ccitt.h
@@ -19,8 +19,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-#ifndef CRC16_CCITT_H
-#define CRC16_CCITT_H
+#ifndef CO_CRC16_CCITT_H
+#define CO_CRC16_CCITT_H
 
 #include "301/CO_driver.h"
 
@@ -55,7 +55,7 @@ extern "C" {
  * be initialized (zero for xmodem).
  * @param chr One byte of data
  */
-void crc16_ccitt_single(uint16_t* crc, const uint8_t chr);
+void CO_crc16_ccitt_single(uint16_t* crc, const uint8_t chr);
 
 /**
  * Calculate CRC sum on block of data.
@@ -67,7 +67,7 @@ void crc16_ccitt_single(uint16_t* crc, const uint8_t chr);
  *
  * @return Calculated CRC.
  */
-uint16_t crc16_ccitt(const uint8_t block[], size_t blockLength, uint16_t crc);
+uint16_t CO_crc16_ccitt(const uint8_t block[], size_t blockLength, uint16_t crc);
 
 /** @} */ /* CO_crc16_ccitt */
 
@@ -77,4 +77,4 @@ uint16_t crc16_ccitt(const uint8_t block[], size_t blockLength, uint16_t crc);
 
 #endif /* (CO_CONFIG_CRC16) & CO_CONFIG_CRC16_ENABLE */
 
-#endif /* CRC16_CCITT_H */
+#endif /* CO_CRC16_CCITT_H */

--- a/304/CO_SRDO.c
+++ b/304/CO_SRDO.c
@@ -512,20 +512,20 @@ CO_SRDO_config(CO_SRDO_t* SRDO, uint8_t SRDO_Index, CO_SRDOGuard_t* SRDOGuard, u
         uint16_t tmp_u16;
         uint32_t tmp_u32;
 
-        crcResult = crc16_ccitt(&informationDirection, 1, crcResult);
+        crcResult = CO_crc16_ccitt(&informationDirection, 1, crcResult);
         tmp_u16 = CO_SWAP_16(safetyCycleTime);
-        crcResult = crc16_ccitt((uint8_t*)&tmp_u16, 2, crcResult);
-        crcResult = crc16_ccitt(&safetyRelatedValidationTime, 1, crcResult);
+        crcResult = CO_crc16_ccitt((uint8_t*)&tmp_u16, 2, crcResult);
+        crcResult = CO_crc16_ccitt(&safetyRelatedValidationTime, 1, crcResult);
         tmp_u32 = CO_SWAP_32(COB_ID1_normal);
-        crcResult = crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
+        crcResult = CO_crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
         tmp_u32 = CO_SWAP_32(COB_ID2_inverted);
-        crcResult = crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
-        crcResult = crc16_ccitt(&mappedObjectsCount, 1, crcResult);
+        crcResult = CO_crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
+        crcResult = CO_crc16_ccitt(&mappedObjectsCount, 1, crcResult);
         for (uint8_t i = 0; i < mappedObjectsCount; i++) {
             uint8_t crcsubindex = i + 1U;
-            crcResult = crc16_ccitt(&crcsubindex, 1, crcResult);
+            crcResult = CO_crc16_ccitt(&crcsubindex, 1, crcResult);
             tmp_u32 = CO_SWAP_32(mapping[i]);
-            crcResult = crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
+            crcResult = CO_crc16_ccitt((uint8_t*)&tmp_u32, 4, crcResult);
         }
 
         if (crcResult != crcSignatureFromOD) {

--- a/storage/CO_storageEeprom.c
+++ b/storage/CO_storageEeprom.c
@@ -35,7 +35,7 @@ storeEeprom(CO_storage_entry_t* entry, CO_CANmodule_t* CANmodule) {
 
     /* save data to the eeprom */
     writeOk = CO_eeprom_writeBlock(entry->storageModule, entry->addr, entry->eepromAddr, entry->len);
-    entry->crc = crc16_ccitt(entry->addr, entry->len, 0);
+    entry->crc = CO_crc16_ccitt(entry->addr, entry->len, 0);
 
     /* Verify, if data in eeprom are equal */
     uint16_t crc_read = CO_eeprom_getCrcBlock(entry->storageModule, entry->eepromAddr, entry->len);
@@ -160,7 +160,7 @@ CO_storageEeprom_init(CO_storage_t* storage, CO_CANmodule_t* CANmodule, void* st
 
             /* Verify CRC, except for auto storage variables */
             if (!isAuto) {
-                uint16_t crc = crc16_ccitt(entry->addr, entry->len, 0);
+                uint16_t crc = CO_crc16_ccitt(entry->addr, entry->len, 0);
                 if (crc != entry->crc) {
                     dataCorrupt = true;
                 }


### PR DESCRIPTION
The crc16_ccitt function has always been an odd duck since it does not follow the same naming conventions as the rest of CANopenNode. This commit adds a "CO_" decorator to the crc functions so that they no longer conflict with other frameworks that implement CRC. For example Zephyr provides a crc16_ccitt function with a different (and incompatible) signature.