### PR TITLE
fix: tighten LSS fastscan completion condition

### DIFF
--- a/305/CO_LSSslave.c
+++ b/305/CO_LSSslave.c
@@ -135,7 +135,8 @@ CO_LSSslave_receive(void* object, void* msg) {
                                 ack = true;
                                 LSSslave->fastscanPos = lssNext;
 
-                                if ((bitCheck == 0U) && (lssNext < lssSub)) {
+                                if ((bitCheck == 0U) && (lssSub == CO_LSS_FASTSCAN_SERIAL)
+                                    && (lssNext == CO_LSS_FASTSCAN_VENDOR_ID)) {
                                     /* complete match, enter configuration state */
                                     LSSslave->lssState = CO_LSS_STATE_CONFIGURATION;
                                 }


### PR DESCRIPTION
### Summary

This PR tightens the LSS fastscan completion condition so that a node enters configuration state only after the final `serial` field completes at `bit0` and the scan returns to `vendor`. It prevents premature selection during earlier fastscan stages.

### Problem

In CiA 305 fastscan, a node should be considered fully matched only after all four 32-bit identity fields have been scanned in order: `vendor`, `product`, `revision`, and `serial`. Reaching the end of an earlier field must not be treated as completion of the full 128-bit identity match.

Previously, the success path in `CO_LSS_IDENT_FASTSCAN` used the condition `bitCheck == 0 && lssNext < lssSub` to decide that fastscan was complete. That condition was too broad, because it did not require the current field to be `serial`, nor did it require `lssNext` to return specifically to `vendor`.

As a result, a master could finish `product` or `revision`, send a smaller `lssNext` value, and the slave would incorrectly enter configuration state before the remaining identity fields had been fully matched.

### Changes

- Replace the broad completion condition with an explicit `serial -> vendor` completion check.
- Require `bitCheck == 0`, `lssSub == CO_LSS_FASTSCAN_SERIAL`, and `lssNext == CO_LSS_FASTSCAN_VENDOR_ID` before entering configuration state.
