### PR TITLE
fix: CO_EM_RPDO_WRONG_LENGTH at wrong error bit position (0x04 info → 0x10 critical)

### DIFF
--- a/301/CO_Emergency.h
+++ b/301/CO_Emergency.h
@@ -182,7 +182,7 @@ extern "C" {
 #define CO_EM_CAN_BUS_WARNING           0x01U /**< 0x01 communication info CAN bus warning limit reached */
 #define CO_EM_RXMSG_WRONG_LENGTH        0x02U /**< 0x02 communication info Wrong data length of the received CAN message */
 #define CO_EM_RXMSG_OVERFLOW            0x03U /**< 0x03 communication info Previous received CAN message wasn't processed */
-#define CO_EM_RPDO_WRONG_LENGTH         0x04U /**< 0x04 communication info Wrong data length of received PDO */
+#define CO_EM_04_unused                 0x04U /**< 0x04 communication info (unused) */
 #define CO_EM_RPDO_OVERFLOW             0x05U /**< 0x05 communication info Previous received PDO wasn't processed yet */
 #define CO_EM_CAN_RX_BUS_PASSIVE        0x06U /**< 0x06 communication info CAN receive bus is passive */
 #define CO_EM_CAN_TX_BUS_PASSIVE        0x07U /**< 0x07 communication info CAN transmit bus is passive */
@@ -195,7 +195,7 @@ extern "C" {
 #define CO_EM_0E_unused                 0x0EU /**< 0x0E communication info (unused) */
 #define CO_EM_0F_unused                 0x0FU /**< 0x0F communication info (unused) */
 
-#define CO_EM_10_unused                 0x10U /**< 0x10 communication critical (unused) */
+#define CO_EM_RPDO_WRONG_LENGTH         0x10U /**< 0x10 communication critical Wrong data length of received PDO */
 #define CO_EM_11_unused                 0x11U /**< 0x11 communication critical (unused) */
 #define CO_EM_CAN_TX_BUS_OFF            0x12U /**< 0x12 communication critical CAN transmit bus is off */
 #define CO_EM_CAN_RXB_OVERFLOW          0x13U /**< 0x13 communication critical CAN module receive buffer overflowed */


### PR DESCRIPTION
## Problem
`CO_EM_RPDO_WRONG_LENGTH` is currently defined as error status bit `0x04`:

```c
#define CO_EM_RPDO_WRONG_LENGTH  0x04U /**< 0x04 communication info Wrong data length of received PDO */
```

In CANopenNode it is the *bit index* of an error-status bit — not the emergency error code — that decides whether a condition is treated as **informational** or **critical**. Critical bits set the matching flag in the Error register (OD `0x1001`); informational bits only emit an EMCY message.

The communication flag of the Error register (`CO_ERR_REG_COMMUNICATION`, `0x1001` bit 4) is computed by `CO_CONFIG_ERR_CONDITION_COMMUNICATION`:

```c
#define CO_CONFIG_ERR_CONDITION_COMMUNICATION \
    ((em->errorStatusBits[2] != 0U) || (em->errorStatusBits[3] != 0U))
```

This inspects only `errorStatusBits[2]`/`[3]`, i.e. bit indices `0x10`–`0x1F` (the block the header labels *"communication critical"*). Bit `0x04` lives in `errorStatusBits[0]` (the *"communication info"* block), so it can never raise the communication bit in the Error register.

As a result, when `CO_RPDO_process()` (`301/CO_PDO.c`) handles a length-mismatched RPDO:

```c
uint16_t code = (RPDO->receiveError == CO_RPDO_RX_SHORT) ? CO_EMC_PDO_LENGTH : CO_EMC_PDO_LENGTH_EXC;
CO_error(PDO->em, setError, CO_EM_RPDO_WRONG_LENGTH, code, PDO->dataLength);
```

a too-short frame is **dropped and not processed** (`CO_EMC_PDO_LENGTH` = `0x8210`, *"PDO not processed due to length error"*), yet `0x1001` bit 4 is never set. A master or peer that monitors the Error register therefore sees a healthy node while it is silently discarding process data.

## Fix
Move `CO_EM_RPDO_WRONG_LENGTH` out of the informational block (`0x04`) into the communication-critical block, reusing the previously unused `0x10` slot, and rename the vacated index to `CO_EM_04_unused`:

```c
#define CO_EM_04_unused          0x04U /**< 0x04 communication info (unused) */
...
#define CO_EM_RPDO_WRONG_LENGTH  0x10U /**< 0x10 communication critical Wrong data length of received PDO */
```

The macro name is unchanged, so existing users (`CO_PDO.c`, `CO_SRDO.c`) keep compiling; only the classification changes, and a wrong-length RPDO now also raises the communication bit in OD `0x1001`.

## Standard basis / discussion
CiA 301 defines `0x1001` bit 4 as the generic *communication error* flag but does not enumerate every internal condition that must set it, so the info/critical split for individual bits is an implementation choice. Rationale for treating this as critical: a wrong-length RPDO is reported with a *Protocol Error* code (`0x8210`/`0x8220`) and, when too short, is not applied at all — a communication fault that consumers should be able to observe via `0x1001`, not only via a single transient EMCY frame.

Trade-off (happy to adjust): the other receive-side conditions — `CO_EM_RXMSG_WRONG_LENGTH` (`0x02`), `CO_EM_RXMSG_OVERFLOW` (`0x03`) and `CO_EM_RPDO_OVERFLOW` (`0x05`) — stay informational, and `0x04` becomes unused. If preserving that symmetry is preferred over relocating the bit, an alternative is to leave the bit at `0x04` and make the classification configurable through `CO_CONFIG_ERR_CONDITION_COMMUNICATION`.
