### PR TITLE
Fix dereference before NULL check

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -75,7 +75,10 @@ static CO_ReturnError_t CO_HBconsumer_initEntry(CO_HBconsumer_t* HBcons, uint8_t
  */
 static ODR_t
 OD_write_1016(OD_stream_t* stream, const void* buf, OD_size_t count, OD_size_t* countWritten) {
-    CO_HBconsumer_t* HBcons = stream->object;
+    CO_HBconsumer_t* HBcons;
+    if (stream != NULL) {
+        HBcons = stream->object;
+    }
 
     if ((stream == NULL) || (buf == NULL) || (stream->subIndex < 1U)
         || (stream->subIndex > HBcons->numberOfMonitoredNodes) || (count != sizeof(uint32_t))


### PR DESCRIPTION
The `stream->object` was dereferenced before the check that `stream` was not `NULL`.  This caused an error when compiling with `-fanalyzer`.

```log
CANopen/CANopen-lib/CANopenNode/301/CO_HBconsumer.c:80:8: error: check of 'stream' for NULL after already dereferencing it [-Werror=analyzer-deref-before-check]
   80 |     if ((stream == NULL) || (buf == NULL) || (stream->subIndex < 1U)
      |        ^
  'OD_write_1016': events 1-2
    |
    |   78 |     CO_HBconsumer_t* HBcons = stream->object;
    |      |                      ^~~~~~
    |      |                      |
    |      |                      (1) pointer 'stream' is dereferenced here
    |   79 | 
    |   80 |     if ((stream == NULL) || (buf == NULL) || (stream->subIndex < 1U)
    |      |        ~              
    |      |        |
    |      |        (2) pointer 'stream' is checked for NULL here but it was already dereferenced at (1)
    |
cc1.exe: all warnings being treated as errors
```

This PR fixes the error by checking `stream` before dereferencing `object`.