### PR TITLE
fix: validate PDO COB-IDs during startup initialization

### DIFF
--- a/301/CO_PDO.c
+++ b/301/CO_PDO.c
@@ -659,7 +659,8 @@ CO_RPDO_init(CO_RPDO_t* RPDO, OD_t* OD, CO_EM_t* em,
 
     bool_t valid = (COB_ID & 0x80000000U) == 0U;
     uint16_t CAN_ID = (uint16_t)(COB_ID & 0x7FFU);
-    if (valid && ((PDO->mappedObjectsCount == 0U) || (CAN_ID == 0U))) {
+    bool_t invalidCobId = ((COB_ID & 0x7FFFF800U) != 0U) || (valid && CO_IS_RESTRICTED_CAN_ID(CAN_ID));
+    if (invalidCobId || (valid && ((PDO->mappedObjectsCount == 0U) || (CAN_ID == 0U)))) {
         valid = false;
         if (erroneousMap == 0U) {
             erroneousMap = 1;
@@ -1119,7 +1120,8 @@ CO_TPDO_init(CO_TPDO_t* TPDO, OD_t* OD, CO_EM_t* em,
 
     bool_t valid = (COB_ID & 0x80000000U) == 0U;
     uint16_t CAN_ID = (uint16_t)(COB_ID & 0x7FFU);
-    if (valid && ((PDO->mappedObjectsCount == 0U) || (CAN_ID == 0U))) {
+    bool_t invalidCobId = ((COB_ID & 0x3FFFF800U) != 0U) || (valid && CO_IS_RESTRICTED_CAN_ID(CAN_ID));
+    if (invalidCobId || (valid && ((PDO->mappedObjectsCount == 0U) || (CAN_ID == 0U)))) {
         valid = false;
         if (erroneousMap == 0U) {
             erroneousMap = 1;


### PR DESCRIPTION
### Summary

This PR aligns PDO startup validation with the existing runtime write validation for PDO communication parameters. It makes `CO_RPDO_init()` and `CO_TPDO_init()` reject persisted PDO COB-IDs that use reserved bits or restricted CAN identifiers.

### Problem

According to CiA 301, the `COB-ID used by PDO` field in PDO communication parameters must follow strict rules. For RPDO, bits 11..30 are reserved and must be zero. For TPDO, bits 11..29 are reserved and must be zero. In addition, PDO must not use restricted CAN identifiers.

Previously, the runtime OD write paths `OD_write_14xx()` and `OD_write_18xx()` already enforced those constraints, but the startup paths in `CO_RPDO_init()` and `CO_TPDO_init()` did not. During initialization, the code only checked whether the PDO was valid, mapped, and had a non-zero CAN-ID, then masked the low 11 bits and configured the PDO. As a result, a persisted but standard-invalid PDO COB-ID could be accepted after restart, while the same value would be rejected when written at runtime through SDO.

This created an inconsistency between cold-start configuration loading and runtime configuration updates, and allowed a device to come up with PDO communication parameters that CiA 301 treats as invalid.

### Changes

- Add reserved-bit validation to `CO_RPDO_init()` for RPDO startup COB-ID parsing.
- Add reserved-bit validation to `CO_TPDO_init()` for TPDO startup COB-ID parsing.
- Reject restricted CAN identifiers in both startup paths when the PDO is enabled.
- Keep the existing initialization behavior for invalid PDO parameters by marking the PDO as invalid and reporting the configuration problem through the existing error path.
