### PR TITLE
Bugfix error reset HB consumer

### DIFF
--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -327,7 +327,7 @@ CO_HBconsumer_process(CO_HBconsumer_t* HBcons, bool_t NMTisPreOrOperational, uin
                                                                monitoredNode->functSignalObjectRemoteReset);
                     }
 #endif
-                    if (monitoredNode->HBstate != CO_HBconsumer_UNKOWN) {
+                    if (monitoredNode->HBstate != CO_HBconsumer_UNKNOWN) {
                         CO_errorReport(HBcons->em, CO_EM_HB_CONSUMER_REMOTE_RESET, CO_EMC_HEARTBEAT, i);
                         monitoredNode->HBstate = CO_HBconsumer_RESTART;
                     }

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -327,11 +327,9 @@ CO_HBconsumer_process(CO_HBconsumer_t* HBcons, bool_t NMTisPreOrOperational, uin
                                                                monitoredNode->functSignalObjectRemoteReset);
                     }
 #endif
-                    if (monitoredNode->HBstate == CO_HBconsumer_ACTIVE) {
+                    if (monitoredNode->HBstate != CO_HBconsumer_UNKOWN) {
                         CO_errorReport(HBcons->em, CO_EM_HB_CONSUMER_REMOTE_RESET, CO_EMC_HEARTBEAT, i);
                         monitoredNode->HBstate = CO_HBconsumer_RESTART;
-                    } else {
-                        monitoredNode->HBstate = CO_HBconsumer_UNKNOWN;
                     }
 
                 } else {

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -342,15 +342,15 @@ CO_HBconsumer_process(CO_HBconsumer_t* HBcons, bool_t NMTisPreOrOperational, uin
                     }
 #endif
                     monitoredNode->HBstate = CO_HBconsumer_ACTIVE;
-                    /* reset timer */
-                    monitoredNode->timeoutTimer = 0;
-                    timeDifference_us_copy = 0;
                 }
                 CO_FLAG_CLEAR(monitoredNode->CANrxNew);
+                /* reset timer */
+                monitoredNode->timeoutTimer = 0;
+                timeDifference_us_copy = 0;
             }
 
             /* Verify timeout */
-            if (monitoredNode->HBstate == CO_HBconsumer_ACTIVE) {
+            if (monitoredNode->HBstate == CO_HBconsumer_ACTIVE || monitoredNode->HBstate == CO_HBconsumer_RESTART) {
                 monitoredNode->timeoutTimer += timeDifference_us_copy;
 
                 if (monitoredNode->timeoutTimer >= monitoredNode->time_us) {

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -329,8 +329,10 @@ CO_HBconsumer_process(CO_HBconsumer_t* HBcons, bool_t NMTisPreOrOperational, uin
 #endif
                     if (monitoredNode->HBstate == CO_HBconsumer_ACTIVE) {
                         CO_errorReport(HBcons->em, CO_EM_HB_CONSUMER_REMOTE_RESET, CO_EMC_HEARTBEAT, i);
+                        monitoredNode->HBstate = CO_HBconsumer_RESTART;
+                    } else {
+                        monitoredNode->HBstate = CO_HBconsumer_UNKNOWN;
                     }
-                    monitoredNode->HBstate = CO_HBconsumer_UNKNOWN;
 
                 } else {
                     /* heartbeat message */

--- a/301/CO_HBconsumer.c
+++ b/301/CO_HBconsumer.c
@@ -377,11 +377,13 @@ CO_HBconsumer_process(CO_HBconsumer_t* HBcons, bool_t NMTisPreOrOperational, uin
 #endif
             }
 
-            if (monitoredNode->HBstate != CO_HBconsumer_ACTIVE) {
-                allMonitoredActiveCurrent = false;
-            }
-            if (monitoredNode->NMTstate != CO_NMT_OPERATIONAL) {
-                allMonitoredOperationalCurrent = false;
+            if (monitoredNode->HBstate != CO_HBconsumer_UNKNOWN) {
+                if (monitoredNode->HBstate != CO_HBconsumer_ACTIVE) {
+                    allMonitoredActiveCurrent = false;
+                }
+                if (monitoredNode->NMTstate != CO_NMT_OPERATIONAL) {
+                    allMonitoredOperationalCurrent = false;
+                }
             }
 #if (((CO_CONFIG_HB_CONS)&CO_CONFIG_HB_CONS_CALLBACK_CHANGE) != 0)                                                     \
     || (((CO_CONFIG_HB_CONS)&CO_CONFIG_HB_CONS_CALLBACK_MULTI) != 0)

--- a/301/CO_HBconsumer.h
+++ b/301/CO_HBconsumer.h
@@ -64,6 +64,7 @@ typedef enum {
     CO_HBconsumer_UNKNOWN = 0x01U,      /**< Consumer enabled, but no heartbeat received yet */
     CO_HBconsumer_ACTIVE = 0x02U,       /**< Heartbeat received within set time */
     CO_HBconsumer_TIMEOUT = 0x03U,      /**< No heatbeat received for set time */
+    CO_HBconsumer_RESTART = 0x04U,      /**< Monitored node was reset */
 } CO_HBconsumer_state_t;
 
 /**


### PR DESCRIPTION
- Unknown nodes should not be monitored until the reception of the first HeartBeat. Exclude nodes with the HB status CO_HBconsumer_UNKNOWN when updating the state of _allMonitoredActiveCurrent_.
- For monitored nodes that have been reset, a new HB status CO_HBconsumer_RESTART is defined. This prevents the heartbeat status from reverting to CO_HBconsumer_UNKNOWN, which would result in the node no longer being monitored until it sends its initial heartbeat again.