### PR TITLE
Define the ODR return variable before it is assigned for critical access

### DIFF
--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -524,10 +524,11 @@ CO_SDOclientDownload(CO_SDOclient_t* SDO_C, uint32_t timeDifference_us, bool_t s
 
             if (abortCode == CO_SDO_AB_NONE) {
                 OD_size_t countWritten = 0;
+                ODR_t odRet;
 
                 /* write data to Object Dictionary */
                 CO_LOCK_OD(SDO_C->CANdevTx);
-                ODR_t odRet = SDO_C->OD_IO.write(&SDO_C->OD_IO.stream, buf, (OD_size_t)count, &countWritten);
+                odRet = SDO_C->OD_IO.write(&SDO_C->OD_IO.stream, buf, (OD_size_t)count, &countWritten);
                 CO_UNLOCK_OD(SDO_C->CANdevTx);
 
                 /* verify for errors in write */
@@ -1135,10 +1136,11 @@ CO_SDOclientUpload(CO_SDOclient_t* SDO_C, uint32_t timeDifference_us, bool_t sen
             OD_size_t countBuf = ((countData > 0U) && (countData <= countFifo)) ? countData : (OD_size_t)countFifo;
             OD_size_t countRd = 0;
             uint8_t buf[CO_CONFIG_SDO_CLI_BUFFER_SIZE + 1U];
+            ODR_t odRet;
 
             /* load data from OD variable into the buffer */
             CO_LOCK_OD(SDO_C->CANdevTx);
-            ODR_t odRet = SDO_C->OD_IO.read(&SDO_C->OD_IO.stream, buf, countBuf, &countRd);
+            odRet = SDO_C->OD_IO.read(&SDO_C->OD_IO.stream, buf, countBuf, &countRd);
             CO_UNLOCK_OD(SDO_C->CANdevTx);
 
             if ((odRet != ODR_OK) && (odRet != ODR_PARTIAL)) {

--- a/301/CO_SDOserver.c
+++ b/301/CO_SDOserver.c
@@ -469,9 +469,10 @@ validateAndWriteToOD(CO_SDOserver_t* SDO, CO_SDO_abortCode_t* abortCode, uint8_t
 
     /* write data */
     OD_size_t countWritten = 0;
+    ODR_t odRet;
 
     CO_LOCK_OD(SDO->CANdevTx);
-    ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, SDO->buf, SDO->bufOffsetWr, &countWritten);
+    odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, SDO->buf, SDO->bufOffsetWr, &countWritten);
     CO_UNLOCK_OD(SDO->CANdevTx);
 
     SDO->bufOffsetWr = 0;
@@ -523,9 +524,10 @@ readFromOd(CO_SDOserver_t* SDO, CO_SDO_abortCode_t* abortCode, OD_size_t countMi
 
         /* load data from OD variable into the buffer */
         OD_size_t countRd = 0;
+        ODR_t odRet;
 
         CO_LOCK_OD(SDO->CANdevTx);
-        ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, &SDO->buf[countRemain], countRdRequest, &countRd);
+        odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, &SDO->buf[countRemain], countRdRequest, &countRd);
         CO_UNLOCK_OD(SDO->CANdevTx);
 
         if ((odRet != ODR_OK) && (odRet != ODR_PARTIAL)) {
@@ -742,9 +744,10 @@ CO_SDOserver_process(CO_SDOserver_t* SDO, bool_t NMTisPreOrOperational, uint32_t
 
                         /* Copy data */
                         OD_size_t countWritten = 0;
+                        ODR_t odRet;
 
                         CO_LOCK_OD(SDO->CANdevTx);
-                        ODR_t odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, buf, dataSizeToWrite, &countWritten);
+                        odRet = SDO->OD_IO.write(&SDO->OD_IO.stream, buf, dataSizeToWrite, &countWritten);
                         CO_UNLOCK_OD(SDO->CANdevTx);
 
                         if (odRet != ODR_OK) {
@@ -1194,9 +1197,10 @@ CO_SDOserver_process(CO_SDOserver_t* SDO, bool_t NMTisPreOrOperational, uint32_t
 #else /* Expedited transfer only */
                 /* load data from OD variable */
                 OD_size_t count = 0;
+                ODR_t odRet;
 
                 CO_LOCK_OD(SDO->CANdevTx);
-                ODR_t odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, &SDO->CANtxBuff->data[4], 4, &count);
+                odRet = SDO->OD_IO.read(&SDO->OD_IO.stream, &SDO->CANtxBuff->data[4], 4, &count);
                 CO_UNLOCK_OD(SDO->CANdevTx);
 
                 /* strings are allowed to be shorter */


### PR DESCRIPTION
The variable is defined and assigned within the critical section, which prevents the critical section execution like:

```c
#define CO_LOCK_OD(...) do { /* Disable interrupts here */
#define CO_UNLOCK_OD(...) }while(0)
```

Such code generates its own local block and:
- Throws out compilation error if for whatever reason user wrongly calls lock/unlock or calls them too many times
- allows the use of local variable for interrupts state before interrupts are disabled.

Please check this issue: https://github.com/CANopenNode/CanOpenSTM32/issues/34#issuecomment-2948859635
