### PR TITLE
docs: clarify blank CAN pointer placeholder

### DIFF
--- a/example/main_blank.c
+++ b/example/main_blank.c
@@ -47,6 +47,7 @@ main(void) {
     CO_ReturnError_t err;
     CO_NMT_reset_cmd_t reset = CO_RESET_NOT;
     uint32_t heapMemoryUsed;
+    /* Blank target keeps this NULL; real ports must provide the CAN module context before CAN initialization. */
     void* CANptr = NULL;           /* CAN module address */
     uint8_t pendingNodeId = 10;    /* read from dip switches or nonvolatile memory, configurable by LSS slave */
     uint8_t activeNodeId = 10;     /* Copied from CO_pendingNodeId in the communication reset section */


### PR DESCRIPTION
Summary:
- Clarify that main_blank.c keeps CANptr as a placeholder.
- Note that real target ports must provide the CAN module context before CAN initialization.

Context:
- Addresses the documentation concern raised in #598 without changing target-specific driver behavior.

Testing:
- git diff --check origin/master...HEAD

No runtime tests were run because this only changes an example comment.