### PR TITLE
fix: prevent out-of-bounds trace datatype index

### DIFF
--- a/extra/CO_trace.c
+++ b/extra/CO_trace.c
@@ -147,7 +147,7 @@ static void findVariable(CO_trace_t *trace) {
         /* third sequence: Output type */
         dtIndex += ((*trace->format) >> 1) * 6;
 
-        if(dtIndex > (sizeof(dataTypes) / sizeof(CO_trace_dataType_t))) {
+        if(dtIndex >= (sizeof(dataTypes) / sizeof(CO_trace_dataType_t))) {
             err = true;
         }
     }


### PR DESCRIPTION
This PR fixes an out-of-bounds index check in `extra/CO_trace.c`.

During code audit of the Trace configuration path, I followed the `format` parameter from OD/SDO configuration into `findVariable()`, then into the `dataTypes[]` lookup and finally to the function-pointer dereference in `CO_trace_process()`. The issue is that `dtIndex` is allowed to become equal to the number of elements in `dataTypes[]`, because the boundary check used `>` instead of `>=`.

With a reachable configuration such as `format = 6` and a final mapped data length of 1 byte, `dtIndex` becomes `18` while the valid array index range is only `0..17`. The old code therefore accepted an out-of-range index and could set `trace->dt` to `&dataTypes[18]`, which is one past the end of the table.

This change tightens the check from `>` to `>=`, so the invalid index is rejected before `trace->dt` is assigned. The fix is intentionally minimal and only closes the out-of-bounds path identified during the audit.
