### PR TITLE
Fix shift-by-64 UB for mappedLength==0 in PDO bitwise mapping

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -819,8 +819,10 @@ CO_RPDO_process(CO_RPDO_t* RPDO,
                 /* Prepare data for writing into OD variable. If mappedLength
                  * is smaller than ODdataLength, then use auxiliary buffer */
                 uint8_t* dataOD;
-                /* Apply the bitmask */
-                uint64_t shiftedData = buf64 & (UINT64_MAX >> (64 - mappedLength));
+                /* Apply the bitmask. mappedLength of 0 is a valid (if unusual)
+                 * mapping - "(64 - mappedLength)" would then shift by 64,
+                 * which is undefined behaviour, so handle it explicitly. */
+                uint64_t shiftedData = (mappedLength == 0U) ? 0U : (buf64 & (UINT64_MAX >> (64 - mappedLength)));
                 /* Shift the original buffer to get ready for the next mapping */
                 buf64 >>= mappedLength;
 #ifdef CO_BIG_ENDIAN
@@ -1262,10 +1264,16 @@ CO_TPDOsend(CO_TPDO_t* TPDO) {
          * For LE not needed, low bytes from the OD entry are copied to low bytes of u64 */
         buf >>= 64 - 8 * ODdataLength;
 #endif /* CO_BIG_ENDIAN */
-        /* Apply the mask and merge with the rest */
-        buf &= (UINT64_MAX >> (64 - mappedLength));
-        buf <<= (verifyLength  - mappedLength);
-        buf64 |= buf;
+        /* Apply the mask and merge with the rest. mappedLength of 0 is a
+         * valid (if unusual) mapping - it must contribute nothing to buf64.
+         * Skip the shifts in that case, since "(64 - mappedLength)" and/or
+         * "(verifyLength - mappedLength)" can then evaluate to 64, and
+         * shifting a 64-bit value by 64 is undefined behaviour. */
+        if (mappedLength > 0U) {
+            buf &= (UINT64_MAX >> (64 - mappedLength));
+            buf <<= (verifyLength - mappedLength);
+            buf64 |= buf;
+        }
 #else
         OD_IO->read(stream, dataTPDOCopy, ODdataLength, &countRd);
 #endif /* (CO_CONFIG_PDO) & (CO_CONFIG_PDO_BITWISE_MAPPING) */


### PR DESCRIPTION
## Problem

In `301/CO_PDO.c`, when `CO_CONFIG_PDO_BITWISE_MAPPING` is enabled, an OD object can be mapped into a PDO with `mappedLength == 0` bits. This is a legal, documented mapping (see the `CO_PDO_t.OD_IO` doc comment in `301/CO_PDO.h`: *"mappedLengthBits can be less or equal to the OD_IO.dataLength\*8"*), and nothing in `PDOconfigMap()` / `PDO_initMapping()` rejects a per-entry length of 0 (only the aggregate PDO length is checked).

However, at runtime, two spots compute a shift amount as `64 - mappedLength`:

- `CO_RPDO_process()`:
  ```c
  uint64_t shiftedData = buf64 & (UINT64_MAX >> (64 - mappedLength));
  ```
- `CO_TPDOsend()`:
  ```c
  buf &= (UINT64_MAX >> (64 - mappedLength));
  buf <<= (verifyLength - mappedLength);
  ```

When `mappedLength == 0`, `64 - mappedLength` is `64`, so these become a shift of a `uint64_t` by 64 bits, which is undefined behaviour in C (the shift amount must be strictly less than the operand width). The TPDO side has a second, independent occurrence of the same pattern in the placement shift (`verifyLength - mappedLength`, also 64 whenever a preceding mapped entry already fills the full PDO width).

This isn't just theoretical: I compiled the exact expression in isolation and confirmed the result is optimization-level-dependent, i.e. genuinely undefined rather than a fixed (if surprising) result — an `-O0` build silently no-ops the shift (mask has no effect, so a 0-bit-mapped RPDO entry can receive leftover CAN-frame payload bits it should never see), while an `-O2` build of the identical source produces a different result for the same input. On the TPDO side, the equivalent buggy pattern let a 0-bit-mapped OD variable leak its full raw bytes onto the outgoing PDO in one build configuration.

## Fix

Guard `mappedLength == 0` explicitly at both sites so a 0-bit-mapped entry deterministically contributes nothing, without ever executing a shift-by-64:

- `CO_RPDO_process()`: `shiftedData` short-circuits to `0` when `mappedLength == 0` (the following `buf64 >>= mappedLength;` is already safe, since shifting by 0 is well-defined).
- `CO_TPDOsend()`: both the mask and the placement shift are skipped when `mappedLength == 0`, so `buf64` is left untouched by that entry.

This matches the documented semantics (a 0-bit mapping leaves the target/source OD variable untouched) and doesn't change behaviour for any legal non-zero `mappedLength`.

## Testing

- Compiled `301/CO_PDO.c` standalone against the `example/` project's headers, and built + linked the full `example/` project (`CO_driver_blank.c` + all listed `301/303/305/storage` sources + `CANopen.c` + `OD.c` + `main_blank.c`) with `-DCO_CONFIG_PDO=0x7F` to force `CO_CONFIG_PDO_BITWISE_MAPPING` on and actually exercise both patched branches. No new warnings, clean link.
- In an isolated harness, reproduced the exact fixed expressions and checked them against a portable (UB-free) reference mask for every `mappedLength` in `0..64` — 0 mismatches, confirming behaviour for all legal non-zero lengths is unchanged and the previously-undefined `mappedLength == 0` case now deterministically yields 0, at both `-O0` and `-O2`.
- Verified the two attack/failure scenarios are eliminated post-fix: an RPDO with a 32-bit real mapping followed by a 0-bit real mapping no longer receives leftover payload bits in the 0-bit entry; a TPDO with a preceding 64-bit mapping followed by a 0-bit mapping no longer leaks the 0-bit entry's raw OD bytes into the outgoing buffer.

No functional/API change for existing (non-zero `mappedLength`) mappings.