### PR TITLE
fix: reject invalid SRDO information direction during config

### DIFF
--- a/304/CO_SRDO.c
+++ b/304/CO_SRDO.c
@@ -487,7 +487,7 @@ CO_SRDO_config(CO_SRDO_t* SRDO, uint8_t SRDO_Index, CO_SRDOGuard_t* SRDOGuard, u
     if ((err == 0U) && configurationInProgress) {
         if (cp_highestSubindexSupported != 6U) {
             err = ERR_INFO(0x1301UL + SRDO_Index, 0, 2);
-        } else if (informationDirection > 3U) {
+        } else if (informationDirection > 2U) {
             err = ERR_INFO(0x1301UL + SRDO_Index, 1, 2);
         } else if (safetyCycleTime < ((CO_CONFIG_SRDO_MINIMUM_DELAY / 1000U) + 1U)) {
             err = ERR_INFO(0x1301UL + SRDO_Index, 2, 2);


### PR DESCRIPTION
### Summary

This PR fixes SRDO startup/reconfiguration validation so that `informationDirection = 3` is rejected in `CO_SRDO_config()`. It aligns the configuration path with the existing runtime OD write validation, which already accepts only `0`, `1`, and `2`.

### Problem

In this implementation, the SRDO communication parameter `informationDirection` only defines three valid values: `0` for disabled, `1` for TX, and `2` for RX. Values outside that set are not defined and should be rejected before the SRDO configuration becomes active.

Previously, the runtime write path `OD_write_SRDO_communicationParam()` correctly rejected values greater than `2`, but `CO_SRDO_config()` validated the same field with `informationDirection > 3U`. That made the startup/reconfiguration path incorrectly accept `informationDirection = 3`, even though the runtime path would reject it.

This mismatch allowed an invalid persisted configuration to pass startup validation and enter later SRDO logic with undefined direction semantics.

### Changes

- Change the `CO_SRDO_config()` validation condition from `informationDirection > 3U` to `informationDirection > 2U`.