### PR TITLE
Fix some warnings including issue #610.

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -18,6 +18,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+#include <stdint.h>
+
 #include "301/CO_HBconsumer.h"
 
 #if ((CO_CONFIG_HB_CONS)&CO_CONFIG_HB_CONS_ENABLE) != 0
@@ -91,7 +93,7 @@ OD_write_1016(OD_stream_t* stream, const void* buf, OD_size_t count, OD_size_t* 
     uint32_t val = CO_getUint32(buf);
     uint8_t nodeId = (uint8_t)((val >> 16) & 0xFFU);
     uint16_t consumer_time = (uint16_t)(val & 0xFFFFU);
-    CO_ReturnError_t ret = CO_HBconsumer_initEntry(HBcons, stream->subIndex - 1U, nodeId, consumer_time);
+    CO_ReturnError_t ret = CO_HBconsumer_initEntry(HBcons, stream->subIndex - (uint8_t)1U, nodeId, consumer_time);
     if (ret != CO_ERROR_NO) {
         return ODR_PAR_INCOMPAT;
     }
@@ -120,8 +122,8 @@ CO_HBconsumer_init(CO_HBconsumer_t* HBcons, CO_EM_t* em, CO_HBconsNode_t* monito
     HBcons->CANdevRxIdxStart = CANdevRxIdxStart;
 
     /* get actual number of monitored nodes */
-    HBcons->numberOfMonitoredNodes = ((OD_1016_HBcons->subEntriesCount - 1U) < monitoredNodesCount)
-                                         ? (OD_1016_HBcons->subEntriesCount - 1U)
+    HBcons->numberOfMonitoredNodes = ((OD_1016_HBcons->subEntriesCount - (uint8_t)1U) < monitoredNodesCount)
+                                         ? (OD_1016_HBcons->subEntriesCount - (uint8_t)1U)
                                          : monitoredNodesCount;
 
     for (uint8_t i = 0; i < HBcons->numberOfMonitoredNodes; i++) {

--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -21,6 +21,8 @@
 #ifndef CO_HB_CONS_H
 #define CO_HB_CONS_H
 
+#include <stdint.h>
+
 #include "301/CO_driver.h"
 #include "301/CO_ODinterface.h"
 #include "301/CO_NMT_Heartbeat.h"

--- a/301/CO_ODinterface.c
+++ b/301/CO_ODinterface.c
@@ -17,7 +17,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+#include <stdint.h>
 #include <string.h>
+
 #define OD_DEFINITION
 #include "301/CO_ODinterface.h"
 
@@ -143,13 +145,13 @@ OD_find(OD_t* od, uint16_t index) {
     }
 
     uint16_t min = 0;
-    uint16_t max = od->size - 1U;
+    uint16_t max = od->size - (uint16_t)1U;
 
     /* Fast search in ordered Object Dictionary. If indexes are mixed, this won't work. If Object
      * Dictionary has up to N entries, then the max number of loop passes is log2(N) */
     while (min < max) {
         /* get entry between min and max */
-        uint16_t cur = (min + max) >> 1;
+        uint16_t cur = (uint16_t)(min + max) >> 1;
         OD_entry_t* entry = &od->list[cur];
 
         if (index == entry->index) {
@@ -157,7 +159,7 @@ OD_find(OD_t* od, uint16_t index) {
         }
 
         if (index < entry->index) {
-            max = (cur > 0U) ? (cur - 1U) : cur;
+            max = (cur > 0U) ? (cur - (uint16_t)1U) : cur;
         } else {
             min = cur + 1U;
         }

--- a/301/CO_ODinterface.h
+++ b/301/CO_ODinterface.h
@@ -21,6 +21,8 @@
 #ifndef CO_OD_INTERFACE_H
 #define CO_OD_INTERFACE_H
 
+#include <stdint.h>
+
 #include "301/CO_driver.h"
 
 #ifdef __cplusplus
@@ -393,7 +395,7 @@ OD_requestTPDO(OD_entry_t* entry, uint8_t subIndex) {
 #if OD_FLAGS_PDO_SIZE > 0
     if ((entry != NULL) && (entry->extension != NULL) && (subIndex < (OD_FLAGS_PDO_SIZE * 8U))) {
         /* clear subIndex-th bit */
-        uint8_t mask = ~(1U << (subIndex & 0x07U));
+        uint8_t mask = (uint8_t)~(1U << (subIndex & 0x07U));
         entry->extension->flagsPDO[subIndex >> 3] &= mask;
     }
 #endif

--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -308,7 +308,7 @@ static CO_ReturnError_t
 PDO_initMapping(CO_PDO_common_t* PDO, OD_t* OD, OD_entry_t* OD_PDOMapPar, bool_t isRPDO, uint32_t* errInfo,
                 uint32_t* erroneousMap) {
     ODR_t odRet;
-    size_t pdoDataLength = 0;
+    uint8_t pdoDataLength = 0;
 
     /* number of mapped application objects in PDO */
     uint8_t mappedObjectsCount = 0;

--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -18,6 +18,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+#include <stdint.h>
 #include <string.h>
 
 #include "301/CO_PDO.h"
@@ -290,7 +291,7 @@ OD_write_PDO_mapping(OD_stream_t* stream, const void* buf, OD_size_t count, OD_s
         PDO->mappedObjectsCount = mappedObjectsCount;
     } else {
         uint32_t val = CO_getUint32(buf);
-        ODR_t odRet = PDOconfigMap(PDO, val, stream->subIndex - 1U, PDO->isRPDO, PDO->OD);
+        ODR_t odRet = PDOconfigMap(PDO, val, stream->subIndex - (uint8_t)1U, PDO->isRPDO, PDO->OD);
         if (odRet != ODR_OK) {
             return odRet;
         }

--- a/301/CO_PDO.h
+++ b/301/CO_PDO.h
@@ -21,6 +21,8 @@
 #ifndef CO_PDO_H
 #define CO_PDO_H
 
+#include <stdint.h>
+
 #include "301/CO_ODinterface.h"
 #include "301/CO_Emergency.h"
 #include "301/CO_SYNC.h"

--- a/example/CO_driver_blank.c
+++ b/example/CO_driver_blank.c
@@ -24,6 +24,7 @@
 
 void
 CO_CANsetConfigurationMode(void* CANptr) {
+    (void)(CANptr);
     /* Put CAN module in configuration mode */
 }
 
@@ -37,6 +38,7 @@ CO_CANsetNormalMode(CO_CANmodule_t* CANmodule) {
 CO_ReturnError_t
 CO_CANmodule_init(CO_CANmodule_t* CANmodule, void* CANptr, CO_CANrx_t rxArray[], uint16_t rxSize, CO_CANtx_t txArray[],
                   uint16_t txSize, uint16_t CANbitRate) {
+    (void)(CANbitRate);
     uint16_t i;
 
     /* verify arguments */

--- a/example/main_blank.c
+++ b/example/main_blank.c
@@ -20,6 +20,8 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "CANopen.h"
 #include "OD.h"
@@ -80,7 +82,7 @@ main(void) {
         log_printf("Error: Can't allocate memory\n");
         return 0;
     } else {
-        log_printf("Allocated %u bytes for CANopen objects\n", heapMemoryUsed);
+        log_printf("Allocated %" PRIu32 " bytes for CANopen objects\n", heapMemoryUsed);
     }
 
 #if (CO_CONFIG_STORAGE) & CO_CONFIG_STORAGE_ENABLE
@@ -138,7 +140,7 @@ main(void) {
                              activeNodeId, &errInfo);
         if (err != CO_ERROR_NO && err != CO_ERROR_NODE_ID_UNCONFIGURED_LSS) {
             if (err == CO_ERROR_OD_PARAMETERS) {
-                log_printf("Error: Object Dictionary entry 0x%X\n", errInfo);
+                log_printf("Error: Object Dictionary entry 0x%" PRIu32 "\n", errInfo);
             } else {
                 log_printf("Error: CANopen initialization failed: %d\n", err);
             }
@@ -148,7 +150,7 @@ main(void) {
         err = CO_CANopenInitPDO(CO, CO->em, OD, activeNodeId, &errInfo);
         if (err != CO_ERROR_NO && err != CO_ERROR_NODE_ID_UNCONFIGURED_LSS) {
             if (err == CO_ERROR_OD_PARAMETERS) {
-                log_printf("Error: Object Dictionary entry 0x%X\n", errInfo);
+                log_printf("Error: Object Dictionary entry 0x%" PRIu32 "\n", errInfo);
             } else {
                 log_printf("Error: PDO initialization failed: %d\n", err);
             }


### PR DESCRIPTION
This pull request fixes the issue of ticket #610. When merged you can close ticket #610.
Warnings regarding (printf) formatting when you use more strict compiler options / other platforms and should be portable now.
Some unused passed variables in functions are made void now.
It also adds <stdint.h> which are missing, but only for the touched files.