### PR TITLE
fix: gateway tok[20] too small — lss_activate_bitrate always fails

### DIFF
--- a/309/CO_gateway_ascii.c
+++ b/309/CO_gateway_ascii.c
@@ -599,7 +599,7 @@ CO_GTWA_process(CO_GTWA_t* gtwa, bool_t enable, uint32_t timeDifference_us, uint
      ***************************************************************************/
     /* if idle, search for new command, skip comments or empty lines */
     while (CO_fifo_CommSearch(&gtwa->commFifo, false) && (gtwa->state == CO_GTWA_ST_IDLE)) {
-        char tok[20];
+        char tok[21];
         size_t n;
         uint32_t ui[3];
         int32_t i;


### PR DESCRIPTION
## Problem

The local command token buffer in CO_GTWA_process() is char tok[20]. The command string lss_activate_bitrate is exactly 20 characters.

CO_fifo_readToken() is called with count = sizeof(tok) = 20. Inside that function, when 	okenSize == count the overflow guard fires: *err = true and the token is discarded as if it overflowed. The command therefore **always fails with a syntax error** and can never be executed.

Root cause (from 301/CO_fifo.c):
`c
if (tokenSize == count) {   // overflow detected
    tokenSize = 0;          // discard
    *err = true;
}
`

The buffer needs at least **21 bytes** (20 chars + null terminator).

## Fix

One-character change: char tok[20] → char tok[21].

Fixes #623.