### PR TITLE
Refine #585

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -76,11 +76,13 @@ static CO_ReturnError_t CO_HBconsumer_initEntry(CO_HBconsumer_t* HBcons, uint8_t
 static ODR_t
 OD_write_1016(OD_stream_t* stream, const void* buf, OD_size_t count, OD_size_t* countWritten) {
     CO_HBconsumer_t* HBcons;
-    if (stream != NULL) {
-        HBcons = stream->object;
-    }
 
-    if ((stream == NULL) || (buf == NULL) || (stream->subIndex < 1U)
+    if (stream == NULL) {
+        return ODR_DEV_INCOMPAT;
+    }
+    HBcons = stream->object;
+
+    if ((buf == NULL) || (stream->subIndex < 1U)
         || (stream->subIndex > HBcons->numberOfMonitoredNodes) || (count != sizeof(uint32_t))
         || (countWritten == NULL)) {
         return ODR_DEV_INCOMPAT;


### PR DESCRIPTION
In MR #585 the initialization of HBcons has been protected from dereferencing stream if it's NULL. However, the logic is now twisted enough to provoke a maybe-uninitialized warning in GCC 13. While this is strictly a false positive since the generated code would never dereference HBcons if stream == NULL this patch refines the code to be easier to read for compilers and humans alike by returning early if stream == NULL.

I kept the changed lines to a minimum. You may want to reformat the big if clause.