### PR TITLE
fix: validate follow-up block size in SDO block download

### DIFF
--- a/301/CO_SDOclient.c
+++ b/301/CO_SDOclient.c
@@ -703,6 +703,11 @@ CO_SDOclientDownload(CO_SDOclient_t* SDO_C, uint32_t timeDifference_us, bool_t s
                             SDO_C->state = CO_SDO_ST_DOWNLOAD_BLK_END_REQ;
                         } else {
                             SDO_C->block_blksize = SDO_C->CANrxData[2];
+                            if ((SDO_C->block_blksize < 1U) || (SDO_C->block_blksize > 127U)) {
+                                abortCode = CO_SDO_AB_CMD;
+                                SDO_C->state = CO_SDO_ST_ABORT;
+                                break;
+                            }
                             SDO_C->block_seqno = 0;
                             (void)CO_fifo_altBegin(&SDO_C->bufFifo, 0);
                             SDO_C->state = CO_SDO_ST_DOWNLOAD_BLK_SUBBLOCK_REQ;


### PR DESCRIPTION
### Summary

This PR makes the SDO client reject invalid `blksize` values in subsequent block download `A2` responses. It closes a gap where only the initial block size was validated, while later server-provided updates were accepted without range checks.

### Problem

According to CiA 301, the SDO block download `blksize` parameter is only valid in the range `1..127`. If the server returns a value outside that range, the client should treat it as an invalid command and abort the transfer instead of continuing with a non-standard block size.

Previously, the client validated `blksize` once during the initial block download response, but did not validate the updated `blksize` carried in later `A2` responses for subsequent sub-blocks. In that path, the code assigned `CANrxData[2]` directly to `block_blksize` and immediately reused it to drive the next send window.

As a result, a server could return an invalid `blksize` such as `0` in a later `A2` response, and the client would continue the block download state machine instead of aborting on the protocol error.

### Changes

- Add `1..127` range validation for `block_blksize` in the `A2` response path of block download.
- Abort the transfer with `CO_SDO_AB_CMD` when the server returns an invalid follow-up `blksize`.
- Keep the existing initial-response validation unchanged and extend the same rule to subsequent sub-block responses.
