### PR TITLE
fix: verify EEPROM CRC before loading stored parameters

### DIFF
--- a/storage/CO_storageEeprom.c
+++ b/storage/CO_storageEeprom.c
@@ -154,17 +154,17 @@ CO_storageEeprom_init(CO_storage_t* storage, CO_CANmodule_t* CANmodule, void* st
         bool_t dataCorrupt = false;
         if (signatureInEeprom != signatureOfEntry) {
             dataCorrupt = true;
-        } else {
-            /* Read data into storage location */
-            CO_eeprom_readBlock(entry->storageModule, entry->addr, entry->eepromAddr, entry->len);
-
-            /* Verify CRC, except for auto storage variables */
-            if (!isAuto) {
-                uint16_t crc = crc16_ccitt(entry->addr, entry->len, 0);
-                if (crc != entry->crc) {
-                    dataCorrupt = true;
-                }
+        } else if (!isAuto) {
+            /* Verify CRC before loading data, so corrupt EEPROM content does not overwrite defaults in RAM. */
+            uint16_t crc = CO_eeprom_getCrcBlock(entry->storageModule, entry->eepromAddr, entry->len);
+            if (crc != entry->crc) {
+                dataCorrupt = true;
+            } else {
+                CO_eeprom_readBlock(entry->storageModule, entry->addr, entry->eepromAddr, entry->len);
             }
+        } else {
+            /* Auto storage entries don't use the CRC guard on startup. */
+            CO_eeprom_readBlock(entry->storageModule, entry->addr, entry->eepromAddr, entry->len);
         }
 
         /* additional info in case of error */


### PR DESCRIPTION
### Summary

This PR fixes EEPROM startup loading so that corrupt stored parameters do not overwrite the in-memory default values before the corruption is reported.

### Problem

During `CO_storageEeprom_init()`, the previous logic loaded EEPROM data into `entry->addr` immediately after the entry signature matched, and only then verified the CRC for non-auto storage entries. That meant corrupt EEPROM content could already overwrite the live RAM copy of the parameters before the code detected the CRC mismatch and returned `CO_ERROR_DATA_CORRUPT`.

As a result, the device could start up in a contradictory state: storage initialization reported corrupted data, but the active communication or application parameters in RAM had already been replaced by that corrupted EEPROM block instead of staying at their compiled default values.

### Changes

- Verify the EEPROM block CRC before loading non-auto storage entries into `entry->addr`.
- Load EEPROM data into RAM only when the stored CRC matches the recorded signature CRC.